### PR TITLE
ciffile change line checking for ATOM/HETATM

### DIFF
--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -180,7 +180,7 @@ def _parseCIFLines(atomgroup, lines, model, chain, subset,
     doneAtomBlock = False
     while not doneAtomBlock:
         line = lines[i]
-        if line[:6] == 'ATOM  ' or line[:6] == 'HETATM':
+        if line.startswith('ATOM') or line.startswith('HETATM'):
             if not foundAtomBlock:
                 foundAtomBlock = True
                 start = i


### PR DESCRIPTION
The parser is crashing for proteins (ex: 4v6w) for which the atom field does not have two spaces after "ATOM":
"ATOM 1      N N     . PHE A  1  4    ? -15.152  72.946   -53.601  1.00 70.00 ? 4    PHE Az N     1 "