### PR TITLE
Fix compiling errors on Windows

### DIFF
--- a/prody/dynamics/saxsConstants.h
+++ b/prody/dynamics/saxsConstants.h
@@ -1,6 +1,6 @@
 //########################CONSTANT VARIABLE DECLARATIONS#########################
 // Maximum number of atoms in the pdb file
-const int MAX_ATOM=100000;
+#define MAX_ATOM 100000
 
 // length of data line in experimental data file
 const int MAX_EXP_LINE=100;

--- a/prody/dynamics/saxstools.c
+++ b/prody/dynamics/saxstools.c
@@ -208,7 +208,7 @@ static PyObject *saxstools_cgSolvateNumeric(PyObject *self, PyObject *args)
   PyObject *X_obj, *Y_obj, *Z_obj, *W_obj;
 
   /* Parse the input tuple */
-  if (!PyArg_ParseTuple(args, "sOOOOfffffiii", &fpdb_file, &X_obj, &Y_obj, &Z_obj, &W_obj, &wDNA, &wRNA, &wPROT, &thickness, &closest_dist, &pdb_flag, &solvent_flag, &MAX_ATOM))
+  if (!PyArg_ParseTuple(args, "sOOOOfffffiii", &fpdb_file, &X_obj, &Y_obj, &Z_obj, &W_obj, &wDNA, &wRNA, &wPROT, &thickness, &closest_dist, &pdb_flag, &solvent_flag, MAX_ATOM))
     return NULL;
 
   /* Interpret the input objects as numpy arrays. */


### PR DESCRIPTION
Fix following compiling errors on Windows (VS C compiler has a [more strict rule](https://msdn.microsoft.com/en-us/library/eff825eh.aspx?f=255&MSPPError=-2147217396)):

prody\dynamics\saxstools.c(865): error C2057: expected constant expression
prody\dynamics\saxstools.c(865): error C2466: cannot allocate an array of constant size 0
prody\dynamics\saxstools.c(865): error C2133: 'atom': unknown size
prody\dynamics\saxstools.c(867): error C2057: expected constant expression
prody\dynamics\saxstools.c(867): error C2466: cannot allocate an array of constant size 0
prody\dynamics\saxstools.c(867): error C2133: 'mol_type': unknown size
prody\dynamics\saxstools.c(1120): error C2057: expected constant expression
prody\dynamics\saxstools.c(1120): error C2466: cannot allocate an array of constant size 0
prody\dynamics\saxstools.c(1120): error C2133: 'atom': unknown size
prody\dynamics\saxstools.c(1121): error C2057: expected constant expression
prody\dynamics\saxstools.c(1121): error C2466: cannot allocate an array of constant size 0
prody\dynamics\saxstools.c(1121): error C2133: 'cgatom': unknown size
prody\dynamics\saxstools.c(1124): error C2057: expected constant expression
prody\dynamics\saxstools.c(1124): error C2466: cannot allocate an array of constant size 0
prody\dynamics\saxstools.c(1124): error C2133: 'mol_type': unknown size