### PR TITLE
Fixed bug in execDSSP()

### DIFF
--- a/prody/proteins.py
+++ b/prody/proteins.py
@@ -2901,7 +2901,7 @@ def buildBiomolecules(header, atoms, biomol=None):
     else:
         return None
 
-def execDSSP(pdb, outputname=None, outputdir=None):
+def execDSSP(pdb, outputname=None, outputdir=os.curdir):
     """Execute DSSP for given *pdb*.  *pdb* can be a PDB identifier or a PDB 
     file path.  If *pdb* is a compressed file, it will be decompressed using
     Python :mod:`gzip` library.  When no *outputname* is given, output name 
@@ -2931,8 +2931,7 @@ def execDSSP(pdb, outputname=None, outputdir=None):
         else:
             pdb = gunzip(pdb, os.path.join(outputdir, 
                                 os.path.split(os.path.splitext(pdb)[0])[1]))
-    if outputdir is None:
-        outputdir = '.'
+
     if outputname is None:
         out = os.path.join(outputdir,
                         os.path.splitext(os.path.split(pdb)[1])[0] + '.dssp')


### PR DESCRIPTION
## Bug description

When calling exceDSSP() on a gzipped pdb file without specifying an "outputdir":

``` python
from prody.proteins import execDSSP

fn = "test_pdb_file.ent.gz"
execDSSP(fn)
```

I get the following error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/kian/lib/python2.7/site-packages/prody/proteins.py", line 1944, in execDSSP
    os.path.split(os.path.splitext(pdb)[0])[1]))
  File "/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/posixpath.py", line 68, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'NoneType' object has no attribute 'endswith'
```

The bug is caused by the following code block in proteins.py:

``` python
if outputdir:
    pdb = gunzip(pdb, os.path.splitext(pdb)[0])
else:
    pdb = gunzip(pdb, os.path.join(outputdir, # <--- BUG HERE
                        os.path.split(os.path.splitext(pdb)[0])[1]))
```

where outputdir == None and causes os.path.join() to attempt to join a NoneType to a string.
## Proposed bug fixes

Change the default function argument value of 'outputdir' in execDSSP to the current directory "os.curdir":

``` python
def execDSSP(pdb, outputname=None, outputdir=os.curdir):
```

and remove lines 2934-2935 since they would now be redundant:

``` python
    if outputdir is None: # REMOVE
        outputdir = '.'  # REMOVE
```
