### PR TITLE
Bug fixes in ModeSet.getCovariance

### DIFF
--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -482,12 +482,12 @@ def calcPerturbResponse(model, atoms=None, repeats=100, **kwargs):
                                  'or difference (from covariance matrix) in quotes ' \
                                  'or a list containing a set of these or None.')
 
-    if not isinstance(model, NMA):
-        raise TypeError('model must be an NMA instance')
+    if not isinstance(model, (NMA, ModeSet, Mode)):
+        raise TypeError('model must be an NMA, ModeSet, or Mode instance')
     elif not model.is3d() and not noForce:
         raise TypeError('model must be a 3-dimensional NMA instance' \
                         'for using PRS with force')
-    elif len(model) == 0:
+    if isinstance(model, NMA) and len(model) == 0:
         raise ValueError('model must have normal modes calculated')
 
     if atoms is not None:

--- a/prody/dynamics/modeset.py
+++ b/prody/dynamics/modeset.py
@@ -113,7 +113,7 @@ class ModeSet(object):
         """Returns covariance matrix. It will be calculated using available modes."""
 
         V = self.getEigvecs()
-        D = diag(self.getEigvals())
+        D = diag(self.getVariances())
         return dot(V, dot(D, V.T))
 
     def getArray(self):

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -137,6 +137,8 @@ def trimPDBEnsemble(pdb_ensemble, **kwargs):
         trim_atoms_idx = [n for n,t in enumerate(torf) if t]
         if type(atoms) is Chain:
             trim_atoms=Chain(atoms.getAtomGroup(), trim_atoms_idx, atoms._hv)
+        elif type(atoms) is AtomGroup:
+            trim_atoms= AtomMap(atoms,trim_atoms_idx)
         else:
             trim_atoms= AtomMap(atoms.getAtomGroup(),trim_atoms_idx)
         trimmed.setAtoms(trim_atoms)


### PR DESCRIPTION
- Now calcPerturbResponse accepts Mode and ModeSet as input
- Fixed a bug where ModeSet.getCovariance weighs each mode with eigenvalue (the weight should be variance which is equivalent to 1/eigenvalue).

