### PR TITLE
Several Changes

### DIFF
--- a/prody/comd/comd.py
+++ b/prody/comd/comd.py
@@ -26,18 +26,18 @@ except NameError:
 	pass
 
 a = open('vmd.dat', 'w')
-call(["which","vmd"], stdout=a)
+call(["which","vmd"], stdout=a, shell = True)
 a.close()
 with open ('vmd.dat', 'r') as a:
 	vmd = a.read().replace('\n','')	
-call(["rm","vmd.dat"])
+call(["rm","vmd.dat"], shell = True)
 
 a = open('namd.dat', 'w')
-call(["which","namd2"], stdout=a)
+call(["which","namd2"], stdout=a, shell = True)
 a.close()
 with open ('namd.dat', 'r') as a:
 	namd = a.read().replace('\n','')	
-call(["rm","namd.dat"])
+call(["rm","namd.dat"], shell = True)
 
 __all__ = ['perturb_structure', 'solvate_and_ionize', 'initial_minimization','align_two_pdbs', 'extract_final_CA', 'extract_tmd_target', 'run_TMD', 'minimization', 'RMSD_check', 'coMD']
 

--- a/prody/dynamics/anm.py
+++ b/prody/dynamics/anm.py
@@ -215,7 +215,8 @@ class ANMBase(NMA):
             if eigvals:
                 turbo = False
             if isinstance(self._hessian, np.ndarray):
-                vectors, values, dummy = linalg.svd(self._hessian)
+                values, vectors = linalg.eigh(self._hessian, turbo=turbo,
+                                              eigvals=eigvals)
             else:
                 try:
                     from scipy.sparse import linalg as scipy_sparse_la

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -42,6 +42,8 @@ def saveEnsemble(ensemble, filename=None, **kwargs):
         value = dict_[attr]
         if value is not None:
             attr_dict[attr] = value
+            
+    attr_dict['_atoms'] = np.array([dict_['_atoms'], 0])
     filename += '.ens.npz'
     ostream = openFile(filename, 'wb', **kwargs)
     np.savez(ostream, **attr_dict)
@@ -57,7 +59,7 @@ def loadEnsemble(filename):
     if '_weights' in attr_dict:
         weights = attr_dict['_weights']
     else:
-        weights = None
+        weights = None   
     isPDBEnsemble = False
     try:
         title = str(attr_dict['_title'])
@@ -69,6 +71,11 @@ def loadEnsemble(filename):
     else:
         ensemble = Ensemble(title)
     ensemble.setCoords(attr_dict['_coords'])
+    if '_atoms' in attr_dict:
+        atoms = attr_dict['_atoms'][0]
+    else:
+        atoms = None
+    ensemble.setAtoms(atoms)    
     if isPDBEnsemble:
         ensemble.addCoordset(attr_dict['_confs'], weights)
         if '_identifiers' in attr_dict.files:

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -905,8 +905,8 @@ def mapOntoChain(atoms, chain, **kwargs):
 
         ch_tar = next((r for r in residues_target if r is not None)).getChain()
         ch_chn = next((r for r in residues_chain if r is not None)).getChain()
-        title_tar = 'Chain {0} from {1}'.fromat(ch_tar.getChid(), ch_tar.getAtomGroup().getTitle())
-        title_chn = 'Chain {0} from {1}'.fromat(ch_chn.getChid(), ch_chn.getAtomGroup().getTitle())
+        title_tar = 'Chain {0} from {1}'.format(ch_tar.getChid(), ch_tar.getAtomGroup().getTitle())
+        title_chn = 'Chain {0} from {1}'.format(ch_chn.getChid(), ch_chn.getAtomGroup().getTitle())
 
         atommap = AM(map_ag, indices_chain, chain.getACSIndex(),
                      mapping=indices_mapping, dummies=indices_dummies,

--- a/prody/proteins/localpdb.py
+++ b/prody/proteins/localpdb.py
@@ -273,9 +273,8 @@ def fetchPDB(*pdb, **kwargs):
                 fn = join(local_folder, pdb[1:3], 'pdb' + pdb + '.pdb.gz')
             else:
                 fn = join(local_folder, pdb + '.pdb.gz')
-
             if isfile(fn):
-                if copy or not compressed:
+                if copy or not compressed and compressed is not None:
                     if compressed:
                         fn = copyFile(fn, join(folder, pdb + 'pdb.gz'))
                     else:


### PR DESCRIPTION
1. Corrected a misspelling in /proteins/compare.py
2. Enable saveEnsemble() to also save the atoms of ensemble in /ensemble/functions.py
3. fix a bug that parsePDB() always compresses PDB files to working directory if a local PDB folder is designated.
4. Add two more arguments to eigh() used in calcModes() to allow specifying number of modes (original code used in calcModes).