### PR TITLE
Fix datatype check in logger

### DIFF
--- a/prody/kdtree/kdtree.py
+++ b/prody/kdtree/kdtree.py
@@ -13,7 +13,7 @@ except ImportError:
         from Bio.KDTree._CKDTree import KDTree as CKDTree
     except ImportError:
         raise ImportError('CKDTree module could not be imported. '
-                          'Reinstall ProDy or install Biopython'
+                          'Reinstall ProDy or install Biopython '
                           'to solve the problem.')
 
 __all__ = ['KDTree']

--- a/prody/sequence/plotting.py
+++ b/prody/sequence/plotting.py
@@ -223,7 +223,7 @@ def showDirectInfoMatrix(dirinfo, *args, **kwargs):
         ndim, shape = dirinfo.ndim, dirinfo.shape
     except AttributeError:
         msa = dirinfo
-        dirinfo = buildDirectInfoMatrix(mutinfo)
+        dirinfo = buildDirectInfoMatrix(dirinfo)
         ndim, shape = dirinfo.ndim, dirinfo.shape
 
     msa = kwargs.pop('msa', msa)

--- a/prody/utilities/logger.py
+++ b/prody/utilities/logger.py
@@ -233,7 +233,7 @@ class PackageLogger(object):
     def progress(self, msg, steps, label=None, **kwargs):
         """Instantiate a labeled process with message and number of steps."""
 
-        assert isinstance(step, (int, long)) and steps > 0, \
+        assert isinstance(steps, (int, long)) and steps > 0, \
             'steps must be a positive integer'
         self._steps = steps
         self._last = 0

--- a/prody/utilities/logger.py
+++ b/prody/utilities/logger.py
@@ -233,7 +233,7 @@ class PackageLogger(object):
     def progress(self, msg, steps, label=None, **kwargs):
         """Instantiate a labeled process with message and number of steps."""
 
-        assert isinstance(steps, int) and steps > 0, \
+        assert isinstance(step, (int, long)) and steps > 0, \
             'steps must be a positive integer'
         self._steps = steps
         self._last = 0
@@ -245,7 +245,7 @@ class PackageLogger(object):
     def update(self, step, label=None):
         """Update progress status to current line in the console."""
 
-        assert isinstance(step, int), 'step must be a positive integer'
+        assert isinstance(step, (int, long)), 'step must be a positive integer'
         n = self._steps
         i = step
         if self._level < logging.WARNING and n > 0 and i <= n and \


### PR DESCRIPTION
Fix: if step is a long, this check will fail on windows.