### PR TITLE
Changes related to building dimers

### DIFF
--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -8,7 +8,6 @@ from prody.proteins import fetchPDB, parsePDB, writePDB, mapOntoChain
 from prody.utilities import openFile, showFigure, copy
 from prody import LOGGER, SETTINGS
 from prody.atomic import AtomMap, Chain, AtomGroup, Selection, Segment, Select, AtomSubset
-from prody.sequence import MSA
 
 from .ensemble import *
 from .pdbensemble import *
@@ -365,10 +364,6 @@ def buildPDBEnsemble(refpdb, PDBs, title='Unknown', labels=None, seqid=94, cover
     :arg unmapped: A list of PDB IDs that cannot be included in the ensemble. This is an 
         output argument. 
     :type unmapped: list
-
-    :arg msa: A multiple sequence alignment that can be converted into
-        alignments for mapOntoChainByAlignment
-    :type msa: `:class:MSA`
     """
 
     if not isinstance(refpdb, (Chain, Segment, Selection, AtomGroup)):
@@ -377,18 +372,6 @@ def buildPDBEnsemble(refpdb, PDBs, title='Unknown', labels=None, seqid=94, cover
     if labels is not None:
         if len(labels) != len(PDBs):
             raise ValueError('labels and PDBs must be the same length.')
-
-    msa = kwargs.get('msa', None)
-    if msa is not None:
-        if len(msa) != len(PDBs):
-            raise ValueError('msa and PDBs must be the same length.')
-
-        alignments = []
-        refseq = msa[msa.getIndex(refpdb.getTitle())]
-        for sequence in msa:
-            alignments.append([str(refseq), str(sequence)])
-
-        kwargs['alignments'] = alignments
 
     # obtain refchains from the hierarhical view of the reference PDB
     refchains = list(refpdb.getHierView())

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -809,6 +809,9 @@ def mapOntoChain(atoms, chain, **kwargs):
         coverage = kwargs.get('coverage', 70.)
     pwalign = kwargs.get('pwalign', True)
     fast = kwargs.get('fast', False)
+    alignment  = kwargs.pop('alignment', None)
+    alignments = kwargs.pop('alignments', None)
+    prealigned = alignment is not None or alignments is not None
 
     if isinstance(atoms, Chain):
         chains = [atoms]
@@ -831,13 +834,12 @@ def mapOntoChain(atoms, chain, **kwargs):
     unmapped = []
     unmapped_chids = []
     target_ag = target_chain.getAtomGroup()
-    simple_target = SimpleChain(target_chain, True)
+    simple_target = SimpleChain(target_chain, False)
     if fast is False:
         LOGGER.debug('Trying to map atoms based on residue numbers and '
                  'identities:')
     for chain in chains:
-        simple_chain = SimpleChain(True)
-        simple_chain.buildFromChain(chain)
+        simple_chain = SimpleChain(chain, False)
         if len(simple_chain) == 0:
             if fast is False:
                 LOGGER.debug('  Skipping {0}, which does not contain any amino '
@@ -848,33 +850,29 @@ def mapOntoChain(atoms, chain, **kwargs):
                      .format(simple_chain.getTitle(), len(simple_chain),
                              simple_target.getTitle()))
 
-        target_list, chain_list, n_match, n_mapped = getTrivialMapping(
-            simple_target, simple_chain)
-        if n_mapped > 0:
-            _seqid = n_match * 100 / n_mapped
-            _cover = n_mapped * 100 / max(len(simple_target), len(simple_chain))
-        else:
-            _seqid = 0
-            _cover = 0
+        _seqid = _cover = -1
+        if not prealigned:
+            target_list, chain_list, n_match, n_mapped = getTrivialMapping(
+                simple_target, simple_chain)
+            if n_mapped > 0:
+                _seqid = n_match * 100 / n_mapped
+                _cover = n_mapped * 100 / max(len(simple_target), len(simple_chain))
 
-        if _seqid >= seqid and _cover >= coverage:
+        if (_seqid >= seqid and _cover >= coverage) and not prealigned:
             if fast is False:
                 LOGGER.debug('\tMapped: {0} residues match with {1:.0f}% '
-                         'sequence identity and {2:.0f}% overlap.'
-                         .format(n_mapped, _seqid, _cover))
+                        'sequence identity and {2:.0f}% overlap.'
+                        .format(n_mapped, _seqid, _cover))
             mappings.append((target_list, chain_list, _seqid, _cover))
         else:
             if fast is False:
                 LOGGER.debug('\tFailed to match chains based on residue numbers '
-                         '(seqid={0:.0f}%, overlap={1:.0f}%).'
-                         .format(_seqid, _cover))
+                        '(seqid={0:.0f}%, overlap={1:.0f}%).'
+                        .format(_seqid, _cover))
             unmapped.append(simple_chain)
             unmapped_chids.append(chain.getChid())
 
     if pwalign or (not mappings and pwalign):
-        alignment  = kwargs.pop('alignment', None)
-        alignments = kwargs.pop('alignments', None)
-
         if not(alignment is None and alignments is None):
             LOGGER.debug('Predefined alignments are provided.')
         LOGGER.debug('Trying to map atoms based on {0} sequence alignment:'
@@ -884,11 +882,10 @@ def mapOntoChain(atoms, chain, **kwargs):
             LOGGER.debug('  Comparing {0} (len={1}) with {2}:'
                          .format(simple_chain.getTitle(), len(simple_chain),
                                  simple_target.getTitle()))
+            curr_alignment = alignment
             if alignments is not None:
                 if chid in alignments:
                     curr_alignment = alignments[chid]
-                else:
-                    curr_alignment = alignment
                     
             result = getAlignedMapping(simple_target, simple_chain, alignment=curr_alignment)
             if result is not None:
@@ -1030,6 +1027,17 @@ def getAlignedMapping(target, chain, alignment=None):
 
     this = str(alignment[0])
     that = str(alignment[1])
+    this_seq = this.upper()
+    for gap in GAPCHARS:
+        this_seq = this_seq.replace(gap, '')
+    that_seq = that.upper()
+    for gap in GAPCHARS:
+        that_seq = that_seq.replace(gap, '')
+
+    if target.getSequence().upper() != this_seq:
+        return None
+    if chain.getSequence().upper() != that_seq:
+        return None
 
     amatch = []
     bmatch = []

--- a/prody/sequence/msa.py
+++ b/prody/sequence/msa.py
@@ -46,6 +46,9 @@ class MSA(object):
             raise ValueError('len(labels) must be equal to number of '
                              'sequences')
         self._labels = labels
+        if labels is None:
+            self._labels = [str(i+1) for i in range(numseq)]
+        
         mapping = kwargs.get('mapping')
         if mapping is None:
             if labels is not None:
@@ -71,9 +74,6 @@ class MSA(object):
             except Exception:
                 raise TypeError('mapping must be a dictionary')
         self._mapping = mapping
-        if labels is None:
-            self._labels = [None] * numseq
-
         self._msa = msa
         self._title = str(title) or 'Unknown'
         self._split = bool(kwargs.get('split', True))

--- a/prody/utilities/pathtools.py
+++ b/prody/utilities/pathtools.py
@@ -332,9 +332,13 @@ def which(program):
     http://stackoverflow.com/questions/377017/"""
 
     fpath, fname = os.path.split(program)
+    fname, fext = os.path.splitext(fname)
+
     if fpath and isExecutable(program):
         return program
     else:
+        if os.name == 'nt' and fext == '':
+            program += '.exe'
         for path in os.environ["PATH"].split(os.pathsep):
             path = os.path.join(path, program)
             if isExecutable(path):


### PR DESCRIPTION
- Allowed mapOntoChainByAlignment to take MSA input ("msa" is then removed).
- Fixed a bug in mapOntoChain when building based on predefined alignments.
- Fixed Windows related issues when running external programs, such as ClustalW2.
- Changed "prefix" to "title", and moved "title" and "labels" to optional arguments from kwargs because of their importance.
- Now buildMSA and alignSequencesByChain do not take PDB identifiers as input because of the dependency issues of parsePDB. Besides, parsePDB can take multiple inputs now so for users it is just one line of code.