### PR TITLE
Added substring matching for msa.getIndex

### DIFF
--- a/prody/sequence/msa.py
+++ b/prody/sequence/msa.py
@@ -287,7 +287,10 @@ class MSA(object):
         try:
             index = self._mapping[label]
         except KeyError:
-            return None
+            try:
+                return list(v for k,v in self._mapping.iteritems() if label in k)[0]
+            except:
+                return None
         except TypeError:
             mapping = self._mapping
             indices = []


### PR DESCRIPTION
This was necessary because the label had white space at the end.