### PR TITLE
change to buildPDBEnsemble to take predefined alignments as input

### DIFF
--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -375,7 +375,7 @@ def buildPDBEnsemble(refpdb, PDBs, title='Unknown', labels=None, seqid=94, cover
 
     # obtain the hierarhical view of the reference PDB
     refhv = refpdb.getHierView()
-    refchains = refhv.iterChains()
+    refchains = list(refhv)
 
     # obtain the atommap of all the chains combined.
     atoms = refchains[0]

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -17,7 +17,8 @@ if PY2K:
     range = xrange
 
 __all__ = ['matchChains', 'matchAlign', 'mapOntoChain',
-           'mapChainByChain', 'getMatchScore', 'setMatchScore',
+           'mapChainByChain', 'mapOntoChainByAlignment', 
+           'getMatchScore', 'setMatchScore',
            'getMismatchScore', 'setMismatchScore',
            'getGapPenalty', 'setGapPenalty',
            'getGapExtPenalty', 'setGapExtPenalty',


### PR DESCRIPTION
- Added a mapping function: mapOntoChainByAlignment
- In buildPDBEnsemble, when mapping the chains to the reference, an additional iteration number `index` will be given to `mapping_func`.

Ideally, the alignment should work like this:
```
alignments = [...] # define your alignment duplets
ens = buildPDBEnsemble(ref, PDBs, alignments=alignments, mapping_func=mapOntoChainByAlignment)
```
This should work but I don't have alignments to test on, so please let me know if it doesn't work.