### PR TITLE
writePDB now can write secondary structures to PDB files

### DIFF
--- a/prody/atomic/fields.py
+++ b/prody/atomic/fields.py
@@ -146,6 +146,21 @@ ATOMIC_FIELDS = {
                        meth='Secstr', synonym='secstr',
                        selstr=('secondary H E', 'secstr H E'),
                        ),
+    'secid':     Field('secid', DTYPE + '3',
+                       doc='secondary structure identifier',
+                       meth='Secid',
+                       selstr=('secid A B', 'secid 1 2')
+                       ),
+    'secclass':  Field('secclass', int,
+                       doc='secondary structure class',
+                       meth='Secclass', meth_pl='Secclasses',
+                       selstr=('secclass 2', 'secclass -1')
+                       ),
+    'secindex':  Field('secindex', int,
+                       doc='secondary structure index',
+                       meth='Secindex', meth_pl='Secindices',
+                       selstr=('secindex 2')
+                       ),
     'segment':   Field('segment', DTYPE + '6', doc='segment name',
                        meth='Segname',
                        selstr=('segment PROT', 'segname PROT'),

--- a/prody/chromatin/hic.py
+++ b/prody/chromatin/hic.py
@@ -1,7 +1,7 @@
 from numpy import ma
 import numpy as np
 from scipy.sparse import coo_matrix
-from collections import Counter
+from scipy.stats import mode
 from prody.chromatin.norm import VCnorm, SQRTVCnorm, Filenorm
 from prody.chromatin.cluster import KMeans, Hierarchy
 from prody.chromatin.functions import div0, showMap, showDomains, _getEigvecs
@@ -383,8 +383,7 @@ def parseHiCStream(stream, **kwargs):
         if bin is None:
             loci = np.unique(np.sort(i))
             bins = np.diff(loci)
-            counts = Counter(bins)
-            bin = counts.most_common(1)[0][0]
+            bin = mode(bins)[0][0]
         # convert coordinate from basepair to locus index
         i = i//bin
         j = j//bin

--- a/prody/chromatin/hic.py
+++ b/prody/chromatin/hic.py
@@ -350,7 +350,55 @@ def parseHiC(filename, **kwargs):
         hic = parseHiCStream(filestream, title=title, **kwargs)
     return hic
 
+def parseHiCStream(stream, **kwargs):
+    """Returns an :class:`.HiC` from a stream of Hi-C data lines.
 
+    :arg stream: Anything that implements the method ``read``, ``seek``
+        (e.g. :class:`file`, buffer, stdin)
+    """
+
+    title = kwargs.get('title', 'Unknown')
+
+    import csv
+    dialect = csv.Sniffer().sniff(stream.read(1024))
+    stream.seek(0)
+    reader = csv.reader(stream, dialect)
+    D = list()
+    for row in reader:
+        d = list()
+        for element in row:
+            d.append(np.double(element))
+        D.append(d)
+    D = np.array(D)
+
+    bin = kwargs.get('bin', None)
+    size = D.shape
+    if len(D.shape) <= 1:
+        raise ValueError("Cannot parse the file: input file only contains one column.")
+    if size[0] == size[1]:
+        M = D
+    else:
+        i, j, value = D.T
+        # determine the bin size by the most frequent interval
+        if bin is None:
+            loci = np.unique(np.sort(i))
+            bins = np.diff(loci)
+            counts = Counter(bins)
+            bin = counts.most_common(1)[0][0]
+        # convert coordinate from basepair to locus index
+        i = i//bin
+        j = j//bin
+        # make sure that the matrix is square
+        if np.max(i) != np.max(j):
+            b = np.max(np.append(i, j))
+            i = np.append(i, b)
+            j = np.append(j, b)
+            value = np.append(value, 0.)
+        # Convert to sparse matrix format, then full matrix format
+        # and finally array type. Matrix format is avoided because
+        # diag() won't work as intended for Matrix instances.
+        M = np.array(coo_matrix((value, (i,j))).todense())
+    return HiC(title=title, map=M, bin=bin)
 
 def writeMap(filename, map, bin=None, format='%f'):
     """Writes *map* to the file designated by *filename*.

--- a/prody/chromatin/hic.py
+++ b/prody/chromatin/hic.py
@@ -2,7 +2,7 @@ from numpy import ma
 import numpy as np
 from scipy.sparse import coo_matrix
 from collections import Counter
-from prody.chromatin.norm import VCnorm, SQRTVCnorm,Filenorm
+from prody.chromatin.norm import VCnorm, SQRTVCnorm, Filenorm
 from prody.chromatin.cluster import KMeans, Hierarchy
 from prody.chromatin.functions import div0, showMap, showDomains, _getEigvecs
 

--- a/prody/chromatin/hic.py
+++ b/prody/chromatin/hic.py
@@ -1,6 +1,7 @@
 from numpy import ma
 import numpy as np
 from scipy.sparse import coo_matrix
+from collections import Counter
 from prody.chromatin.norm import VCnorm, SQRTVCnorm,Filenorm
 from prody.chromatin.cluster import KMeans, Hierarchy
 from prody.chromatin.functions import div0, showMap, showDomains, _getEigvecs
@@ -370,18 +371,20 @@ def parseHiCStream(stream, **kwargs):
         D.append(d)
     D = np.array(D)
 
-    bin = None
+    bin = kwargs.get('bin', None)
     size = D.shape
     if len(D.shape) <= 1:
         raise ValueError("Cannot parse the file: input file only contains one column.")
     if size[0] == size[1]:
-        bin = None
         M = D
     else:
         i, j, value = D.T
-        # determine the bin size by the first and second locus
-        bins = np.unique(np.sort(i))
-        bin = bins[1] - bins[0]
+        # determine the bin size by the most frequent interval
+        if bin is None:
+            loci = np.unique(np.sort(i))
+            bins = np.diff(loci)
+            counts = Counter(bins)
+            bin = counts.most_common(1)[0][0]
         # convert coordinate from basepair to locus index
         i = i//bin
         j = j//bin

--- a/prody/proteins/header.py
+++ b/prody/proteins/header.py
@@ -904,6 +904,16 @@ mapHelix = {
     10: '',  # Polyproline
 }
 
+def isHelix(secstrs):
+    torf = np.logical_and(secstrs, False)
+    for h in mapHelix.itervalues():
+        if h != '':
+            torf = np.logical_or(torf, secstrs==h)
+    return torf
+
+def isSheet(secstrs):
+    torf = secstrs == 'E'
+    return torf
 
 def assignSecstr(header, atoms, coil=False):
     """Assign secondary structure from *header* dictionary to *atoms*.
@@ -962,6 +972,13 @@ def assignSecstr(header, atoms, coil=False):
             ag = atoms.getAtomGroup()
         ag.setSecstrs(np.zeros(ag.numAtoms(),
                       ATOMIC_FIELDS['secondary'].dtype))
+        ag.setSecids(np.zeros(ag.numAtoms(),
+                      ATOMIC_FIELDS['secid'].dtype))
+        ag.setSecclasses(np.zeros(ag.numAtoms(),
+                      ATOMIC_FIELDS['secclass'].dtype)) 
+        ag.setSecindices(np.zeros(ag.numAtoms(),
+                      ATOMIC_FIELDS['secindex'].dtype))  
+
     atoms.select('protein').setSecstrs('C')
     hierview = atoms.getHierView()
     count = 0
@@ -970,12 +987,19 @@ def assignSecstr(header, atoms, coil=False):
         res = getResidue(*key)
         if res is None:
             continue
+        res.setSecids(value[2])
+        res.setSecclasses(value[0])
+        res.setSecindices(value[1])
         res.setSecstrs(mapHelix[value[0]])
+        
         count += 1
-    for key, res in sheet.items():  # PY3K: OK
+    for key, value in sheet.items():  # PY3K: OK
         res = getResidue(*key)
         if res is None:
             continue
+        res.setSecids(value[2])
+        res.setSecclasses(value[0])
+        res.setSecindices(value[1])
         res.setSecstrs('E')
         count += 1
     LOGGER.info('Secondary structures were assigned to {0} residues.'

--- a/prody/proteins/header.py
+++ b/prody/proteins/header.py
@@ -905,7 +905,7 @@ mapHelix = {
 }
 
 def isHelix(secstrs):
-    torf = np.logical_and(secstrs, False)
+    torf = np.logical_and(secstrs=='', False)
     for h in mapHelix.itervalues():
         if h != '':
             torf = np.logical_or(torf, secstrs==h)

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -765,7 +765,7 @@ PDBLINE = ('{0:6s}{1:5d} {2:4s}{3:1s}'
            '{11:6.2f}{12:6.2f}      '
            '{13:4s}{14:2s}\n')
 
-HELIXLINE = ('%-6s %3d %-3s %-3s %1s %4d%1s %-3s %1s %4d%1s%2d'
+HELIXLINE = ('HELIX  %3d %-3s %-3s %1s %4d%1s %-3s %1s %4d%1s%2d'
              '                              %5d\n')
 
 PDBLINE_LT100K = ('%-6s%5d %-4s%1s%-4s%1s%4d%1s   '
@@ -918,10 +918,11 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
         # write helices
         for i in range(1,max(secindices)+1):
             torf = np.logical_or(isHelix(secstrs), secindices==i)
-            helix_resnums = resnums[torf]
-            helix_chainids = chainids[torf]
-            helix_resname = resnames[torf]
-
+            if torf.any():
+                helix_resnums = resnums[torf]
+                helix_chainids = chainids[torf]
+                helix_resname = resnames[torf]
+                write(HELIXLINE % (i))
         pass
 
     # write atoms

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -944,22 +944,28 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
                             helixClass=helix_secclasses[0], length=L))
         
         # write strands
-        for i in range(1,max(secindices)+1):
-            torf = np.logical_and(isSheet(secstrs), secindices==i)
-            if torf.any():
-                sheet_resnums = resnums[torf]
-                sheet_chainids = chainids[torf]
-                sheet_resnames = resnames[torf]
-                sheet_secclasses = secclasses[torf]
-                sheet_secids = secids[torf]
-                sheet_icodes = icodes[torf]
+        torf_all_sheets = isSheet(secstrs)
+        sheet_secids = secids[torf_all_sheets]
 
-                stream.write(SHEETLINE.format(strand=i, sheetID=sheet_secids[0], numStrands=1,
-                            initResName=sheet_resnames[0], initChainID=sheet_chainids[0], 
-                            initSeqNum=sheet_resnums[0], initICode=sheet_icodes[0],
-                            endResName=sheet_resnames[-1], endChainID=sheet_chainids[-1], 
-                            endSeqNum=sheet_resnums[-1], endICode=sheet_icodes[-1],
-                            sense=sheet_secclasses[0]))
+        for sheet_id in np.unique(sheet_secids):
+            torf_strands_in_sheet = np.logical_and(torf_all_sheets, secids==sheet_id)
+            strand_indices = secindices[torf_strands_in_sheet]
+            numStrands = len(np.unique(strand_indices))
+
+            for i in np.unique(strand_indices):
+                torf_strand = np.logical_and(torf_strands_in_sheet, secindices==i)
+                strand_resnums = resnums[torf_strand]
+                strand_chainids = chainids[torf_strand]
+                strand_resnames = resnames[torf_strand]
+                strand_secclasses = secclasses[torf_strand]
+                strand_icodes = icodes[torf_strand]
+
+                stream.write(SHEETLINE.format(strand=i, sheetID=sheet_id, numStrands=numStrands,
+                            initResName=strand_resnames[0], initChainID=strand_chainids[0], 
+                            initSeqNum=strand_resnums[0], initICode=strand_icodes[0],
+                            endResName=strand_resnames[-1], endChainID=strand_chainids[-1], 
+                            endSeqNum=strand_resnums[-1], endICode=strand_icodes[-1],
+                            sense=strand_secclasses[0]))
         pass
 
     # write atoms


### PR DESCRIPTION
- Added three secondary structure related attributes to AtomGroup: secid (helix or sheet id), secindex (helix or strand index), and secclass (helix class or strand sense).
- Accommodated assignSecstr and writePDB so that complete information on secondary structures can be read or written. *Note that the registrations of the beta sheets are not included in reading or writing, since for that a residue needs to store a reference to other residues, but I am not sure which attributes/data types I should use.
- Fixed a problem in HiC module where the bin size cannot be correctly recognized in some cases.
