### PR TITLE
Added tests for PDBEnsemble associated MSA

### DIFF
--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -125,8 +125,15 @@ class Ensemble(object):
             LOGGER.info('Atom weights from {0} are used in {1}.'
                         .format(repr(self._title), repr(ensemble.getTitle())))
             ensemble.setWeights(self._weights)
-        ensemble.setAtoms(self._atoms)
-        ensemble._indices = self._indices
+        elif other._weights is not None:
+            ensemble.setWeights(other._weights)
+        
+        if self._atoms is not None:
+            ensemble.setAtoms(self._atoms)
+            ensemble._indices = self._indices
+        else:
+            ensemble.setAtoms(other._atoms)
+            ensemble._indices = other._indices
         return ensemble
 
     def __iter__(self):

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -62,8 +62,13 @@ class PDBEnsemble(Ensemble):
         other_weights = copy(other._weights)
         ensemble.addCoordset(copy(other._confs), weights=other_weights, 
                              label=other.getLabels(), sequence=other._msa)
-        ensemble.setAtoms(self._atoms)
-        ensemble._indices = self._indices
+
+        if self._atoms is not None:
+            ensemble.setAtoms(self._atoms)
+            ensemble._indices = self._indices
+        else:
+            ensemble.setAtoms(other._atoms)
+            ensemble._indices = other._indices
         return ensemble
 
     def __iter__(self):

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -305,7 +305,7 @@ class PDBEnsemble(Ensemble):
             msa = MSA(seqs, title=self.getTitle(), labels=labels)
             if self._msa is None:
                 if n_confs > 0:
-                    def_seqs = np.zeros((n_confs, n_atoms), dtype='|S1')
+                    def_seqs = np.chararray((n_confs, n_atoms))
                     def_seqs[:] = 'X'
 
                     old_labels = [self._labels[i] for i in range(n_confs)]

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -171,16 +171,28 @@ class PDBEnsemble(Ensemble):
         n_atoms = self.numAtoms()
         n_select = self.numSelected()
         try:
-            if self._coords is not None:
-                if isinstance(coords, Ensemble):
-                    coords = coords._getCoordsets(selected=False)
-                elif hasattr(coords, '_getCoordsets'):
-                    coords = coords._getCoordsets()
+            if degeneracy:
+                if self._coords is not None:
+                    if isinstance(coords, Ensemble):
+                        coords = coords._getCoords(selected=False)
+                    elif hasattr(coords, '_getCoords'):
+                        coords = coords._getCoords()
+                else:
+                    if isinstance(coords, Ensemble):
+                        coords = coords.getCoords(selected=False)
+                    elif hasattr(coords, 'getCoords'):
+                        coords = coords.getCoords()
             else:
-                if isinstance(coords, Ensemble):
-                    coords = coords.getCoordsets(selected=False)
-                elif hasattr(coords, 'getCoordsets'):
-                    coords = coords.getCoordsets()
+                if self._coords is not None:
+                    if isinstance(coords, Ensemble):
+                        coords = coords._getCoordsets(selected=False)
+                    elif hasattr(coords, '_getCoordsets'):
+                        coords = coords._getCoordsets()
+                else:
+                    if isinstance(coords, Ensemble):
+                        coords = coords.getCoordsets(selected=False)
+                    elif hasattr(coords, 'getCoordsets'):
+                        coords = coords.getCoordsets()
 
         except AttributeError:
             label = label or 'Unknown'
@@ -214,7 +226,12 @@ class PDBEnsemble(Ensemble):
             n_csets = 1
         else:
             n_csets, n_nodes, _ = coords.shape
+            if degeneracy:
+                coords = coords[:1]
+                weights = weights[:1]
 
+        n_repeats = 1 if degeneracy else n_csets
+       
         if not n_atoms:
             self._n_atoms = n_nodes
 
@@ -232,7 +249,6 @@ class PDBEnsemble(Ensemble):
         # check sequences
         seqs = None
         sequence = kwargs.pop('sequence', None)
-        n_repeats = 1 if degeneracy else n_csets
         if hasattr(atoms, 'getSequence'):
             if sequence is not None:
                 LOGGER.warn('sequence is supplied though coords has getSequence')
@@ -270,8 +286,6 @@ class PDBEnsemble(Ensemble):
                     labels = label
             else:
                 labels = [label]
-                coords = np.reshape(coords[0],(1,coords[0].shape[0],coords[0].shape[1]))
-                weights = np.reshape(weights[0],(1,weights[0].shape[0],weights[0].shape[1]))
         else:
             labels = [label]
         self._labels.extend(labels)

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -305,7 +305,7 @@ class PDBEnsemble(Ensemble):
             msa = MSA(seqs, title=self.getTitle(), labels=labels)
             if self._msa is None:
                 if n_confs > 0:
-                    def_seqs = np.zeros((n_confs, n_atoms), dtype='|S')
+                    def_seqs = np.zeros((n_confs, n_atoms), dtype='|S1')
                     def_seqs[:] = 'X'
 
                     old_labels = [self._labels[i] for i in range(n_confs)]

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -228,7 +228,6 @@ class PDBEnsemble(Ensemble):
             n_csets, n_nodes, _ = coords.shape
             if degeneracy:
                 coords = coords[:1]
-                weights = weights[:1]
 
         n_repeats = 1 if degeneracy else n_csets
        
@@ -245,6 +244,9 @@ class PDBEnsemble(Ensemble):
             weights = np.ones((n_csets, n_atoms, 1), dtype=float)
         else:
             weights = checkWeights(weights, n_atoms, n_csets)
+
+        if degeneracy:
+            weights = weights[:1]
 
         # check sequences
         seqs = None

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -311,6 +311,7 @@ class PDBEnsemble(Ensemble):
                     old_labels = [self._labels[i] for i in range(n_confs)]
                     self._msa = MSA(def_seqs, title=self.getTitle(), labels=old_labels)
                     self._msa += msa
+                    self._msa.setTitle(self.getTitle())
                 else:
                     self._msa = msa
             else:

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -213,7 +213,7 @@ class PDBEnsemble(Ensemble):
                     ag = atoms.getAtomGroup()
                 label = ag.getTitle()
                 if coords.shape[0] < ag.numCoordsets():
-                    label += 'm' + str(atoms.getACSIndex())
+                    label += '_m' + str(atoms.getACSIndex())
             else:
                 label = label or 'Unknown'
 

--- a/prody/sequence/analysis.py
+++ b/prody/sequence/analysis.py
@@ -901,28 +901,28 @@ def showAlignment(alignment, row_size=60, max_seqs=5, **kwargs):
         default the point when the shortest sequence stops
     :type index_stop: int
 
-    :arg labels: a list of labels, required if alignment is a list of strings
+    :arg labels: a list of labels
     :type labels: list, tuple, `~numpy.ndarray`
     """
-    labels = kwargs.get('labels', None)
-    if labels is None:
-        if not isinstance(labels, list) and not isinstance(labels, tuple) \
-        and not isinstance(labels, ndarray):
-            raise TypeError('labels should be a list or tuple.')
 
-        if not isinstance(labels[0], str):
-            raise TypeError('each label should be a string.')
+    labels = kwargs.get('labels', None)
+    if labels is not None:
+        if not isscalar(labels):
+            raise TypeError('labels should be a list of strings')
+
+        for label in labels:
+            if not isinstance(label, str):
+                raise TypeError('each label should be a string')
 
         if len(labels) < max_seqs:
-            raise ValueError('there should be a label for every sequence shown.')
-
-        if isinstance(alignment, MSA) or (isinstance(alignment[0], Sequence)):
-            labels = []
-            for sequence in alignment:
+            raise ValueError('there should be a label for every sequence shown')
+    else:
+        labels = []
+        for i, sequence in enumerate(alignment):
+            if hasattr(sequence, 'getLabel'):
                 labels.append(sequence.getLabel())
-        else:
-            if isinstance(alignment[0], str):
-                raise ValueError('labels must be provided if alignment contains strings')
+            else:
+                labels.append(str(i+1))
 
     indices = kwargs.get('indices',None)
     index_start = kwargs.get('index_start',0)

--- a/prody/sequence/msa.py
+++ b/prody/sequence/msa.py
@@ -37,7 +37,7 @@ class MSA(object):
 
         if ndim < 1:
             raise ValueError('msa.ndim should be at least 1')
-        if dtype_.char not in ['S', 'U']:
+        if dtype_.char != 'S':
             raise ValueError('msa must be a character array')
 
         self._aligned = aligned = kwargs.get('aligned', True)
@@ -122,7 +122,7 @@ class MSA(object):
 
         split = self._split or other._split
 
-        msa = MSA(AB, title='(%s) + (%s)'%(self.getTitle(), other.getTitle()), 
+        msa = MSA(AB, title='%s + %s'%(self.getTitle(), other.getTitle()), 
                   aligned=aligned, labels=labels, split=split)
         return msa
 

--- a/prody/sequence/msa.py
+++ b/prody/sequence/msa.py
@@ -2,13 +2,17 @@
 """This module defines MSA analysis functions."""
 
 from numpy import all, zeros, dtype, array, char, cumsum, ceil 
-from numpy import where, sort, concatenate, vstack, isscalar
-from .sequence import Sequence, splitSeqLabel
-from prody.atomic import Atomic
+from numpy import where, sort, concatenate, vstack, isscalar, chararray
+
 from Bio import AlignIO
 from Bio import pairwise2
 from Bio.SubsMat import MatrixInfo as matlist
+
 from prody import LOGGER
+from prody.atomic import Atomic
+from prody.utilities import chr2
+from .sequence import Sequence, splitSeqLabel
+
 import sys
 
 __all__ = ['MSA', 'refineMSA', 'mergeMSA', 'specMergeMSA',]
@@ -44,11 +48,11 @@ class MSA(object):
         if ndim != 2:
             n_seq = msa.shape[0]
             l_seq = dtype_.itemsize
-            new_msa = zeros((n_seq, l_seq), dtype='|S1')
+            new_msa = chararray((n_seq, l_seq))
             for i, strarr in enumerate(msa):
                 for j in range(l_seq):
                     if j < len(strarr):
-                        new_msa[i, j] = strarr[j]
+                        new_msa[i, j] = chr2(strarr[j])
                     else:
                         if aligned:
                             raise ValueError('msa does not the same lengths')

--- a/prody/sequence/sequence.py
+++ b/prody/sequence/sequence.py
@@ -22,6 +22,8 @@ def splitSeqLabel(label):
     from sequence label."""
 
     try:
+        if label == '':
+            raise Exception
         idcode, start, end = SPLITLABEL(label)
     except Exception:
         return label, None, None

--- a/prody/tests/ensemble/__init__.py
+++ b/prody/tests/ensemble/__init__.py
@@ -49,7 +49,6 @@ for i in range(ATOMS.numCoordsets()):
     if i > 0:
         weights[i] = 0
         weights[-i] = 0
-        PDBENSEMBLE2.addCoordset(ATOMS, weights=weights)
+        PDBENSEMBLE2.addCoordset(ATOMS, weights=weights, degeneracy=True)
     else:
         PDBENSEMBLE2.addCoordset(ATOMS)
-        

--- a/prody/tests/ensemble/__init__.py
+++ b/prody/tests/ensemble/__init__.py
@@ -51,4 +51,6 @@ for i in range(ATOMS.numCoordsets()):
         weights[-i] = 0
         PDBENSEMBLE2.addCoordset(ATOMS, weights=weights, degeneracy=True)
     else:
-        PDBENSEMBLE2.addCoordset(ATOMS)
+        PDBENSEMBLE2.addCoordset(ATOMS, degeneracy=True)
+
+ATOMS.setACSIndex(0)

--- a/prody/tests/ensemble/__init__.py
+++ b/prody/tests/ensemble/__init__.py
@@ -39,3 +39,17 @@ PDBCONF = PDBENSEMBLE[0]
 WEIGHTS = array(WEIGHTS)
 WEIGHTS_BOOL = tile(WEIGHTS.astype(bool), (1,1,3))
 WEIGHTS_BOOL_INVERSE = invert(WEIGHTS_BOOL)
+
+PDBENSEMBLE2 = PDBEnsemble('PDBEnsemble 2')
+PDBENSEMBLE2.setAtoms(ATOMS)
+PDBENSEMBLE2.setCoords(COORDS)
+for i in range(ATOMS.numCoordsets()):
+    weights = ones((len(ATOMS), 1), dtype=float)
+    ATOMS.setACSIndex(i)
+    if i > 0:
+        weights[i] = 0
+        weights[-i] = 0
+        PDBENSEMBLE2.addCoordset(ATOMS, weights=weights)
+    else:
+        PDBENSEMBLE2.addCoordset(ATOMS)
+        

--- a/prody/tests/ensemble/__init__.py
+++ b/prody/tests/ensemble/__init__.py
@@ -40,17 +40,17 @@ WEIGHTS = array(WEIGHTS)
 WEIGHTS_BOOL = tile(WEIGHTS.astype(bool), (1,1,3))
 WEIGHTS_BOOL_INVERSE = invert(WEIGHTS_BOOL)
 
-PDBENSEMBLE2 = PDBEnsemble('PDBEnsemble 2')
-PDBENSEMBLE2.setAtoms(ATOMS)
-PDBENSEMBLE2.setCoords(COORDS)
+PDBENSEMBLEA = PDBEnsemble('PDBEnsemble 2')
+PDBENSEMBLEA.setAtoms(ATOMS)
+PDBENSEMBLEA.setCoords(COORDS)
 for i in range(ATOMS.numCoordsets()):
     weights = ones((len(ATOMS), 1), dtype=float)
     ATOMS.setACSIndex(i)
     if i > 0:
         weights[i] = 0
         weights[-i] = 0
-        PDBENSEMBLE2.addCoordset(ATOMS, weights=weights, degeneracy=True)
+        PDBENSEMBLEA.addCoordset(ATOMS, weights=weights, degeneracy=True)
     else:
-        PDBENSEMBLE2.addCoordset(ATOMS, degeneracy=True)
+        PDBENSEMBLEA.addCoordset(ATOMS, degeneracy=True)
 
 ATOMS.setACSIndex(0)

--- a/prody/tests/ensemble/test_ensemble.py
+++ b/prody/tests/ensemble/test_ensemble.py
@@ -170,7 +170,7 @@ class TestEnsemble(TestCase):
                     'concatenation failed')
         assert_equal(ensemble.getCoords(), COORDS,
                      'concatenation failed')
-        self.assertIsNone(ensemble.getWeights(), 'concatenation failed')
+        assert_equal(ensemble.getWeights(), ENSEMBLEW.getWeights(), 'concatenation failed')
 
     def testConcatenationWeightsNoweights(self):
         """Test concatenation of ensembles with and without weights."""

--- a/prody/tests/ensemble/test_pdbensemble.py
+++ b/prody/tests/ensemble/test_pdbensemble.py
@@ -139,4 +139,15 @@ class TestPDBEnsemble(TestCase):
 
         assert_equal(msa, msa2, 'associated MSA concatenation failed')
 
+    def testAddCoordsets(self):
+        ensemble = PDBENSEMBLE2[:]
+        n_conf = ensemble.numCoordsets()
+        n_csets = ATOMS.numCoordsets()
 
+        ensemble.addCoordsets(ATOMS)
+        assert_equal(ensemble.numCoordsets(), n_conf+n_csets,
+                     'adding coordsets failed')
+
+        ensemble.addCoordsets(ATOMS, degeneracy=False)
+        assert_equal(ensemble.numCoordsets(), n_conf+n_csets+1,
+                     'adding coordsets failed')

--- a/prody/tests/ensemble/test_pdbensemble.py
+++ b/prody/tests/ensemble/test_pdbensemble.py
@@ -144,10 +144,10 @@ class TestPDBEnsemble(TestCase):
         n_conf = ensemble.numCoordsets()
         n_csets = ATOMS.numCoordsets()
 
-        ensemble.addCoordsets(ATOMS)
+        ensemble.addCoordset(ATOMS)
         assert_equal(ensemble.numCoordsets(), n_conf+n_csets,
                      'adding coordsets failed')
 
-        ensemble.addCoordsets(ATOMS, degeneracy=True)
+        ensemble.addCoordset(ATOMS, degeneracy=True)
         assert_equal(ensemble.numCoordsets(), n_conf+n_csets+1,
                      'adding coordsets failed')

--- a/prody/tests/ensemble/test_pdbensemble.py
+++ b/prody/tests/ensemble/test_pdbensemble.py
@@ -5,7 +5,7 @@ from prody.tests import TestCase
 from numpy import arange
 from numpy.testing import assert_equal
 
-from . import ATOMS, PDBENSEMBLE, COORDS, WEIGHTS_BOOL, ENSEMBLE, WEIGHTS
+from . import ATOMS, PDBENSEMBLE, PDBENSEMBLE2, COORDS, WEIGHTS_BOOL, ENSEMBLE, WEIGHTS
 
 class TestPDBEnsemble(TestCase):
 
@@ -13,10 +13,15 @@ class TestPDBEnsemble(TestCase):
 
         assert_equal(PDBENSEMBLE.getCoords(), COORDS,
                      'failed to set reference coordinates for PDBEnsemble')
+        assert_equal(PDBENSEMBLE2.getCoords(), COORDS,
+                     'failed to set reference coordinates for PDBEnsemble')
 
     def testGetCoordsets(self):
 
         assert_equal(PDBENSEMBLE.getCoordsets()[WEIGHTS_BOOL],
+                     ATOMS.getCoordsets()[WEIGHTS_BOOL],
+                     'failed to add coordinate sets for PDBEnsemble')
+        assert_equal(PDBENSEMBLE2.getCoordsets()[WEIGHTS_BOOL],
                      ATOMS.getCoordsets()[WEIGHTS_BOOL],
                      'failed to add coordinate sets for PDBEnsemble')
 
@@ -30,30 +35,39 @@ class TestPDBEnsemble(TestCase):
                                'wrong shape for weights of PDBEnsemble')
         assert_equal(PDBENSEMBLE.getWeights(), WEIGHTS,
                      'failed to get correct weights')
+        
+        self.assertEqual(PDBENSEMBLE2.getWeights().ndim, 3,
+                        'wrong ndim for weights of PDBEnsemble')
+        self.assertTupleEqual(PDBENSEMBLE2.getWeights().shape,
+                              (PDBENSEMBLE2.numCoordsets(),
+                               PDBENSEMBLE2.numAtoms(), 1),
+                               'wrong shape for weights of PDBEnsemble')
+        assert_equal(PDBENSEMBLE2.getWeights(), WEIGHTS,
+                     'failed to get correct weights')
 
 
     def testSlicingCopy(self):
 
-        SLICE = PDBENSEMBLE[:]
-        assert_equal(SLICE.getCoords(), PDBENSEMBLE.getCoords(),
+        SLICE = PDBENSEMBLE2[:]
+        assert_equal(SLICE.getCoords(), PDBENSEMBLE2.getCoords(),
                      'slicing copy failed to set reference coordinates')
-        assert_equal(SLICE.getCoordsets(), PDBENSEMBLE.getCoordsets(),
+        assert_equal(SLICE.getCoordsets(), PDBENSEMBLE2.getCoordsets(),
                      'slicing copy failed to add coordinate sets')
 
     def testSlicing(self):
 
-        SLICE = PDBENSEMBLE[:2]
-        assert_equal(SLICE.getCoords(), PDBENSEMBLE.getCoords(),
+        SLICE = PDBENSEMBLE2[:2]
+        assert_equal(SLICE.getCoords(), PDBENSEMBLE2.getCoords(),
                      'slicing failed to set reference coordinates')
-        assert_equal(SLICE.getCoordsets(), PDBENSEMBLE.getCoordsets([0,1]),
+        assert_equal(SLICE.getCoordsets(), PDBENSEMBLE2.getCoordsets([0,1]),
                      'slicing failed to add coordinate sets')
 
     def testSlicingList(self):
 
-        SLICE = PDBENSEMBLE[[0,2]]
-        assert_equal(SLICE.getCoords(), PDBENSEMBLE.getCoords(),
+        SLICE = PDBENSEMBLE2[[0,2]]
+        assert_equal(SLICE.getCoords(), PDBENSEMBLE2.getCoords(),
                      'slicing failed to set reference coordinates')
-        assert_equal(SLICE.getCoordsets(), PDBENSEMBLE.getCoordsets([0,2]),
+        assert_equal(SLICE.getCoordsets(), PDBENSEMBLE2.getCoordsets([0,2]),
                      'slicing failed to add coordinate sets')
 
     def testSlicingWeights(self):
@@ -82,7 +96,7 @@ class TestPDBEnsemble(TestCase):
 
     def testDelCoordsetMiddle(self):
 
-        ensemble = PDBENSEMBLE[:]
+        ensemble = PDBENSEMBLE2[:]
         ensemble.delCoordset(1)
         assert_equal(ensemble.getCoordsets()[WEIGHTS_BOOL[[0,2]]],
                      ATOMS.getCoordsets([0,2])[WEIGHTS_BOOL[[0,2]]],
@@ -91,8 +105,8 @@ class TestPDBEnsemble(TestCase):
     def testDelCoordsetAll(self):
         """Test consequences of deleting all coordinate sets."""
 
-        ensemble = PDBENSEMBLE[:]
-        ensemble.delCoordset(arange(len(PDBENSEMBLE)))
+        ensemble = PDBENSEMBLE2[:]
+        ensemble.delCoordset(arange(len(PDBENSEMBLE2)))
         self.assertIsNone(ensemble.getCoordsets(),
                         'failed to delete all coordinate sets')
         self.assertIsNone(ensemble.getWeights(), 'failed to delete weights '
@@ -104,12 +118,12 @@ class TestPDBEnsemble(TestCase):
     def testConcatenation(self):
         """Test concatenation of PDB ensembles."""
 
-        ensemble = PDBENSEMBLE + PDBENSEMBLE
+        ensemble = PDBENSEMBLE + PDBENSEMBLE2
         assert_equal(ensemble.getCoordsets(arange(3)),
                      PDBENSEMBLE.getCoordsets(),
                      'concatenation failed')
         assert_equal(ensemble.getCoordsets(arange(3,6)),
-                     PDBENSEMBLE.getCoordsets(),
+                     PDBENSEMBLE2.getCoordsets(),
                      'concatenation failed')
         assert_equal(ensemble.getCoords(), COORDS,
                      'concatenation failed')
@@ -117,5 +131,12 @@ class TestPDBEnsemble(TestCase):
                      PDBENSEMBLE.getWeights(),
                      'concatenation failed')
         assert_equal(ensemble.getWeights()[arange(3,6)],
-                     PDBENSEMBLE.getWeights(),
+                     PDBENSEMBLE2.getWeights(),
                      'concatenation failed')
+
+        msa = PDBENSEMBLE2.getMSA()
+        msa2 = ensemble.getMSA(arange(3,6))
+
+        assert_equal(msa, msa2, 'associated MSA concatenation failed')
+
+

--- a/prody/tests/ensemble/test_pdbensemble.py
+++ b/prody/tests/ensemble/test_pdbensemble.py
@@ -148,6 +148,6 @@ class TestPDBEnsemble(TestCase):
         assert_equal(ensemble.numCoordsets(), n_conf+n_csets,
                      'adding coordsets failed')
 
-        ensemble.addCoordsets(ATOMS, degeneracy=False)
+        ensemble.addCoordsets(ATOMS, degeneracy=True)
         assert_equal(ensemble.numCoordsets(), n_conf+n_csets+1,
                      'adding coordsets failed')

--- a/prody/tests/ensemble/test_pdbensemble.py
+++ b/prody/tests/ensemble/test_pdbensemble.py
@@ -5,7 +5,7 @@ from prody.tests import TestCase
 from numpy import arange
 from numpy.testing import assert_equal
 
-from . import ATOMS, PDBENSEMBLE, PDBENSEMBLE2, COORDS, WEIGHTS_BOOL, ENSEMBLE, WEIGHTS
+from . import ATOMS, PDBENSEMBLE, PDBENSEMBLEA, COORDS, WEIGHTS_BOOL, ENSEMBLE, WEIGHTS
 
 class TestPDBEnsemble(TestCase):
 
@@ -13,7 +13,7 @@ class TestPDBEnsemble(TestCase):
 
         assert_equal(PDBENSEMBLE.getCoords(), COORDS,
                      'failed to set reference coordinates for PDBEnsemble')
-        assert_equal(PDBENSEMBLE2.getCoords(), COORDS,
+        assert_equal(PDBENSEMBLEA.getCoords(), COORDS,
                      'failed to set reference coordinates for PDBEnsemble')
 
     def testGetCoordsets(self):
@@ -21,7 +21,7 @@ class TestPDBEnsemble(TestCase):
         assert_equal(PDBENSEMBLE.getCoordsets()[WEIGHTS_BOOL],
                      ATOMS.getCoordsets()[WEIGHTS_BOOL],
                      'failed to add coordinate sets for PDBEnsemble')
-        assert_equal(PDBENSEMBLE2.getCoordsets()[WEIGHTS_BOOL],
+        assert_equal(PDBENSEMBLEA.getCoordsets()[WEIGHTS_BOOL],
                      ATOMS.getCoordsets()[WEIGHTS_BOOL],
                      'failed to add coordinate sets for PDBEnsemble')
 
@@ -36,38 +36,38 @@ class TestPDBEnsemble(TestCase):
         assert_equal(PDBENSEMBLE.getWeights(), WEIGHTS,
                      'failed to get correct weights')
         
-        self.assertEqual(PDBENSEMBLE2.getWeights().ndim, 3,
+        self.assertEqual(PDBENSEMBLEA.getWeights().ndim, 3,
                         'wrong ndim for weights of PDBEnsemble')
-        self.assertTupleEqual(PDBENSEMBLE2.getWeights().shape,
-                              (PDBENSEMBLE2.numCoordsets(),
-                               PDBENSEMBLE2.numAtoms(), 1),
+        self.assertTupleEqual(PDBENSEMBLEA.getWeights().shape,
+                              (PDBENSEMBLEA.numCoordsets(),
+                               PDBENSEMBLEA.numAtoms(), 1),
                                'wrong shape for weights of PDBEnsemble')
-        assert_equal(PDBENSEMBLE2.getWeights(), WEIGHTS,
+        assert_equal(PDBENSEMBLEA.getWeights(), WEIGHTS,
                      'failed to get correct weights')
 
 
     def testSlicingCopy(self):
 
-        SLICE = PDBENSEMBLE2[:]
-        assert_equal(SLICE.getCoords(), PDBENSEMBLE2.getCoords(),
+        SLICE = PDBENSEMBLEA[:]
+        assert_equal(SLICE.getCoords(), PDBENSEMBLEA.getCoords(),
                      'slicing copy failed to set reference coordinates')
-        assert_equal(SLICE.getCoordsets(), PDBENSEMBLE2.getCoordsets(),
+        assert_equal(SLICE.getCoordsets(), PDBENSEMBLEA.getCoordsets(),
                      'slicing copy failed to add coordinate sets')
 
     def testSlicing(self):
 
-        SLICE = PDBENSEMBLE2[:2]
-        assert_equal(SLICE.getCoords(), PDBENSEMBLE2.getCoords(),
+        SLICE = PDBENSEMBLEA[:2]
+        assert_equal(SLICE.getCoords(), PDBENSEMBLEA.getCoords(),
                      'slicing failed to set reference coordinates')
-        assert_equal(SLICE.getCoordsets(), PDBENSEMBLE2.getCoordsets([0,1]),
+        assert_equal(SLICE.getCoordsets(), PDBENSEMBLEA.getCoordsets([0,1]),
                      'slicing failed to add coordinate sets')
 
     def testSlicingList(self):
 
-        SLICE = PDBENSEMBLE2[[0,2]]
-        assert_equal(SLICE.getCoords(), PDBENSEMBLE2.getCoords(),
+        SLICE = PDBENSEMBLEA[[0,2]]
+        assert_equal(SLICE.getCoords(), PDBENSEMBLEA.getCoords(),
                      'slicing failed to set reference coordinates')
-        assert_equal(SLICE.getCoordsets(), PDBENSEMBLE2.getCoordsets([0,2]),
+        assert_equal(SLICE.getCoordsets(), PDBENSEMBLEA.getCoordsets([0,2]),
                      'slicing failed to add coordinate sets')
 
     def testSlicingWeights(self):
@@ -96,7 +96,7 @@ class TestPDBEnsemble(TestCase):
 
     def testDelCoordsetMiddle(self):
 
-        ensemble = PDBENSEMBLE2[:]
+        ensemble = PDBENSEMBLEA[:]
         ensemble.delCoordset(1)
         assert_equal(ensemble.getCoordsets()[WEIGHTS_BOOL[[0,2]]],
                      ATOMS.getCoordsets([0,2])[WEIGHTS_BOOL[[0,2]]],
@@ -105,8 +105,8 @@ class TestPDBEnsemble(TestCase):
     def testDelCoordsetAll(self):
         """Test consequences of deleting all coordinate sets."""
 
-        ensemble = PDBENSEMBLE2[:]
-        ensemble.delCoordset(arange(len(PDBENSEMBLE2)))
+        ensemble = PDBENSEMBLEA[:]
+        ensemble.delCoordset(arange(len(PDBENSEMBLEA)))
         self.assertIsNone(ensemble.getCoordsets(),
                         'failed to delete all coordinate sets')
         self.assertIsNone(ensemble.getWeights(), 'failed to delete weights '
@@ -118,12 +118,12 @@ class TestPDBEnsemble(TestCase):
     def testConcatenation(self):
         """Test concatenation of PDB ensembles."""
 
-        ensemble = PDBENSEMBLE + PDBENSEMBLE2
+        ensemble = PDBENSEMBLE + PDBENSEMBLEA
         assert_equal(ensemble.getCoordsets(arange(3)),
                      PDBENSEMBLE.getCoordsets(),
                      'concatenation failed')
         assert_equal(ensemble.getCoordsets(arange(3,6)),
-                     PDBENSEMBLE2.getCoordsets(),
+                     PDBENSEMBLEA.getCoordsets(),
                      'concatenation failed')
         assert_equal(ensemble.getCoords(), COORDS,
                      'concatenation failed')
@@ -131,16 +131,16 @@ class TestPDBEnsemble(TestCase):
                      PDBENSEMBLE.getWeights(),
                      'concatenation failed')
         assert_equal(ensemble.getWeights()[arange(3,6)],
-                     PDBENSEMBLE2.getWeights(),
+                     PDBENSEMBLEA.getWeights(),
                      'concatenation failed')
 
-        msa = PDBENSEMBLE2.getMSA()
+        msa = PDBENSEMBLEA.getMSA()
         msa2 = ensemble.getMSA(arange(3,6))
 
         assert_equal(msa, msa2, 'associated MSA concatenation failed')
 
     def testAddCoordsets(self):
-        ensemble = PDBENSEMBLE2[:]
+        ensemble = PDBENSEMBLEA[:]
         n_conf = ensemble.numCoordsets()
         n_csets = ATOMS.numCoordsets()
 

--- a/prody/tests/ensemble/test_pdbensemble.py
+++ b/prody/tests/ensemble/test_pdbensemble.py
@@ -137,7 +137,7 @@ class TestPDBEnsemble(TestCase):
         msa = PDBENSEMBLEA.getMSA()
         msa2 = ensemble.getMSA(arange(3,6))
 
-        assert_equal(msa, msa2, 'associated MSA concatenation failed')
+        assert_equal(msa.getArray(), msa2.getArray(), 'associated MSA concatenation failed')
 
     def testAddCoordsets(self):
         ensemble = PDBENSEMBLEA[:]

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -7,7 +7,7 @@ from collections import Counter
 __all__ = ['Everything', 'rangeString', 'alnum', 'importLA', 'dictElement',
            'intorfloat', 'startswith', 'showFigure', 'countBytes', 'sqrtm',
            'saxsWater', 'count', 'addBreaks', 'copy', 'dictElementLoop', 
-           'getDataPath', 'openData']
+           'getDataPath', 'openData', 'chr2']
 
 
 class Everything(object):
@@ -260,3 +260,10 @@ def openData(filename, mode='rb'):
 def saxsWater():
     filename = getDataPath('saxs_water.dat')
     return loadtxt(filename, delimiter=',')
+
+def chr2(a):
+    try:
+        c = chr(a)
+    except TypeError:
+        c = str(a)
+    return c


### PR DESCRIPTION
- Improvement of `addCoordset`. If `degeneracy=True` and `coords` is `Atomic`, then `getCoords` instead of `getCoordsets` will be used to retrieve coordinates. **This will allow using `setACSIndex` to alter active coordinates when adding an atom with multiple coordinate sets.**
- `other._atoms` will be used as the new atoms when adding ensembles if `self._atoms` isn't available. The same goes with weights.
- Bug fixes to `showAlignment` and **now it assumes default labels if labels are not available**. 
- Changed the default title for `MSA.__add__` in order to be consistent with other classes, such as `Ensemble`.