### PR TITLE
Several fixes

### DIFF
--- a/prody/dynamics/pca.py
+++ b/prody/dynamics/pca.py
@@ -189,8 +189,10 @@ class PCA(NMA):
             raise ValueError('covariance matrix is not built or set')
         start = time.time()
         dof = self._dof
+        if str(n_modes).lower() is 'all':
+            n_modes = None
         if linalg.__package__.startswith('scipy'):
-            if n_modes is None or 'all':
+            if n_modes is None:
                 eigvals = None
                 n_modes = dof
             else:

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -7,7 +7,7 @@ import numpy as np
 from prody.proteins import fetchPDB, parsePDB, writePDB, mapOntoChain
 from prody.utilities import openFile, showFigure
 from prody import LOGGER, SETTINGS
-from prody.atomic import AtomMap, Chain, AtomGroup, Selection, Segment
+from prody.atomic import AtomMap, Chain, AtomGroup, Selection, Segment, Select
 
 from .ensemble import *
 from .pdbensemble import *
@@ -127,8 +127,15 @@ def trimPDBEnsemble(pdb_ensemble, **kwargs):
         #weights = weights.flatten()
         #mean_weights = weights / n_confs
         torf = occupancies >= occupancy
+    elif 'selstr' in kwargs:
+        selstr = kwargs['selstr']
+        atoms = pdb_ensemble.getAtoms()
+        assert atoms is not None, 'atoms are empty'
+        selector = Select()
+        torf = selector.getBoolArray(atoms, selstr)
     else:
-        return None
+        n_atoms = pdb_ensemble.getCoords().shape[0]
+        torf = np.ones(n_atoms, dtype=bool)
 
     trimmed = PDBEnsemble(pdb_ensemble.getTitle())
 

--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -253,6 +253,7 @@ def showProtein(*atoms, **kwargs):
         cnames = list(cnames)
         import random
         random.shuffle(cnames)
+        cnames_copy = list(cnames)
         min_ = list()
         max_ = list()
         for atoms in alist:
@@ -268,6 +269,8 @@ def showProtein(*atoms, **kwargs):
                     for ch in HierView(calpha, chain=True):
                         xyz = ch._getCoords()
                         chid = ch.getChid()
+                        if len(cnames) == 0:
+                            cnames = list(cnames_copy)
                         show.plot(xyz[:, 0], xyz[:, 1], xyz[:, 2],
                                 label=title + '_' + chid,
                                 color=kwargs.get(chid, cnames.pop()).lower(),
@@ -318,6 +321,8 @@ def showProtein(*atoms, **kwargs):
                     resname = res.getResname()
                     resnum = str(res.getResnum())
                     chid = res.getChid()
+                    if len(cnames) == 0:
+                        cnames = list(cnames_copy)
                     show.plot(xyz[:, 0], xyz[:, 1], xyz[:, 2], ls='None',
                               color=kwargs.get(resname, cnames.pop()).lower(),
                               label=title + '_' + chid + '_' + resname + resnum,


### PR DESCRIPTION
- Fixed a bug which causes n_modes in PCA.calcModes not functional.
- trimPDBEnsemble now takes 'selstr' as input so it will trimed the residues NOT selected by 'selstr'.
- Fixed a bug where showProtein uses up all the colors if the number of molecules is very large.




