### PR TITLE
Integration with py3Dmol

### DIFF
--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -129,7 +129,9 @@ def showProtein(*atoms, **kwargs):
         import StringIO, py3Dmol
         from pdbfile import writePDBStream
         pdb = StringIO.StringIO()
-        writePDBStream(pdb, atoms)
+        
+        for mol in alist:
+            writePDBStream(pdb, mol)
         
         width = kwargs.get('width',400)
         height = kwargs.get('height',400)
@@ -138,7 +140,7 @@ def showProtein(*atoms, **kwargs):
         bgcolor = kwargs.get('backgroundColor','white')
         view.setBackgroundColor(bgcolor)
 
-        view.addModel(pdb.getvalue(),'pdb')
+        view.addModels(pdb.getvalue(),'pdb')
         view.setStyle({'cartoon': {'color':'spectrum'}})
         view.setStyle({'hetflag': True}, {'stick':{}})
         view.setStyle({'bonds': 0}, {'sphere':{'radius': 0.5}})

--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -96,7 +96,8 @@ def view3D(*alist, **kwargs):
     for visualization of GNM/ANM calculations.  The array is assumed to 
     correpond to a calpha selection of the provided protein.
     The default color will be set to a RWB color scheme on a per-residue
-    basis.  
+    basis.  If the fluctuation vector contains negative values, the
+    midpoint (white) will be at zero.  Otherwise the midpoint is the mean.
     
     An array of displacement vectors can be provided with the vecs kwarg.
     The animation of these motions can be controlled with frames (number
@@ -140,7 +141,8 @@ def view3D(*alist, **kwargs):
             #color by property using gradient
             extreme = np.abs(garr).max()
             lo = -extreme if garr.min() < 0 else 0
-            view.setColorByProperty({}, 'flucts', 'rwb', [extreme,lo])
+            mid = np.mean(garr) if garr.min() >= 0 else 0
+            view.setColorByProperty({}, 'flucts', 'rwb', [extreme,lo,mid])
             view.setStyle({'cartoon':{'style':'trace'}})
             
     if 'vecs' in kwargs:

--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -167,7 +167,7 @@ def showProtein(*atoms, **kwargs):
             garr = kwargs['flucts']
             #note we are only getting info from last set of atoms..
             if atoms.calpha.numAtoms() != len(garr):
-                print "Atom count mismatch: %d vs %d.  GNM styling assume a calpha selection." % (atoms.calpha.numAtoms(), len(garr))
+                print "Atom count mismatch: {} vs {}.  flucts styling assume a calpha selection.".format(atoms.calpha.numAtoms(), len(garr))
             else:
                 #construct map from residue to flucts property
                 propmap = []
@@ -188,7 +188,7 @@ def showProtein(*atoms, **kwargs):
 
             #note we are only getting info from last set of atoms..
             if atoms.calpha.numAtoms()*3 != len(aarr):
-                print "Atom count mismatch: %d vs %d.  GNM styling assume a calpha selection." % (atoms.calpha.numAtoms(), len(aarr)/3)
+                print "Atom count mismatch: {} vs {}.  vecs animation assume a calpha selection.".format(atoms.calpha.numAtoms(), len(aarr)/3)
             else:
                 #construct map from residue to anm property and dx,dy,dz vectors
                 propmap = []


### PR DESCRIPTION
If py3Dmol has been imported (e.g., within a Jupyter notebook, which is the only place it makes sense), then showProtein will render using py3Dmol instead of matplotlib.

For example, see:
http://mscbio2025.csb.pitt.edu/notes/prody1.slides.html#/43