### PR TITLE
Improved calcPerturbResponse and writePerturbResponse

### DIFF
--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -463,6 +463,7 @@ def calcPerturbResponse(model, atoms=None, repeats=100, **kwargs):
     useCovariance = kwargs.get('useCovariance',False)
     if useCovariance is True:
         operationList = ['None']
+        cov_squared = cov**2
         n_by_3n_matrix = np.zeros((n_atoms, 3 * n_atoms))
         matrix_set = np.zeros((1, n_atoms, n_atoms))
         i3 = -3
@@ -470,14 +471,14 @@ def calcPerturbResponse(model, atoms=None, repeats=100, **kwargs):
         for i in range(n_atoms):
             i3 += 3
             i3p3 += 3
-            n_by_3n_matrix[i,:] = ((cov[i3:i3p3,:])**2).sum(0)
+            n_by_3n_matrix[i,:] = (cov_squared[i3:i3p3,:]).sum(0)
 
         j3 = -3
         j3p3 = 0
         for j in range(n_atoms):
             j3 += 3
             j3p3 += 3                
-            matrix_set[0,:,j] = ((n_by_3n_matrix[:,j3:j3p3])**2).sum(1)
+            matrix_set[0,:,j] = (n_by_3n_matrix[:,j3:j3p3]).sum(1)
  
         LOGGER.clear()
         LOGGER.report('Perturbation response scanning completed in %.1fs.',
@@ -628,21 +629,21 @@ def calcPerturbResponse(model, atoms=None, repeats=100, **kwargs):
     if normMatrix == True:
         norm_PRS_mat = np.zeros((len(operationList),n_atoms,n_atoms))
         # calculate the normalized PRS matrix for each operation
-        for i in range(len(operationList)):
-            self_dp = np.diag(matrix_set[i])  # using self displacement (diagonal of
+        for m in range(len(operationList)):
+            self_dp = np.diag(matrix_set[m])  # using self displacement (diagonal of
                                               # the original matrix) as a
                                               # normalization factor
             self_dp = self_dp.reshape(n_atoms, 1)
-            norm_PRS_mat[i] = matrix_set[i] / np.repeat(self_dp, n_atoms, axis=1)
+            norm_PRS_mat[m] = matrix_set[m] / np.repeat(self_dp, n_atoms, axis=1)
 
             if suppressDiag == True:
                 # suppress the diagonal (self displacement) to facilitate
                 # visualizing the response profile
-                norm_PRS_mat[i] = norm_PRS_mat[i] - np.diag(np.diag(norm_PRS_mat[i]))
+                norm_PRS_mat[m] = norm_PRS_mat[m] - np.diag(np.diag(norm_PRS_mat[m]))
 
             if saveMatrix == True:
-                np.savetxt('norm_{0}_{1}.txt'.format(baseSaveName,operationList[i]), \
-                           norm_PRS_mat[i], delimiter='\t', fmt='%8.6f')
+                np.savetxt('norm_{0}_{1}.txt'.format(baseSaveName,operationList[m]), \
+                           norm_PRS_mat[m], delimiter='\t', fmt='%8.6f')
            
     if normMatrix == True:
         if np.shape(norm_PRS_mat)[0] == 1:

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -722,11 +722,11 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
     :arg prs_matrix: a perturbation response matrix
     :type prs_matrix: ndarray
 
-    :arg pdbInFile: file name for the input PDB file where you would like the PRS
+    :arg pdbIn: file name for the input PDB file where you would like the PRS
         data mapped
     :type pdbIn: str
 
-    :arg pdbOutFiles: a list of file names (enclosed in square
+    :arg pdbOut: a list of file names (enclosed in square
         brackets) for the output PDB file, default is to append
         the chain and residue info (name and number) onto the pdbIn stem.
         The input for pdbOut can also be used as a stem if you enter a 

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -782,7 +782,7 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
             else:
                 sel_line_res = structure.select('resid {0}'.format(line[22:26]))
                 j = np.where(structure.getResnums() == line[22:26])[0] \
-                    [np.where(sele_line_resnum.getChids() == line[21])[0][0]]
+                    [np.where(sel_line_resnum.getChids() == line[21])[0][0]]
                 fileEffs.write(line[:60] + ' '*(6-len('{:3.2f}'.format((effectiveness[j])*100))) \
                          + '{:3.2f}'.format((effectiveness[j])*100) + line[66:])
                 fileSens.write(line[:60] + ' '*(6-len('{:3.2f}'.format((sensitivity[j])*10))) \
@@ -824,7 +824,7 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
             else:
                 sel_line_res = structure.select('resid {0}'.format(line[22:26]))
                 j = np.where(structure.getResnums() == line[22:26])[0] \
-                    [np.where(sele_line_resnum.getChids() == line[21])[0][0]]
+                    [np.where(sel_line_resnum.getChids() == line[21])[0][0]]
                 fo.write(line[:60] + ' '*(6-len('{:3.2f}'.format((prs_matrix[i[n]][j])*10))) \
                          + '{:3.2f}'.format((prs_matrix[i[n]][j])*10) + line[66:])
         fo.close()

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -781,7 +781,7 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
                 fileSens.write(line)
             else:
                 sel_line_res = structure.select('resid {0}'.format(line[22:26]))
-                j = np.where(structure.getResnums() == line[22:26])[0] \
+                j = np.where(structure.getResnums() == int(line[22:26]))[0] \
                     [np.where(sel_line_res.getChids() == line[21])[0][0]]
                 fileEffs.write(line[:60] + ' '*(6-len('{:3.2f}'.format((effectiveness[j])*100))) \
                          + '{:3.2f}'.format((effectiveness[j])*100) + line[66:])
@@ -792,7 +792,11 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
         fileSens.close()
         LOGGER.info('The effectiveness and sensitivity profiles were written' \
                     ' to {0} and {1}.'.format(file_effs_name,file_sens_name))
-        return effectiveness, sensitivity
+
+        if kwargs.get('effectiveness') is None:
+            return effectiveness, sensitivity
+        else:
+            return
 
     outFiles = []
     timesNotFound = 0
@@ -823,7 +827,7 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
                 fo.write(line)
             else:
                 sel_line_res = structure.select('resid {0}'.format(line[22:26]))
-                j = np.where(structure.getResnums() == line[22:26])[0] \
+                j = np.where(structure.getResnums() == int(line[22:26]))[0] \
                     [np.where(sel_line_res.getChids() == line[21])[0][0]]
                 fo.write(line[:60] + ' '*(6-len('{:3.2f}'.format((prs_matrix[i[n]][j])*10))) \
                          + '{:3.2f}'.format((prs_matrix[i[n]][j])*10) + line[66:])

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -707,8 +707,8 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
     If no chain is given this will be done for that residue in all chains.
     
     If no residue number is given then the effectiveness and sensitivity
-    profiles will be written out instead. These two profiles are also output 
-    as arrays for further analysis.
+    profiles will be written out instead. These two profiles are also returned
+    as arrays for further analysis if they aren't already provided.
 
     :arg prs_matrix: a perturbation response matrix
     :type prs_matrix: ndarray

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -782,7 +782,7 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
             else:
                 sel_line_res = structure.select('resid {0}'.format(line[22:26]))
                 j = np.where(structure.getResnums() == line[22:26])[0] \
-                    [np.where(sel_line_resnum.getChids() == line[21])[0][0]]
+                    [np.where(sel_line_res.getChids() == line[21])[0][0]]
                 fileEffs.write(line[:60] + ' '*(6-len('{:3.2f}'.format((effectiveness[j])*100))) \
                          + '{:3.2f}'.format((effectiveness[j])*100) + line[66:])
                 fileSens.write(line[:60] + ' '*(6-len('{:3.2f}'.format((sensitivity[j])*10))) \
@@ -824,7 +824,7 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
             else:
                 sel_line_res = structure.select('resid {0}'.format(line[22:26]))
                 j = np.where(structure.getResnums() == line[22:26])[0] \
-                    [np.where(sel_line_resnum.getChids() == line[21])[0][0]]
+                    [np.where(sel_line_res.getChids() == line[21])[0][0]]
                 fo.write(line[:60] + ' '*(6-len('{:3.2f}'.format((prs_matrix[i[n]][j])*10))) \
                          + '{:3.2f}'.format((prs_matrix[i[n]][j])*10) + line[66:])
         fo.close()


### PR DESCRIPTION
Doing 3N to N square sum in two separate loops rather than nested loops
gives a massive speed up (we're going from N**2 to 2*N)

Also fixed some things in the default file naming for writePerturbResponse
and made it work for missing residues and residues being in only some chains.