### PR TITLE
fix: int casting error in proteins/pdbfile  #369

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -545,7 +545,7 @@ def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
                     else:
                         atomgroup._setCoords(coordinates)
                 else:
-                    coordsets = np.zeros((diff//acount+1, acount, 3))
+                    coordsets = np.zeros((int(diff//acount+1), acount, 3))
                     coordsets[0] = coordinates[:acount]
                     onlycoords = True
                 atomnames.resize(acount, refcheck=False)


### PR DESCRIPTION
tested on:
```
Python 3.6.0 (default, Jan 16 2017, 12:12:55) 
[GCC 6.3.1 20170109] on linux
```
