### PR TITLE
Small changes

### DIFF
--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -561,11 +561,11 @@ def showSignature(signature, linespec='-', **kwargs):
     x, _ = line.get_data()
     polys = []
     poly = fill_between(x, minV, maxV,
-                        alpha=0.3, facecolor=color,
+                        alpha=0.3, facecolor=color, edgecolor=color,
                         linewidth=1, antialiased=True)
     polys.append(poly)
     poly = fill_between(x, meanV-stdV, meanV+stdV,
-                        alpha=0.5, facecolor=color,
+                        alpha=0.5, facecolor=color, edgecolor=color,
                         linewidth=1, antialiased=True)
     polys.append(poly)
 
@@ -803,7 +803,7 @@ def showVarianceBar(mode_ensemble, highlights=None, **kwargs):
                       orientation='horizontal')
 
     if not highlights:
-        highlights = range(len(mode_ensemble))
+        highlights = []
 
     indices = []; labels = []
     ens_labels = mode_ensemble.getLabels()

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -388,7 +388,13 @@ def buildPDBEnsemble(refpdb, PDBs, title='Unknown', labels=None, seqid=94, cover
     
     # build the ensemble
     if unmapped is None: unmapped = []
+
+    verb = LOGGER.verbosity
+    LOGGER.verbosity = 'info'
+
+    LOGGER.progress('Building the ensemble...', len(PDBs))
     for i, pdb in enumerate(PDBs):
+        LOGGER.update(i, 'Mapping %s to the reference...'%pdb)
         try:
             pdb.getHierView()
         except AttributeError:
@@ -424,6 +430,9 @@ def buildPDBEnsemble(refpdb, PDBs, title='Unknown', labels=None, seqid=94, cover
         # add the mappings to the ensemble
         ensemble.addCoordset(atommap, weights=atommap.getFlags('mapped'), label = lbl)
     
+    LOGGER.update(len(PDBs), 'Finished.')
+    LOGGER.verbosity = verb
+
     if occupancy is not None:
         ensemble = trimPDBEnsemble(ensemble, occupancy=occupancy)
     ensemble.iterpose()

--- a/prody/utilities/catchall.py
+++ b/prody/utilities/catchall.py
@@ -163,7 +163,7 @@ def showData(*args, **kwargs):
                 x_new, y_new = x, y
 
             poly = ax.fill_between(x_new, y_new-_dy, y_new+_dy,
-                                   alpha=alpha, facecolor=color,
+                                   alpha=alpha, facecolor=color, edgecolor=color,
                                    linewidth=1, antialiased=True)
             polys.append(poly)
 


### PR DESCRIPTION
- now `mapOntoChain` will be forced to use pairwise alignment if `pwalign` is set to `True`. The default behavior is used by setting `pwalign` to `None`.
- `fast` option is removed from `mapOntoChain` as it will be handled by the logger's verbosity.
- showVarianceBar now shows no highlights by default.