### PR TITLE
Adding ANM support to signature functions

### DIFF
--- a/prody/dynamics/editing.py
+++ b/prody/dynamics/editing.py
@@ -299,8 +299,8 @@ def reduceModel(model, atoms, select):
     other = np.invert(system)
 
     if model.is3d():
-        system = np.tile(system, (3, 1)).transpose().flatten()
-        other = np.tile(other, (3, 1)).transpose().flatten()
+        system = np.repeat(system, 3)
+        other = np.repeat(other, 3)
     ss = matrix[system, :][:, system]
     if isinstance(model, PCA):
         eda = PCA(model.getTitle() + ' reduced')

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -31,7 +31,7 @@ class ModeEnsemble(object):
     or :class:`PDBEnsemble`. 
     """
 
-    __slots__ = ['_modesets', '_title', '_labels', '_atoms', '_weights']
+    __slots__ = ['_modesets', '_title', '_labels', '_atoms', '_weights', '_matched']
 
     def __init__(self, title=None):
         self._modesets = []
@@ -39,6 +39,7 @@ class ModeEnsemble(object):
         self._labels = None
         self._atoms = None
         self._weights = None
+        self._matched = False
 
     def __len__(self):
         """Returns the number of vectors."""
@@ -100,6 +101,7 @@ class ModeEnsemble(object):
         ens = ModeEnsemble(title=self.getTitle())
         ens.addModeSet(modesets, weights=weights, label=labels)
         ens.setAtoms(self.getAtoms())
+        ens._matched = self._matched
         return ens
 
     def __getitem__(self, index):
@@ -138,6 +140,7 @@ class ModeEnsemble(object):
         
         ensemble.addModeSet(other.getModeSets(), weights=other.getWeights(),
                             label=other.getLabels())
+        ensemble._matched = self._matched and other._matched
         return ensemble
 
     def is3d(self):
@@ -252,6 +255,8 @@ class ModeEnsemble(object):
         weights = self.getWeights()
         if weights is not None:
             weights = weights[:, :, 0]
+            if self.is3d():
+                weights = np.repeat(weights, 3, axis=1)
         return self._getModeData('getEigvec', mode_index, weights=weights, sign_correction=True)
 
     def getEigvecs(self, mode_indices=None, sign_correction=True):
@@ -260,12 +265,14 @@ class ModeEnsemble(object):
         weights = self.getWeights()
         if weights is not None:
             weights = weights[:, :, 0]
-            if mode_indices is None:
+            if mode_indices is not None:
                 n_modes = len(mode_indices)
             else:
                 n_modes = self.numModes()
             W = [weights.copy() for _ in range(n_modes)]  # almost equivalent to W = [weights]*n_modes
             W = np.stack(W, axis=-1)
+            if self.is3d():
+                W = np.repeat(W, 3, axis=1)
 
         return self._getData('getEigvecs', mode_indices, weights=W, sign_correction=True)
 
@@ -302,6 +309,7 @@ class ModeEnsemble(object):
     def match(self):
         if self._modesets:
             self._modesets = matchModes(*self._modesets)
+        self._matched = True
         return
 
     def addModeSet(self, modeset, weights=None, label=None):
@@ -375,6 +383,8 @@ class ModeEnsemble(object):
             torf[index] = False
             self._weights = self._weights[torf, :, :]
 
+    def isMatched(self):
+        return self._matched
 
 class Signature(object):
     """
@@ -499,6 +509,7 @@ class Signature(object):
 def calcEnsembleENMs(ensemble, model='gnm', trim='trim', n_modes=20, **kwargs):
     """Description"""
 
+    match = kwargs.pop('match', True)
     if isinstance(ensemble, Conformation):
         conformation = ensemble
         ensemble = conformation.getEnsemble()
@@ -570,6 +581,8 @@ def calcEnsembleENMs(ensemble, model='gnm', trim='trim', n_modes=20, **kwargs):
                              label=ensemble.getLabels())
     modeens.setAtoms(ensemble.getAtoms())
 
+    if match:
+        modeens.match()
     return modeens
 
 def _getEnsembleENMs(ensemble, **kwargs):
@@ -612,9 +625,12 @@ def calcSignatureSqFlucts(mode_ensemble, **kwargs):
 
     if not isinstance(mode_ensemble, ModeEnsemble):
         raise TypeError('mode_ensemble should be an instance of ModeEnsemble')
-    modesets = mode_ensemble
-    modesets.match()
+    
+    if not mode_ensemble.isMatched():
+        LOGGER.warn('modes in mode_ensemble did not match cross modesets. '
+                    'Consider running mode_ensemble.match() prior to using this function')
 
+    modesets = mode_ensemble
     V = []
     for modes in modesets:
         sqfs = calcSqFlucts(modes)
@@ -692,11 +708,27 @@ def showSignature(signature, linespec='-', **kwargs):
     return lines, polys, bars
 
 def showSignatureMode(mode_ensemble, **kwargs):
+
+    if not isinstance(mode_ensemble, ModeEnsemble):
+        raise TypeError('mode_ensemble should be an instance of ModeEnsemble')
+
+    if not mode_ensemble.isMatched():
+        LOGGER.warn('modes in mode_ensemble did not match cross modesets. '
+                    'Consider running mode_ensemble.match() prior to using this function')
+
     mode = mode_ensemble.getEigvec()
     show_zero = kwargs.pop('show_zero', True)
     return showSignature(mode, atoms=mode_ensemble.getAtoms(), show_zero=show_zero, **kwargs)
 
 def showSignatureSqFlucts(mode_ensemble, **kwargs):
+
+    if not isinstance(mode_ensemble, ModeEnsemble):
+        raise TypeError('mode_ensemble should be an instance of ModeEnsemble')
+
+    if not mode_ensemble.isMatched():
+        LOGGER.warn('modes in mode_ensemble did not match cross modesets. '
+                    'Consider running mode_ensemble.match() prior to using this function')
+
     sqf = calcSignatureSqFlucts(mode_ensemble)
     show_zero = kwargs.pop('show_zero', False)
     return showSignature(sqf, atoms=mode_ensemble.getAtoms(), show_zero=show_zero, **kwargs)
@@ -707,7 +739,9 @@ def calcSignatureCrossCorr(mode_ensemble, norm=True):
     if not isinstance(mode_ensemble, ModeEnsemble):
         raise TypeError('mode_ensemble should be an instance of ModeEnsemble')
 
-    mode_ensemble.match()
+    if not mode_ensemble.isMatched():
+        LOGGER.warn('modes in mode_ensemble did not match cross modesets. '
+                    'Consider running mode_ensemble.match() prior to using this function')
     matches = mode_ensemble
     n_atoms = matches.numAtoms()
     n_sets = len(matches)
@@ -742,7 +776,10 @@ def calcSignatureFractVariance(mode_ensemble):
     if not isinstance(mode_ensemble, ModeEnsemble):
         raise TypeError('mode_ensemble should be an instance of ModeEnsemble')
 
-    mode_ensemble.match()
+    if not mode_ensemble.isMatched():
+        LOGGER.warn('modes in mode_ensemble did not match cross modesets. '
+                    'Consider running mode_ensemble.match() prior to using this function')
+
     matches = mode_ensemble
     n_sets = len(matches)
 

--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -2,7 +2,7 @@
 """This module defines a class for handling ensembles of conformations."""
 
 from numpy import dot, add, subtract, array, ndarray, sign, concatenate
-from numpy import zeros, ones, arange, isscalar, max, intersect1d, where
+from numpy import zeros, ones, arange, isscalar, max
 from numpy import newaxis, unique, repeat
 
 from prody import LOGGER


### PR DESCRIPTION
- Added ANM support to signature functions (not finished).
- **Now matching is performed right after ENM ensemble is calculated**. This will partly solve the 'bulb' issue when only a slice of the ensemble is given to the function. This feature can be disabled by passing `match=False` to `calcEnsembleENMs`.
- Other slight changes.