### PR TITLE
parsePDB accepts multiple PDB identifiers as input

### DIFF
--- a/prody/dynamics/compare.py
+++ b/prody/dynamics/compare.py
@@ -208,7 +208,7 @@ def pairModes(modes1, modes2, index=False):
     row_ind, col_ind = linear_sum_assignment(costs)
 
     if index:
-        return zip(row_ind, col_ind)
+        return np.array(zip(row_ind, col_ind))
 
     mode_pairs = []
     for i in range(len(row_ind)):

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -79,7 +79,32 @@ _parsePDBdoc = _parsePQRdoc + """
 
 _PDBSubsets = {'ca': 'ca', 'calpha': 'ca', 'bb': 'bb', 'backbone': 'bb'}
 
-def parsePDB(pdb, **kwargs):
+def parsePDB(*pdb, **kwargs):
+    n_pdb = len(pdb)
+    if n_pdb == 1:
+        return _parsePDB(pdb[0], **kwargs)
+    else:
+        results = []
+
+        argnames = ['model', 'header', 'chain', 'subset', 'altloc']
+        defaults = [None, False, None, None, 'A']
+
+        lstkwargs = {}
+        for name, default in zip(argnames, defaults):
+            argval = kwargs.pop(name, default)
+            if np.isscalar(argval):
+                argval = [argval]*n_pdb
+            lstkwargs[name] = argval
+
+        for i, p in enumerate(pdb):
+            for name in argnames:
+                kwargs[name] = lstkwargs[name][i]
+            result = _parsePDB(p, **kwargs)
+            results.append(result)
+        return results
+
+
+def _parsePDB(pdb, **kwargs):
     """Returns an :class:`.AtomGroup` and/or dictionary containing header data
     parsed from a PDB file.
 


### PR DESCRIPTION
Now parsePDB accepts multiple PDB identifiers as input. The PDB identifier can contain chain identifier at the end. For example:

prot = parsePDB('1p38:A')
prots = parsePDB('1p38', '3tt1', chain='A')
prots = parsePDB('1p38', '3tt1', chain=['A', 'B'])
prots = parsePDB('1p38A', '3tt1B')
prots = parsePDB('1p38:A', '3tt1:B')
