### PR TITLE
Updated calcPerturbResponse and showPerturbResponse

### DIFF
--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -449,16 +449,15 @@ def calcPerturbResponse(model, atoms=None, repeats=100, **kwargs):
         elif atoms.numAtoms() != model.numAtoms():
             raise ValueError('model and atoms must have the same number atoms')
 
+    n_atoms = model.numAtoms()
+    LOGGER.progress('Calculating perturbation response', n_atoms, '_prody_prs')
+
     assert isinstance(repeats, int), 'repeats must be an integer'
     cov = calcCovariance(model)
     if cov is None:
         raise ValueError('model did not return a covariance matrix')
 
-    n_atoms = model.numAtoms()
     matrix_dict = {}
-
-    LOGGER.progress('Calculating perturbation response', n_atoms, '_prody_prs')
-
     if noForce is True:
         if not model.is3d():
             matrix_dict['noForce'] = cov**2
@@ -814,7 +813,7 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
         fileSens = open(file_sens_name,'w')
 
         for line in lines:            
-            if line.find('ATOM') != 0 and line.find('HETATM') != 0 or line.find('ANISOU') != 0:
+            if line.find('ATOM') != 0 and line.find('HETATM') != 0 and line.find('ANISOU') != 0:
                 fileEffs.write(line)                    
                 fileSens.write(line)
             elif line.find('ATOM') == 0:
@@ -828,10 +827,10 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
                 fileSens.write(line[:60] + ' '*(6-len('{:3.2f}'.format((\
                                sensitivity[j]*100/np.max(sensitivity))))) \
                                + '{:3.2f}'.format((sensitivity[j]) \
-                               *100/np.max(effectiveness)) + line[66:])
+                               *100/np.max(sensitivity)) + line[66:])
             elif line.find('HETATM') == 0:
-                fileEffs.write(line[:60] + ' '*3 + '0.00' + line[66:])
-                fileSens.write(line[:60] + ' '*3 + '0.00' + line[66:])
+                fileEffs.write(line[:60] + ' '*2 + '0.00' + line[66:])
+                fileSens.write(line[:60] + ' '*2 + '0.00' + line[66:])
                       
         fileEffs.close()
         fileSens.close()

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -605,7 +605,7 @@ def calcPerturbResponse(model, atoms=None, repeats=100, **kwargs):
             return response_matrix
 
     if atoms is not None: 
-        atoms.setData('prs_profile', matrix_dict[matrix_dict.keys()[0])
+        atoms.setData('prs_profile', matrix_dict[matrix_dict.keys()[0]])
         if len(operationList) > 1:
             LOGGER.info('Only one matrix can be added as data to atoms so' \
                         ' the first one was chosen. The operation that generated' \

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -606,7 +606,7 @@ def calcPerturbResponse(model, atoms=None, repeats=100, **kwargs):
 
     if atoms is not None: 
         atoms.setData('prs_profile', matrix_dict[matrix_dict.keys()[0]])
-        if len(operationList) > 1:
+        if len(matrix_dict.keys()) > 1:
             LOGGER.info('Only one matrix can be added as data to atoms so' \
                         ' the first one was chosen. The operation that generated' \
                         ' it was {0} (1st 3 letters).'.format(matrix_dict.keys()[0]))
@@ -650,27 +650,22 @@ def calcPerturbResponse(model, atoms=None, repeats=100, **kwargs):
             matrix_list.append(matrix_dict[m])
     matrix_array = array(matrix_list)
 
-    if len(norm_PRS_mat) == 1:
-        matrix_array = norm_PRS_mat.reshape(n_atoms,n_atoms)
-
     returnFormat = kwargs.get('returnFormat','array')
     returnFormat = returnFormat.lower()
+
+    if len(matrix_array) == 1:
+        LOGGER.info('Output has been returned as a single matrix (an array).')
+        return matrix_array.reshape(n_atoms,n_atoms)
     
     if returnFormat is 'both':
         LOGGER.info('You have requested return in both formats.' \
                     ' Array comes first.')
         return matrix_array, matrix_dict
-    elif returnFormat is 'array':
-        return matrix_array
     elif 'dict' in returnFormat:
+        LOGGER.info('Output has been returned as a dictionary of matrices.')
         return matrix_dict
-    elif len(matrix_array) == 1:
-        LOGGER.info('You only have one matrix that has been returned ' \
-                    ' as an array (returnFormat has been ignored).')
-        return matrix_array.reshape(n_atoms,n_atoms)
     else:
-        LOGGER.info('You have not entered a valid return format.' \
-                    ' You have therefore been given an array of matrices,' \
+        LOGGER.info('Output has been returned as an array of matrices,' \
                     ' which you can split into individual matrices.')
         return matrix_array
 

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -816,10 +816,10 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
                 sel_line_res = structure.select('resid {0}'.format(line[22:26]))
                 j = np.where(structure.getResnums() == int(line[22:26]))[0] \
                     [np.where(sel_line_res.getChids() == line[21])[0][0]]
-                fileEffs.write(line[:60] + ' '*(6-len('{:3.2f}'.format((effectiveness[j])*100))) \
-                               + '{:3.2f}'.format((effectiveness[j])*100) + line[66:])
-                fileSens.write(line[:60] + ' '*(6-len('{:3.2f}'.format((sensitivity[j])*10))) \
-                               + '{:3.2f}'.format((sensitivity[j])*10) + line[66:])
+                fileEffs.write(line[:60] + ' '*(6-len('{:3.2f}'.format((effectiveness[j]*100/np.max(effectiveness))))) \
+                               + '{:3.2f}'.format((effectiveness[j])*100/np.max(effectiveness)) + line[66:])
+                fileSens.write(line[:60] + ' '*(6-len('{:3.2f}'.format((sensitivity[j]*100/np.max(sensitivity))))) \
+                               + '{:3.2f}'.format((sensitivity[j])*100/np.max(effectiveness)) + line[66:])
                       
         fileEffs.close()
         fileSens.close()

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -732,9 +732,12 @@ def calcPerturbResponseProfiles(prs_matrix):
 def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
     """ Write the average response to perturbation of
     a particular residue (a row of a perturbation response matrix)
-    into the b-factor field of a PDB file for visualisation in PyMOL.
+    or the average effect of perturbation of a particular residue
+    (a column of a normalized perturbation response matrix)
+    into the b-factor field of a PDB file for visualisation in a
+    molecular graphics program.
     If no chain is given this will be done for that residue in all chains.
-    
+
     If no residue number is given then the effectiveness and sensitivity
     profiles will be written out instead. These two profiles are also returned
     as arrays for further analysis if they aren't already provided.
@@ -763,10 +766,13 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
     :arg resnum: residue number for the residue of interest
     :type resnum: int
 
-    :arg direction: whether you want to write out to PDB
-        a row (the effect on each residue of peturbing the specified residue)
-        or a column (the response of the specified residue to perturbing each 
-        residue). Default is row.
+    :arg direction: the direction you want to use to read data out
+        of the PRS matrix for plotting: the options are 'row' or 'column'.
+        Default is 'row'.
+        A row gives the effect on each residue of peturbing the specified 
+        residue.
+        A column gives the response of the specified residue to perturbing 
+        each residue.
         If no residue number is provided then this option will be ignored
     :type direction: str
     """
@@ -846,7 +852,6 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
     timesNotFound = 0
     direction = kwargs.get('direction','row')
     for n in range(len(chain)):
-
         if not chain[n] in chains:
             raise PRSMatrixParseError('Chain {0} was not found in {1}'.format(chain[n], pdbIn))
 
@@ -862,11 +867,14 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
     if pdbOut is None:
         pdbOut = []
         for n in range(len(chain)):
+            chainNum = int(np.where(chains == chain[n])[0])
             i = np.where(structure.getResnums() == resnum)[0][chainNum-timesNotFound]
             pdbOut.append('{0}_{1}_{2}{3}_{4}.pdb'.format(stem, chain[n], \
                               structure.getResnames()[i[n]], resnum, direction))
 
     for n in range(len(chain)):
+        chainNum = int(np.where(chains == chain)[0])
+        i = np.where(structure.getResnums() == resnum)[0][chainNum-timesNotFound]
         fo = open(pdbOut[n],'w')
         for line in lines:
             if line.find('ATOM') != 0:

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -814,10 +814,10 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
         fileSens = open(file_sens_name,'w')
 
         for line in lines:            
-            if line.find('ATOM') != 0 and line.find('HETATM') != 0 and line.find('ANISOU') != 0:
+            if line.find('ATOM') != 0 and line.find('HETATM') != 0 or line.find('ANISOU') != 0:
                 fileEffs.write(line)                    
                 fileSens.write(line)
-            else:
+            elif line.find('ATOM') == 0:
                 sel_line_res = structure.select('resid {0}'.format(line[22:26]))
                 j = np.where(structure.getResnums() == int(line[22:26]))[0] \
                     [np.where(sel_line_res.getChids() == line[21])[0][0]]
@@ -829,6 +829,9 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
                                sensitivity[j]*100/np.max(sensitivity))))) \
                                + '{:3.2f}'.format((sensitivity[j]) \
                                *100/np.max(effectiveness)) + line[66:])
+            elif line.find('HETATM') == 0:
+                fileEffs.write(line[:60] + ' '*3 + '0.00' + line[66:])
+                fileSens.write(line[:60] + ' '*3 + '0.00' + line[66:])
                       
         fileEffs.close()
         fileSens.close()

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -23,7 +23,7 @@ __all__ = ['calcCollectivity', 'calcCovariance', 'calcCrossCorr',
            'calcFractVariance', 'calcSqFlucts', 'calcTempFactors',
            'calcProjection', 'calcCrossProjection', 
            'calcPerturbResponse', 'parsePerturbResponseMatrix', 
-           'writePerturbResponsePDB', 'calcPerturbResponseProfiles', 
+           'calcPerturbResponseProfiles', 'writePerturbResponsePDB',
            'calcSpecDimension', 'calcPairDeformationDist',]
 
 class PRSMatrixParseError(Exception):
@@ -775,6 +775,10 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
         each residue.
         If no residue number is provided then this option will be ignored
     :type direction: str
+
+    :arg returnData: whether to return effectiveness and sensitivity for analysis
+        default is False
+    :type returnProfiles: bool
     """
 
     if not type(prs_matrix) is np.ndarray:
@@ -843,7 +847,8 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
         LOGGER.info('The effectiveness and sensitivity profiles were written' \
                     ' to {0} and {1}.'.format(file_effs_name,file_sens_name))
 
-        if kwargs.get('effectiveness') is None:
+        returnData = kwargs.get('returnData',False)
+        if returnData:
             return effectiveness, sensitivity
         else:
             return
@@ -899,6 +904,7 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
         outFiles.append(fo)
         LOGGER.report('Perturbation responses for specific residues were written', 
                        ' to {0} and {1}.'.format(', '.join(outFiles[:-1]),outFiles[-1]))
+
     return
 
 

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -814,7 +814,7 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
         fileSens = open(file_sens_name,'w')
 
         for line in lines:            
-            if line.find('ATOM') != 0:  
+            if line.find('ATOM') != 0 and line.find('HETATM') != 0 and line.find('ANISOU') != 0:
                 fileEffs.write(line)                    
                 fileSens.write(line)
             else:

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -816,10 +816,14 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
                 sel_line_res = structure.select('resid {0}'.format(line[22:26]))
                 j = np.where(structure.getResnums() == int(line[22:26]))[0] \
                     [np.where(sel_line_res.getChids() == line[21])[0][0]]
-                fileEffs.write(line[:60] + ' '*(6-len('{:3.2f}'.format((effectiveness[j]*100/np.max(effectiveness))))) \
-                               + '{:3.2f}'.format((effectiveness[j])*100/np.max(effectiveness)) + line[66:])
-                fileSens.write(line[:60] + ' '*(6-len('{:3.2f}'.format((sensitivity[j]*100/np.max(sensitivity))))) \
-                               + '{:3.2f}'.format((sensitivity[j])*100/np.max(effectiveness)) + line[66:])
+                fileEffs.write(line[:60] + ' '*(6-len('{:3.2f}'.format(( \
+                               effectiveness[j]*100/np.max(effectiveness))))) \
+                               + '{:3.2f}'.format((effectiveness[j]) \
+                               *100/np.max(effectiveness)) + line[66:])
+                fileSens.write(line[:60] + ' '*(6-len('{:3.2f}'.format((\
+                               sensitivity[j]*100/np.max(sensitivity))))) \
+                               + '{:3.2f}'.format((sensitivity[j]) \
+                               *100/np.max(effectiveness)) + line[66:])
                       
         fileEffs.close()
         fileSens.close()
@@ -866,11 +870,15 @@ def writePerturbResponsePDB(prs_matrix,pdbIn,**kwargs):
                     [np.where(sel_line_res.getChids() == line[21])[0][0]]
 
                 if direction is 'row':
-                    fo.write(line[:60] + ' '*(6-len('{:3.2f}'.format((prs_matrix[i[n]][j])*10))) \
-                         + '{:3.2f}'.format((prs_matrix[i[n]][j])*10) + line[66:])
+                    fo.write(line[:60] + ' '*(6-len('{:3.2f}'.format(( \
+                             prs_matrix[i[n]][j])*100/np.max(prs_matrix)))) \
+                             + '{:3.2f}'.format((prs_matrix[i[n]][j]) \
+                             *100/np.max(prs_matrix)) + line[66:])
                 else:
-                    fo.write(line[:60] + ' '*(6-len('{:3.2f}'.format((prs_matrix[j][i[n]])*10))) \
-                         + '{:3.2f}'.format((prs_matrix[j][i[n]])*10) + line[66:])
+                    fo.write(line[:60] + ' '*(6-len('{:3.2f}'.format(( \
+                             prs_matrix[j][i[n]])*100/np.max(prs_matrix)))) \
+                             + '{:3.2f}'.format((prs_matrix[j][i[n]]) \
+                             *100/np.max(prs_matrix)) + line[66:])
 
         fo.close()
         outFiles.append(fo)

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -448,6 +448,7 @@ def showOverlapTable(modes_x, modes_y, **kwargs):
 
     cmap = kwargs.pop('cmap', plt.cm.jet)
     norm = kwargs.pop('norm', matplotlib.colors.Normalize(0, 1))
+    plt.figure()
     show = (plt.pcolor(overlap, cmap=cmap, norm=norm, **kwargs),
             plt.colorbar())
     x_range = np.arange(1, modes_x.numModes() + 1)

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -921,6 +921,10 @@ def showPerturbResponse(**kwargs):
 
     :arg atoms: a :class: `AtomGroup` instance
     :type atoms: AtomGroup
+
+    :arg returnData: whether to return data for further analysis
+        default is False
+    :type returnData: bool
     """
 
     import matplotlib.pyplot as plt
@@ -979,7 +983,8 @@ def showPerturbResponse(**kwargs):
         plt.subplot(2,2,2); plt.bar(effectiveness,range(len(effectiveness)))
         plt.subplot(2,2,3); plt.barh(sensitivity,range(len(sensitivity)))
 
-    if kwargs.get('effectiveness') is not None:
+    returnData = kwargs.get('returnData',False)
+    if not returnData:
         return
     elif kwargs.get('prs_matrix') is not None:
         return effectiveness, sensitivity
@@ -1034,6 +1039,10 @@ def showPerturbResponseProfiles(prs_matrix,atoms,**kwargs):
         each residue.
         If no residue number is provided then this option will be ignored
     :type direction: str
+
+    :arg returnData: whether to return profiles for further analysis
+        default is False
+    :type returnProfiles: bool
     """
     import matplotlib.pyplot as plt
     import matplotlib
@@ -1127,4 +1136,8 @@ def showPerturbResponseProfiles(prs_matrix,atoms,**kwargs):
         else:
             plt.axis([atoms.getResnums()[borders[0]],atoms.getResnums()[borders[1]-1],0,np.max(profile)])
 
-    return profiles
+    returnData = kwargs.get('returnData',False)
+    if returnData:
+        return profiles
+    else:
+        return

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -23,6 +23,7 @@ from .analysis import calcFractVariance, calcCrossProjection
 from .analysis import calcPerturbResponse, calcPerturbResponseProfiles
 from .compare import calcOverlap
 from prody.atomic import AtomGroup, Selection
+from math import ceil
 
 __all__ = ['showContactMap', 'showCrossCorr',
            'showCumulOverlap', 'showFractVars',
@@ -964,14 +965,14 @@ def showPerturbResponse(**kwargs):
                      effectiveness[borders[n]:borders[n+1]], \
                      color=chain_colors[n], \
                      edgecolor=chain_colors[n])
-            plt.axis([0,math.ceil(np.max(effectiveness)),0,borders[-1]])
+            plt.axis([0,ceil(np.max(effectiveness)),0,borders[-1]])
 
             plt.subplot(2,2,3)
             plt.bar(range(borders[n],borders[n+1]), \
                     sensitivity[borders[n]:borders[n+1]], \
                     color=chain_colors[n], \
                     edgecolor=chain_colors[n])
-            plt.axis([0,borders[-1],0,math.ceil(np.max(sensitivity))])
+            plt.axis([0,borders[-1],0,ceil(np.max(sensitivity))])
 
     else:
         plt.subplot(2,2,2); plt.bar(effectiveness,range(len(effectiveness)))

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -940,8 +940,8 @@ def showPerturbResponse(**kwargs):
     if effectiveness is None:
         effectiveness, sensitivity = calcPerturbResponseProfiles(prs_matrix)
 
-    fig = plt.figure()
-    plt.subplot(2,2,1) 
+    plt.figure()
+    plt.subplot(2,2,1)
     show = plt.imshow(prs_matrix, cmap=kwargs.get('cmap', plt.cm.jet), \
                       norm=kwargs.get('norm', None), aspect='auto', \
                       origin='lower')
@@ -964,21 +964,23 @@ def showPerturbResponse(**kwargs):
                      effectiveness[borders[n]:borders[n+1]], \
                      color=chain_colors[n], \
                      edgecolor=chain_colors[n])
+            plt.axis([0,math.ceil(np.max(effectiveness)),0,borders[-1]])
 
             plt.subplot(2,2,3)
             plt.bar(range(borders[n],borders[n+1]), \
                     sensitivity[borders[n]:borders[n+1]], \
                     color=chain_colors[n], \
                     edgecolor=chain_colors[n])
+            plt.axis([0,borders[-1],0,math.ceil(np.max(sensitivity))])
 
     else:
         plt.subplot(2,2,2); plt.bar(effectiveness,range(len(effectiveness)))
         plt.subplot(2,2,3); plt.barh(sensitivity,range(len(sensitivity)))
 
     if kwargs.get('effectiveness') is not None:
-        return fig
+        return
     elif kwargs.get('prs_matrix') is not None:
-        return effectiveness, sensitivity, fig
+        return effectiveness, sensitivity
     else:
-        return prs_matrix, effectiveness, sensitivity, fig
+        return prs_matrix, effectiveness, sensitivity
 

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -87,6 +87,7 @@ def parsePDB(pdb, **kwargs):
 
     :arg pdb: a PDB identifier or a filename
         If needed, PDB files are downloaded using :func:`.fetchPDB()` function.
+        You can also provide arguments that you would like passed on to fetchPDB().
     """
     title = kwargs.get('title', None)
     if not os.path.isfile(pdb):
@@ -94,7 +95,7 @@ def parsePDB(pdb, **kwargs):
             if title is None:
                 title = pdb
                 kwargs['title'] = title
-            filename = fetchPDB(pdb, report=True)
+            filename = fetchPDB(pdb, report=True, **kwargs)
             if filename is None:
                 raise IOError('PDB file for {0} could not be downloaded.'
                               .format(pdb))


### PR DESCRIPTION
These changes shouldn't really do anything except add ease of use through having more options. Basically 3 changes (the first two are unnecessary except for showing forces have no effect):
1. Forces are now fully random rather than in the positive quadrant
2. If the user wants to check what happens from doing different things with the matrices from individual forces, this is now handled with dictionaries. The the user can choose whether to have a dictionary returned or stick with arrays, which can be read out into individual variables. (There is a commit associated with this because I missed a square bracket implementing it.)
3. showPerturbResponse now has the effectiveness and sensitivity clipped at the last residue to align with the PRS matrix