### PR TITLE
Changes related to SignDy

### DIFF
--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -668,10 +668,10 @@ def calcSignatureProfile(ensemble, index, **kwargs):
                 modes.append(mode)
             sqfs = calcSqFlucts(modes)
             V.append(sqfs)
-    V = np.vstack(V)
+    V = np.vstack(V); V = V.T
 
-    meanV = V.mean(axis=0)
-    stdV = V.std(axis=0)
+    meanV = V.mean(axis=1)
+    stdV = V.std(axis=1)
 
-    return meanV, stdV
+    return meanV, stdV, V
     

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -25,7 +25,7 @@ __all__ = ['calcCollectivity', 'calcCovariance', 'calcCrossCorr',
            'calcFractVariance', 'calcSqFlucts', 'calcTempFactors',
            'calcProjection', 'calcCrossProjection', 'calcPerturbResponse',
            'calcSpecDimension', 'calcPairDeformationDist', 'calcEnsembleENMs', 
-           'calcOverlapTree']
+           'calcSignatureProfile', 'calcOverlapTree']
            #'calcEntropyTransfer', 'calcOverallNetEntropyTransfer']
 
 def calcCollectivity(mode, masses=None):
@@ -247,16 +247,25 @@ def calcSqFlucts(modes):
     relative units."""
 
     if not isinstance(modes, (VectorBase, NMA, ModeSet)):
-        raise TypeError('modes must be a Mode, NMA, or ModeSet instance, '
-                        'not {0}'.format(type(modes)))
-    is3d = modes.is3d()
+        try:
+            modes = [ mode for mode in modes ]
+        except TypeError:
+            raise TypeError('modes must be a Mode, NMA, ModeSet instance, '
+                            'or a list of Mode instances, not {0}'.format(type(modes)))
+    if isinstance(modes, list):
+        is3d = modes[0].is3d()
+        n_atoms = modes[0].numAtoms()
+    else:
+        is3d = modes.is3d()
+        n_atoms = modes.numAtoms()
+
     if isinstance(modes, Vector):
         if is3d:
             return (modes._getArrayNx3()**2).sum(axis=1)
         else:
             return (modes._getArray() ** 2)
     else:
-        sq_flucts = np.zeros(modes.numAtoms())
+        sq_flucts = np.zeros(n_atoms)
         if isinstance(modes, VectorBase):
             modes = [modes]
         for mode in modes:

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -25,7 +25,7 @@ __all__ = ['calcCollectivity', 'calcCovariance', 'calcCrossCorr',
            'calcFractVariance', 'calcSqFlucts', 'calcTempFactors',
            'calcProjection', 'calcCrossProjection', 'calcPerturbResponse',
            'calcSpecDimension', 'calcPairDeformationDist', 'calcEnsembleENMs', 
-           'calcSignatureProfile', 'calcOverlapTree']
+           'getSignatureProfile', 'calcOverlapTree']
            #'calcEntropyTransfer', 'calcOverallNetEntropyTransfer']
 
 def calcCollectivity(mode, masses=None):
@@ -642,7 +642,7 @@ def calcOverlapTree(ensemble, method='nj', **kwargs):
 
     return tree, enms, dist_mat
 
-def calcSignatureProfile(ensemble, index, **kwargs):
+def getSignatureProfile(ensemble, index, **kwargs):
     """Description"""
 
     enms = _checkEnsembleType(ensemble, **kwargs)
@@ -673,5 +673,5 @@ def calcSignatureProfile(ensemble, index, **kwargs):
     meanV = V.mean(axis=1)
     stdV = V.std(axis=1)
 
-    return meanV, stdV, V
+    return V, (meanV, stdV)
     

--- a/prody/dynamics/compare.py
+++ b/prody/dynamics/compare.py
@@ -12,7 +12,7 @@ from .mode import Mode, Vector
 from .gnm import ZERO
 
 __all__ = ['calcOverlap', 'calcCumulOverlap', 'calcSubspaceOverlap',
-           'calcCovOverlap', 'printOverlapTable', 'writeOverlapTable',
+           'calcSpectralOverlap', 'calcCovOverlap', 'printOverlapTable', 'writeOverlapTable',
            'pairModes', 'matchModes']
 
 
@@ -159,7 +159,7 @@ def calcSubspaceOverlap(modes1, modes2):
     return rmsip
 
 
-def calcCovOverlap(modes1, modes2):
+def calcSpectralOverlap(modes1, modes2):
     """Returns overlap between covariances of *modes1* and *modes2*.  Overlap
     between covariances are calculated using normal modes (eigenvectors),
     hence modes in both models must have been calculated.  This function
@@ -185,6 +185,8 @@ def calcCovOverlap(modes1, modes2):
     else:
         diff = diff ** 0.5
     return 1 - diff / np.sqrt(varA.sum() + varB.sum())
+
+calcCovOverlap = calcSpectralOverlap
 
 def pairModes(modes1, modes2):
     """Returns the optimal matches between *modes1* and *modes2*. *modes1* 

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -33,7 +33,8 @@ __all__ = ['showContactMap', 'showCrossCorr',
            'showDiffMatrix','showMechStiff','showNormDistFunct',
            'showPairDeformationDist','showMeanMechStiff', 
            'showPerturbResponse', 'showPerturbResponseProfiles',
-           'showMatrix', 'showPlot', 'showTree', 'showTree_networkx']
+           'showMatrix', 'showPlot', 'showTree', 'showTree_networkx',
+           'showSignatureProfile']
 
 
 def showEllipsoid(modes, onto=None, n_std=2, scale=1., *args, **kwargs):
@@ -1778,3 +1779,32 @@ def showTree_networkx(tree, node_size=20, node_color='red', withlabels=True, sca
         showFigure()
 
     return mpl.gca()
+
+def showSignatureProfile(ensemble, index, linespec='-', **kwargs):
+    """Description"""
+
+    from matplotlib.pyplot import figure, plot, fill_between, gca
+    from .analysis import getSignatureProfile
+
+    V, (meanV, stdV) = getSignatureProfile(ensemble, index, **kwargs)
+    minV = V.min(axis=1)
+    maxV = V.max(axis=1)
+
+    x = range(meanV.shape[0])
+
+    new_fig = kwargs.pop('new_fig', True)
+
+    if new_fig:
+        figure()
+    line = plot(x, meanV, linespec)[0]
+    color = line.get_color()
+    fill_between(x, minV, maxV,
+                alpha=0.3, facecolor=color,
+                linewidth=1, antialiased=True)
+    fill_between(x, meanV-stdV, meanV+stdV,
+                alpha=0.5, facecolor=color,
+                linewidth=1, antialiased=True)
+    
+    if SETTINGS['auto_show']:
+        showFigure()
+    return gca()

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -1746,7 +1746,7 @@ def showTree_networkx(tree, node_size=20, node_color='red', withlabels=True, sca
 
     for node in G.nodes():
         lbl = node.name
-        if 'Inner' in lbl:
+        if lbl is None:
             lbl = ''
             colors.append('black')
             sizes.append(0)

--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -112,8 +112,6 @@ class Ensemble(object):
         ensemble.addCoordset(self._confs.copy())
         ensemble.addCoordset(other.getCoordsets())
 
-        if self._enms is None and other._enms is None:
-            ensemble._enms = None
         if self._weights is not None:
             LOGGER.info('Atom weights from {0} are used in {1}.'
                         .format(repr(self._title), repr(ensemble.getTitle())))

--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -600,7 +600,12 @@ class Ensemble(object):
     def getRMSDs(self, pairwise=False):
         """Returns root mean square deviations (RMSDs) for selected atoms.
         Conformations can be aligned using one of :meth:`superpose` or
-        :meth:`iterpose` methods prior to RMSD calculation."""
+        :meth:`iterpose` methods prior to RMSD calculation.
+        
+        :arg pairwise: if ``True`` then it will return pairwise RMSDs 
+        as an n-by-n matrix. n is the number of conformations.
+        :type pairwise: bool
+        """
 
         if self._confs is None or self._coords is None:
             return None

--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -111,6 +111,9 @@ class Ensemble(object):
         ensemble.setCoords(self._coords.copy())
         ensemble.addCoordset(self._confs.copy())
         ensemble.addCoordset(other.getCoordsets())
+
+        if self._enms is None and other._enms is None:
+            ensemble._enms = None
         if self._weights is not None:
             LOGGER.info('Atom weights from {0} are used in {1}.'
                         .format(repr(self._title), repr(ensemble.getTitle())))

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -324,7 +324,7 @@ def alignPDBEnsemble(ensemble, suffix='_aligned', outdir='.', gzip=False):
     else:
         return output
 
-def calcTree(ensemble, distance_matrix):
+def calcTree(ensemble, distance_matrix, method='nj'):
     """ Given a distance matrix for an ensemble, it creates an returns a tree structure.
     :arg ensemble: an ensemble with labels. 
     :type ensemble: prody.ensemble.Ensemble or prody.ensemble.PDBEnsemble
@@ -342,7 +342,7 @@ def calcTree(ensemble, distance_matrix):
     names = ensemble.getLabels()
     if len(names) != distance_matrix.shape[0] or len(names) != distance_matrix.shape[1]:
         raise ValueError("The size of matrix and ensemble has a mismatch.")
-        return None
+        
     matrix = []
     k = 1
     for row in distance_matrix:
@@ -351,7 +351,15 @@ def calcTree(ensemble, distance_matrix):
     from Bio.Phylo.TreeConstruction import _DistanceMatrix
     dm = _DistanceMatrix(names, matrix)
     constructor = Phylo.TreeConstruction.DistanceTreeConstructor()
-    tree = constructor.nj(dm)
+
+    method = method.strip().lower()
+    if method == 'nj':
+        tree = constructor.nj(dm)
+    elif method == 'upgma':
+        tree = constructor.upgma(dm)
+    else:
+        raise ValueError('Method can be only either "nj" or "upgma".')
+
     for node in tree.get_nonterminals():
         node.name = None
     return tree

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -326,7 +326,12 @@ class PDBEnsemble(Ensemble):
     def getRMSDs(self, pairwise=False):
         """Calculate and return root mean square deviations (RMSDs). Note that
         you might need to align the conformations using :meth:`superpose` or
-        :meth:`iterpose` before calculating RMSDs."""
+        :meth:`iterpose` before calculating RMSDs.
+
+        :arg pairwise: if ``True`` then it will return pairwise RMSDs 
+        as an n-by-n matrix. n is the number of conformations.
+        :type pairwise: bool
+        """
 
         if self._confs is None or self._coords is None:
             return None

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -323,7 +323,7 @@ class PDBEnsemble(Ensemble):
             ssqf += ((conf - mean) * weights[i]) ** 2
         return ssqf.sum(1) / weightsum.flatten()
 
-    def getRMSDs(self):
+    def getRMSDs(self, pairwise=False):
         """Calculate and return root mean square deviations (RMSDs). Note that
         you might need to align the conformations using :meth:`superpose` or
         :meth:`iterpose` before calculating RMSDs."""
@@ -333,10 +333,20 @@ class PDBEnsemble(Ensemble):
 
         indices = self._indices
         if indices is None:
-            return getRMSD(self._coords, self._confs, self._weights)
+            indices = np.arange(self._confs.shape[1])
+        
+        weights = self._weights[:, indices] if self._weights is not None else None
+
+        if pairwise:
+            n_confs = self.numConfs()
+            RMSDs = np.zeros((n_confs, n_confs))
+            for i in range(n_confs):
+                for j in range(n_confs):
+                    RMSDs[i, j] = getRMSD(self._confs[i, indices], self._confs[j, indices], weights)
         else:
-            return getRMSD(self._coords[indices], self._confs[:, indices],
-                           self._weights[:, indices])
+            RMSDs = getRMSD(self._coords[indices], self._confs[:, indices], weights)
+
+        return RMSDs
 
     def setWeights(self, weights):
         """Set atomic weights."""

--- a/prody/measure/transform.py
+++ b/prody/measure/transform.py
@@ -419,13 +419,13 @@ def getRMSD(ref, tar, weights=None):
     else:
         if tar.ndim == 2:
             return np.sqrt((((ref-tar) ** 2) * weights).sum() *
-                           (1 / weights.sum()))
+                           (1. / weights.sum()))
         else:
             rmsd = np.zeros(len(tar))
             if weights.ndim == 2:
                 for i, t in enumerate(tar):
                     rmsd[i] = (((ref-t) ** 2) * weights).sum()
-                return np.sqrt(rmsd * (1 / weights.sum()))
+                return np.sqrt(rmsd * (1. / weights.sum()))
             else:
                 for i, t in enumerate(tar):
                     rmsd[i] = (((ref-t) ** 2) * weights[i]).sum()


### PR DESCRIPTION
- **added calcEnsembleENMs.**
- **added calcSignatureProfile and showSignatureProfile.**
- renamed calcCovOverlap to calcSpectralOverlap and also kept the old name.
- **redesigned calcOverlapTree.** The function is separated into two parts, first, calcSpectralDistances is used to obtain the distance matrix, and then calcTree, which is an original function of prody, is used to obtain the tree.
- added an argument 'method' to calcTree, so that the tree can be built by either Neighour Joining or UPGMA.
- now Ensemble.getRMSDs has an option to obtain them pairwisely.
- a small bug fixed in getRMSDs where it could result zero output.