### PR TITLE
Use truncating integer division

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -545,7 +545,7 @@ def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
                     else:
                         atomgroup._setCoords(coordinates)
                 else:
-                    coordsets = np.zeros((diff/acount+1, acount, 3))
+                    coordsets = np.zeros((diff//acount+1, acount, 3))
                     coordsets[0] = coordinates[:acount]
                     onlycoords = True
                 atomnames.resize(acount)


### PR DESCRIPTION
NumPy will throw an error in the future if passed a non-integer number in the future. Use the truncating integer division operator to guard against this.