### PR TITLE
Fix issue #252

### DIFF
--- a/prody/atomic/select.py
+++ b/prody/atomic/select.py
@@ -773,10 +773,11 @@ def rangeParseAction(sel, loc, tokens):
     except ValueError:
         stop = float(last)
 
-    if start > stop:
+    if start > stop or (start == stop and sep == ':'):
         raise SelectionError(sel, loc, 'range start value ({0}) is greater '
-                             'than and stop value ({1})'
-                             .format(repr(start), repr(stop)))
+                             'than stop value ({1})'
+                             .format(repr(start),
+                                     repr(stop if sep != ':' else stop - 1)))
     elif start == stop:
         return first
 


### PR DESCRIPTION
Fix issue #252 Correctly throw SelectionError when a slice style range is specified in
a selection string with the same start and end value.