### PR TITLE
Fixed failed downloading of obsolete PDBs

### DIFF
--- a/prody/proteins/localpdb.py
+++ b/prody/proteins/localpdb.py
@@ -332,8 +332,6 @@ def fetchPDB(*pdb, **kwargs):
         LOGGER.warn('Downloading PDB files via FTP failed ({0}), '
                     'trying HTTP.'.format(str(err)))
     else:
-        LOGGER.warn('Downloading PDB files via FTP failed, '
-                    'trying HTTP.')
         if fns is None:
             tryHTTP = True
         elif isinstance(fns, list): 
@@ -341,6 +339,8 @@ def fetchPDB(*pdb, **kwargs):
             if len(downloads) > 0: 
                 tryHTTP = True
         if tryHTTP:
+            LOGGER.warn('Downloading PDB files via FTP failed, '
+                    'trying HTTP.')
             try:
                 fns = fetchPDBviaHTTP(*downloads, check=False, **kwargs)
             except Exception as err:

--- a/prody/proteins/wwpdb.py
+++ b/prody/proteins/wwpdb.py
@@ -307,7 +307,7 @@ def fetchPDBviaHTTP(*pdb, **kwargs):
         try:
             handle = openURL(getURL(pdb))
         except Exception as err:
-            LOGGER.warn('{0} download failed ({0}).'.format(pdb, str(err)))
+            LOGGER.warn('{0} download failed ({1}).'.format(pdb, str(err)))
             failure += 1
             filenames.append(None)
         else:


### PR DESCRIPTION
- Partly fixed the obsolete PDB ID problem (#380). Now fetchPDB will try to use HTTP (it can find obsolete PDBs) if FTP couldn't locate the ID. Soon I will implement a function that can redirect the obsolete PDB IDs to the new IDs according to the official obsolete list (ftp://ftp.wwpdb.org/pub/pdb/data/status/obsolete.dat).