### PR TITLE
Remove non-existing Counter module import

### DIFF
--- a/prody/atomic/atomgroup.py
+++ b/prody/atomic/atomgroup.py
@@ -233,7 +233,7 @@ from types import NoneType
 import numpy as np
 
 from prody import LOGGER
-from prody.tools import checkCoords, Counter
+from prody.tools import checkCoords
 from prody.KDTree import getKDTree
 
 from atomic import Atomic


### PR DESCRIPTION
Hi Ahmet,

atomgroup module cannot be imported now:

ImportError: cannot import name Counter

This is introduced in this commit[1] but I couldn't find a module named Counter. This commit just removes that to make atomgroup module available again.

[1] https://github.com/abakan/ProDy/commit/490c803448789e708fa52d218acef2666da8d106
