### PR TITLE
Add missing third replacement field {2:d} and use the minimum of two coordset number for addition.

### DIFF
--- a/prody/atomic/atomgroup.py
+++ b/prody/atomic/atomgroup.py
@@ -464,13 +464,14 @@ class AtomGroup(Atomic):
                                            repr(type(other).__name__)))
                                                        
         new = AtomGroup(self._title + ' + ' + other._title)
-        n_csets = self._n_csets
-        if n_csets != other._n_csets:
+        if self._n_csets != other._n_csets:
+
+            n_csets = min(self._n_csets, other._n_csets)
             LOGGER.warning('AtomGroups {0:s} and {1:s} do not have same '
-                           'number of coordinate sets.  First from both '
+                           'number of coordinate sets.  First {2:d} {3:s} from both '
                            'AtomGroups will be merged.'
-              .format(str(self._title), str(other._title), n_csets))
-            n_csets = 1
+              .format(str(self._title), str(other._title), n_csets, "sets" if n_csets > 1 else "set"))
+
         coordset_range = range(n_csets)
         new.setCoords(np.concatenate((self._coords[coordset_range],
                                       other._coords[coordset_range]), 1))


### PR DESCRIPTION
Hello,

n_csets value is used for format string but {2:d} replacement filed was forgotten, added by this commit. I also didn't understand why n_csets is set to 1 in the next line. Instead, selecting the minimum of two _n_csets seems better to me. Of course, you can reject that and just add the {2:d} field if I made a mistake.
