### PR TITLE
Modified the handling of the PDB mirror paths

### DIFF
--- a/prody/proteins.py
+++ b/prody/proteins.py
@@ -317,8 +317,7 @@ def fetchPDB(pdb, folder='.', compressed=True, copy=False):
             exists += 1
             continue
         if mirror_path is not None and os.path.isdir(mirror_path):
-            fn = os.path.join(mirror_path, 'data/structures/divided/pdb',
-                    pdbid[1:3], 'pdb' + pdbid + '.ent.gz')
+            fn = os.path.join(mirror_path, pdbid[1:3], "pdb%s.ent.gz" % pdbid)
             if os.path.isfile(fn):
                 if copy or not compressed:
                     if compressed:


### PR DESCRIPTION
Changed the fetchPDB() code to require the user to specify only the path to the
"pdb" directory in "data/structures/divided/pdb" to allow it to work for users
not using such a complex directory structure structure.
