### PR TITLE
Implemented buildPDBEnsemble

### DIFF
--- a/prody/atomic/atomic.py
+++ b/prody/atomic/atomic.py
@@ -198,3 +198,11 @@ class Atomic(object):
         documentation for details and usage examples."""
 
         return SELECT.select(self, selstr, **kwargs)
+
+    def getTitle(self):
+        """Returns title of the instance."""
+        try:
+            ag = self.getAtomGroup()
+        except AttributeError:
+            ag = self
+        return ag._title

--- a/prody/ensemble/__init__.py
+++ b/prody/ensemble/__init__.py
@@ -22,9 +22,10 @@ are missing.  The following classes extend above to support this heterogeneity:
   * :class:`.PDBEnsemble`
   * :class:`.PDBConformation`
 
-Following functions are for editing PDB ensembles, e.g. finding and removing
-residues that are missing in too many structures:
-
+Following functions are for creating or editing PDB ensembles, e.g. finding and 
+removing residues that are missing in too many structures:
+  
+  * :func:`.buildPDBEnsemble`
   * :func:`.alignPDBEnsemble`
   * :func:`.calcOccupancies`
   * :func:`.showOccupancies`

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -4,10 +4,10 @@ import os.path
 
 import numpy as np
 
-from prody.proteins import fetchPDB, parsePDB, writePDB
+from prody.proteins import fetchPDB, parsePDB, writePDB, mapOntoChain
 from prody.utilities import openFile, showFigure
 from prody import LOGGER, SETTINGS
-from prody.atomic import AtomMap, Chain
+from prody.atomic import AtomMap, Chain, AtomGroup, Selection
 
 from .ensemble import *
 from .pdbensemble import *
@@ -15,7 +15,7 @@ from .conformation import *
 
 __all__ = ['saveEnsemble', 'loadEnsemble', 'trimPDBEnsemble',
            'calcOccupancies', 'showOccupancies', 'alignPDBEnsemble',
-           'calcTree', 'showTree']
+           'calcTree', 'showTree', 'buildPDBEnsemble']
 
 
 def saveEnsemble(ensemble, filename=None, **kwargs):
@@ -377,3 +377,86 @@ def showTree(tree, **kwargs):
         pylab.xlabel('distance')
         pylab.ylabel('proteins')
     return obj
+
+def buildPDBEnsemble(refpdb, PDBs, title='Unknown', labels=None, seqid=94, coverage=85, unmapped=None):  
+    """Builds a PDB ensemble from a given reference structure and a list of PDB structures. 
+    Note that the reference structure should be included in the list as well.
+
+    :arg refpdb: Reference structure
+    :type refpdb: :class:`.Chain`, :class:`.Selection`, or :class:`.AtomGroup`
+    :arg PDBs: A list of PDB structures
+    :type PDBs: list
+    :arg title: The title of the ensemble
+    :type title: str
+    :arg labels: labels of the conformations
+    :type labels: list
+    :arg seqid: Minimal sequence identity (percent)
+    :type seqid: int
+    :arg coverage: Minimal sequence overlap (percent)
+    :type coverage: int
+    :arg unmapped: A list of PDB IDs that cannot be included in the ensemble. This is an 
+    output argument. 
+    :type unmapped: list
+    """
+
+    if not isinstance(refpdb, (Chain, Selection, AtomGroup)):
+        raise TypeError('Refpdb must be a Chain, Selection, or AtomGroup.')
+    
+    if not isinstance(PDBs, list):
+        raise TypeError('PDBs must be a list of Chain, Selection, or AtomGroup.')
+    
+    if labels is not None:
+        if len(labels) != len(PDBs):
+            raise TypeError('Labels and PDBs must have the same lengths.')
+
+    # obtain the hierarhical view of the referrence PDB
+    refhv = refpdb.getHierView()
+    refchains = list(refhv)
+
+    # obtain the atommap of all the chains combined.
+    atoms = refchains[0]
+    for i in range(1, len(refchains)):
+        atoms += refchains[i]
+    
+    # initialize a PDBEnsemble with referrence atoms and coordinates
+    ensemble = PDBEnsemble(title)
+    ensemble.setAtoms(atoms)
+    ensemble.setCoords(atoms.getCoords())
+    
+    # build the ensemble
+    if unmapped is None: unmapped = []
+    for i,pdb in enumerate(PDBs):
+        if not isinstance(pdb, (Chain, Selection, AtomGroup)):
+            raise TypeError('PDBs must be a list of Chain, Selection, or AtomGroup.')
+        
+        if labels is None:
+            lbl = pdb.getTitle()
+        else:
+            lbl = labels[i]
+
+        atommaps = []
+        # find the mapping of the pdb to each reference chain
+        for chain in refchains:
+            mappings = mapOntoChain(pdb, chain,
+                                    seqid=seqid,
+                                    coverage=coverage)
+            if len(mappings) > 0:
+                atommaps.append(mappings[0][0])
+            else:
+                break
+
+        if len(atommaps) != len(refchains):
+            unmapped.append(lbl)
+            continue
+        
+        # combine the mappings of pdb to reference chains
+        atommap = atommaps[0]
+        for i in range(1, len(atommaps)):
+            atommap += atommaps[i]
+        
+        # add the mappings to the ensemble
+        ensemble.addCoordset(atommap, weights=atommap.getFlags('mapped'), label = lbl)
+         
+    ensemble.iterpose()
+
+    return ensemble


### PR DESCRIPTION
- add a function `buildPDBEnsemble` that can be used to create `PDBEnsemble` from a list of PDBs conveniently, e.g.:
`ensemble = buildPDBEnsemble(referencePDB, PDBs, title=title, labels=labels)`

- now all atomic classes have `getTitle()` (non-`AtomGroup` classes will return the title of their `AtomGroup`).