### PR TITLE
Improved ensemble selection

### DIFF
--- a/prody/atomic/atomic.py
+++ b/prody/atomic/atomic.py
@@ -224,6 +224,7 @@ class Atomic(object):
         return new
 
     __copy__ = copy
+    toAtomGroup = copy
 
     def select(self, selstr, **kwargs):
         """Returns atoms matching *selstr* criteria.  See :mod:`~.select` module

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -512,9 +512,9 @@ def calcEnsembleENMs(ensemble, model='gnm', trim='trim', n_modes=20, **kwargs):
 
     atoms = ensemble.getAtoms()
     select = None
-    if ensemble._indices is not None:
+    if ensemble.isSelected():
         select = atoms
-        atoms = atoms.getAtomGroup()
+        atoms = ensemble.getAtoms(selected=False)
         
     labels = ensemble.getLabels()
 
@@ -531,11 +531,11 @@ def calcEnsembleENMs(ensemble, model='gnm', trim='trim', n_modes=20, **kwargs):
 
     for i in range(n_confs):
         coords = ensemble.getCoordsets(i, selected=False)
+        nodes = coords[0, :, :]
         if atoms is not None:
-            atoms.setCoords(coords)
-        else:
-            atoms = coords
-        enm, _ = calcENM(atoms, select, model=model, trim=trim, 
+            atoms.setCoords(nodes)
+            nodes = atoms
+        enm, _ = calcENM(nodes, select, model=model, trim=trim, 
                             n_modes=n_modes, title=labels[i], **kwargs)
         enms.append(enm)
 

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -58,7 +58,8 @@ class PDBEnsemble(Ensemble):
         
         other_weights = copy(other._weights)
         ensemble.addCoordset(copy(other._confs), other_weights)
-        ensemble.setAtoms(self.getAtoms())
+        ensemble.setAtoms(self._atoms)
+        ensemble._indices = self._indices
         return ensemble
 
     def __iter__(self):
@@ -85,7 +86,8 @@ class PDBEnsemble(Ensemble):
                             label=self._labels[index])
             if self._trans is not None:
                 ens._trans = self._trans[index]
-            ens.setAtoms(self.getAtoms())
+            ens.setAtoms(self._atoms)
+            ens._indices = self._indices
             return ens
 
         elif isinstance(index, (list, np.ndarray)):
@@ -96,6 +98,8 @@ class PDBEnsemble(Ensemble):
                             label=[self._labels[i] for i in index])
             if self._trans is not None:
                 ens._trans = self._trans[index]
+            ens.setAtoms(self._atoms)
+            ens._indices = self._indices
             return ens
         else:
             raise IndexError('invalid index')

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -156,6 +156,8 @@ class PDBEnsemble(Ensemble):
         list of identifiers, is used to label conformations."""
 
         atoms = coords
+        n_atoms = self.numAtoms()
+        n_select = self.numSelected()
         try:
             if self._coords is not None:
                 if isinstance(coords, Ensemble):
@@ -184,18 +186,29 @@ class PDBEnsemble(Ensemble):
             else:
                 label = label or str(coords)
         try:
-            checkCoords(coords, csets=True, natoms=self._n_atoms)
-        except TypeError:
-            raise TypeError('coords must be a Numpy array or must have '
-                            '`getCoords` attribute')
+            checkCoords(coords, csets=True, natoms=n_atoms)
+        except:
+            try:
+                checkCoords(coords, csets=True, natoms=n_select)
+            except TypeError:
+                raise TypeError('coords must be a numpy array or an object '
+                                'with `getCoords` method')
 
         if coords.ndim == 2:
-            coords = coords.reshape((1, self._n_atoms, 3))
+            n_nodes, _ = coords.shape
+            coords = coords.reshape((1, n_nodes, 3))
+            n_csets = 1
+        else:
+            n_csets, n_nodes, _ = coords.shape
 
-        n_csets, n_atoms, _ = coords.shape
-        if not self._n_atoms:
-            self._n_atoms = n_atoms
+        if not n_atoms:
+            self._n_atoms = n_nodes
 
+        if n_nodes == n_select and self.isSelected():
+            full_coords = np.repeat(self._coords[np.newaxis, :, :], n_csets, axis=0)
+            full_coords[:, self._indices, :] = coords
+            coords = full_coords
+        
         if weights is None:
             weights = np.ones((n_csets, n_atoms, 1), dtype=float)
         else:

--- a/prody/tests/ensemble/test_ensemble.py
+++ b/prody/tests/ensemble/test_ensemble.py
@@ -201,7 +201,7 @@ class TestEnsemble(TestCase):
 
         anti_sel = ATOMS.select('not resnum 1 to 3')
         ensemble.setAtoms(anti_sel)
-        new_conf = ensemble.getCoordset()[-1]
+        new_conf = ensemble.getCoordsets()[-1]
         coords = ensemble.getCoords()
         assert_allclose(new_conf, coords,
                         rtol=0, atol=1e-3,

--- a/prody/tests/ensemble/test_ensemble.py
+++ b/prody/tests/ensemble/test_ensemble.py
@@ -193,6 +193,22 @@ class TestEnsemble(TestCase):
         assert_equal(ENSEMBLE.getCoordsets(), sel.getCoordsets(),
                      'selection failed')
 
+        ensemble = ENSEMBLE + ENSEMBLE
+        assert_equal(ensemble._indices, ENSEMBLE._indices,
+                     'concatenation failed for Ensemble after selection')
+
+        ensemble.addCoordset(sel.getCoords())
+
+        anti_sel = ATOMS.select('not resnum 1 to 3')
+        ensemble.setAtoms(anti_sel)
+        new_conf = ensemble.getCoordset()[-1]
+        coords = ensemble.getCoords()
+        assert_allclose(new_conf, coords,
+                        rtol=0, atol=1e-3,
+                        err_msg='failed at addCoordset for Ensemble after selection')
+
         ENSEMBLE.setAtoms(ATOMS)
         assert_equal(ENSEMBLE.getCoordsets(), ATOMS.getCoordsets(),
                      'restoration failed')
+
+        


### PR DESCRIPTION
- Ensemble selection should be more robust. There could be further improvements making ensemble selection easier to understand and operate.
- Now Ensemble.addCoordset can add coordsets having the length of selected atoms. The rest will be assumed to be the reference coordinate.
- `Atomic` classes now have an extra function called `toAtomGroup` which functions exactly the same as `copy`.
