### PR TITLE
a small change to `buildPDBEnsemble`

### DIFF
--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -385,7 +385,7 @@ def buildPDBEnsemble(refpdb, PDBs, title='Unknown', labels=None, seqid=94, cover
     :arg refpdb: Reference structure
     :type refpdb: :class:`.Chain`, :class:`.Selection`, or :class:`.AtomGroup`
     :arg PDBs: A list of PDB structures
-    :type PDBs: list
+    :type PDBs: iterable
     :arg title: The title of the ensemble
     :type title: str
     :arg labels: labels of the conformations
@@ -404,9 +404,6 @@ def buildPDBEnsemble(refpdb, PDBs, title='Unknown', labels=None, seqid=94, cover
 
     if not isinstance(refpdb, (Chain, Segment, Selection, AtomGroup)):
         raise TypeError('Refpdb must be a Chain, Segment, Selection, or AtomGroup.')
-    
-    if not isinstance(PDBs, list):
-        raise TypeError('PDBs must be a list of Chain, Segment, Selection, or AtomGroup.')
     
     if labels is not None:
         if len(labels) != len(PDBs):


### PR DESCRIPTION
Relaxed the constraint of argument `PDBs` in `buildPDBEnsemble`.