### PR TITLE
Fix a future warning

### DIFF
--- a/prody/atomic/select.py
+++ b/prody/atomic/select.py
@@ -441,6 +441,7 @@ all alphanumeric characters."""
 
 import sys
 from re import compile as re_compile
+from collections import Iterable
 
 import numpy as np
 from numpy import array, ndarray, ones, zeros, arange
@@ -1319,8 +1320,10 @@ class Select(object):
 
         debug(sel, loc, '_and2', tokens)
         if NUMB: return
-
-        if tokens[0] == 'and' or tokens[-1] == 'and':
+        
+        firsttoken = tokens[0] if not isinstance(tokens[0], Iterable) else list(tokens[0])
+        lasttoken = tokens[-1] if not isinstance(tokens[-1], Iterable) else list(tokens[-1])
+        if firsttoken == 'and' or lasttoken == 'and':
             return None, SelectionError(sel, loc, '{0} operator must be '
                 'surrounded with arguments'.format(repr('and')), [tokens[0]])
 

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -434,6 +434,7 @@ def showOverlapTable(modes_x, modes_y, **kwargs):
       * ``norm=matplotlib.colors.Normalize(0, 1)``"""
 
     import matplotlib.pyplot as plt
+    import matplotlib
 
     overlap = abs(calcOverlap(modes_y, modes_x))
     if overlap.ndim == 0:


### PR DESCRIPTION
Fix following warning:
C:\GitHub\ProDy\prody\atomic\select.py:1326: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  if tokens[0] == 'and' or tokens[-1] == 'and':