### PR TITLE
vs 2015 compilation fix: set size of pointer

### DIFF
--- a/prody/measure/measure.py
+++ b/prody/measure/measure.py
@@ -202,7 +202,7 @@ def getDihedral(coords1, coords2, coords3, coords4, radian=False):
     porm = sign((v1 * a3).sum(-1))
     rad = arccos((v1*v2).sum(-1) / ((v1**2).sum(-1) * (v2**2).sum(-1))**0.5)
     if not porm == 0:
-	rad = rad * porm
+        rad = rad * porm
     if radian:
         return rad
     else:

--- a/prody/sequence/msatools.c
+++ b/prody/sequence/msatools.c
@@ -219,7 +219,7 @@ void *allocmat(int rows, int columns, int size)
 
     *((int *)rp) = rows;
 
-    p = rp + sizeof(int);
+    p = (char *)rp + sizeof(int);
 
     for (i = 0; i < rows; i++)
 	if ((p[i] = calloc(columns, size)) == NULL)
@@ -248,12 +248,12 @@ void
     int             rows;
     void **p = rp;
 
-    rows = *((int *)(rp - sizeof(int)));
+    rows = *((int *)( (char *)rp - sizeof(int)));
 
     while (rows--)
 	free(p[rows]);
 
-    free(rp - sizeof(int));
+    free( (char *) rp - sizeof(int));
 }
 
 // Cholesky test


### PR DESCRIPTION
To compile on Visual Studio 2015, (void *) must be cast to (char *) to make the pointer size explicit. See https://msdn.microsoft.com/en-us/library/1kay26wa.aspx?f=255&MSPPError=-2147217396 