### PR TITLE
Implementation of sdarray

### DIFF
--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -435,12 +435,12 @@ class sdarray(ndarray):
     array([[0, 1, 1],
         [1, 1, 1]])
     ```
-    Then if we use the :method:`sdarray.mean`: 
+    Then if we use the :method:`sdarray.mean`,
     ```
     In [4]: sdarr.mean()
     Out[4]: array([4., 3.5, 4.5])
     ```
-    will compute the **weighted** average over the modesets (first axis), whereas
+    It will compute the **weighted** average over the modesets (first axis), whereas
     ```
     In [5]: mean(sdarr)
     Out[5]: 3.5

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -415,8 +415,8 @@ class sdarray(ndarray):
     the collection. 
     
     :class:`sdarray` functions exactly the same as :class:`~numpy.ndarray`, 
-    except that :method:`sdarray.mean()`, :method:`sdarray.std()`, 
-    :method:`sdarray.max()`, :method:`sdarray.min()` are overriden. 
+    except that :method:`sdarray.mean`, :method:`sdarray.std`, 
+    :method:`sdarray.max`, :method:`sdarray.min` are overriden. 
     Average, standard deviation, minimum, maximum, etc. are weighted and 
     calculated over the first axis by default. "sdarray" stands for 
     "signature dynamics array".

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -412,9 +412,14 @@ class sdarray(ndarray):
     """
     A class for representing a collection of arrays. It is derived from 
     :class:`~numpy.ndarray`, and the first axis is reserved for indexing 
-    the collection. Average, standard deviation, minimum, maximum, etc. 
-    are calculated over the first axis. "sdarray" stands for "signature 
-    dynamics array".
+    the collection. 
+    
+    :class:`sdarray` functions exactly the same as :class:`~numpy.ndarray`, 
+    except that :method:`sdarray.mean()`, :method:`sdarray.std()`, 
+    :method:`sdarray.max()`, :method:`sdarray.min()` are overriden. 
+    Average, standard deviation, minimum, maximum, etc. are weighted and 
+    calculated over the first axis by default. "sdarray" stands for 
+    "signature dynamics array".
 
     Notes for developper: please read following article about subclassing 
     :class:`~numpy.ndarray` before modifying this class:
@@ -444,10 +449,6 @@ class sdarray(ndarray):
         arr = np.asarray(self)
         return arr[index]
 
-    def __repr__(self):
-        shape = self.shape
-        return '<sdarray: {0} arrays of size {1}>'.format(shape[0], shape[1:])
-
     def __str__(self):
         return self.getTitle()
 
@@ -457,7 +458,7 @@ class sdarray(ndarray):
         return self._is3d
 
     def numAtoms(self):
-        """Returns number of atoms assuming it is represented by the second axis."""
+        """Returns the number of atoms assuming it is represented by the second axis."""
 
         try:
             n_atoms = self.shape[1]
@@ -469,23 +470,29 @@ class sdarray(ndarray):
             return 0
 
     def numModeSets(self):
-        """Returns number of modesets in the instance """
+        """Returns the number of modesets in the instance """
 
         return len(self)
 
     def getTitle(self):
-        """Returns title of the signature."""
+        """Returns the title of the signature."""
 
         return self._title
 
     def getLabels(self):
+        """Returns the labels of the signature."""
+
         return self._labels
 
     def mean(self, axis=0, **kwargs):
+        """Calculates the weighted average of the sdarray over modesets (`axis=0`)."""
+
         arr = np.asarray(self)
         return np.average(arr, axis=axis, weights=self._weights)
     
     def std(self, axis=0, **kwargs):
+        """Calculates the weighted standard deviations of the sdarray over modesets (`axis=0`)."""
+
         arr = np.asarray(self)
         mean = np.average(arr, weights=self._weights, axis=axis)
         variance = np.average((arr - mean)**2, 
@@ -493,17 +500,25 @@ class sdarray(ndarray):
         return np.sqrt(variance)
 
     def min(self, axis=0, **kwargs):
+        """Calculates the minimum values of the sdarray over modesets (`axis=0`)."""
+
         arr = np.asarray(self)
         return arr.min(axis=axis)
 
     def max(self, axis=0, **kwargs):
+        """Calculates the maximum values of the sdarray over modesets (`axis=0`)."""
+
         arr = np.asarray(self)
         return arr.max(axis=axis)
 
     def getWeights(self):
+        """Returns the weights of the signature."""
+
         return self._weights
 
     def setWeights(self, weights):
+        """Sets the weights of the signature."""
+
         self._weights = weights
 
 def calcEnsembleENMs(ensemble, model='gnm', trim='trim', n_modes=20, **kwargs):

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -421,6 +421,29 @@ class sdarray(ndarray):
     calculated over the first axis by default. "sdarray" stands for 
     "signature dynamics array".
 
+    Suppose:
+    ```
+    In [1]: from prody import sdarray
+
+    In [2]: from numpy import mean
+
+    In [3]: sdarr = sdarray([[1, 2, 3], [4, 5, 6]])
+    Out[3]:
+    sdarray([[1, 2, 3],
+            [4, 5, 6]])
+    ```
+    Then
+    ```
+    In [4]: sdarr.mean()
+    Out[4]: array([2.5, 3.5, 4.5])
+    ```
+    will compute the **weighted** average over the modesets (first axis), whereas
+    ```
+    In [5]: mean(sdarr)
+    Out[5]: 3.5
+    ```
+    will just perform a usually `numpy.mean` calculation, assuming `axis=None` and **unweighted**.
+
     Notes for developper: please read following article about subclassing 
     :class:`~numpy.ndarray` before modifying this class:
 

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -427,22 +427,26 @@ class sdarray(ndarray):
 
     In [2]: from numpy import mean
 
-    In [3]: sdarr = sdarray([[1, 2, 3], [4, 5, 6]])
+    In [3]: sdarr = sdarray([[1, 2, 3], [4, 5, 6]], weights=[[0, 1, 1], [1, 1, 1]])
     Out[3]:
     sdarray([[1, 2, 3],
             [4, 5, 6]])
+    weights=
+    array([[0, 1, 1],
+        [1, 1, 1]])
     ```
-    Then
+    Then if we use the :method:`sdarray.mean`: 
     ```
     In [4]: sdarr.mean()
-    Out[4]: array([2.5, 3.5, 4.5])
+    Out[4]: array([4., 3.5, 4.5])
     ```
     will compute the **weighted** average over the modesets (first axis), whereas
     ```
     In [5]: mean(sdarr)
     Out[5]: 3.5
     ```
-    will just perform a usually `numpy.mean` calculation, assuming `axis=None` and **unweighted**.
+    will just perform a usually `numpy.mean` calculation, assuming `axis=None` 
+    and **unweighted**.
 
     Notes for developper: please read following article about subclassing 
     :class:`~numpy.ndarray` before modifying this class:
@@ -465,7 +469,7 @@ class sdarray(ndarray):
         
         obj._labels = labels
         obj._is3d = is3d
-        obj._weights = weights
+        obj._weights = np.asarray(weights)
         return obj
 
     def __getitem__(self, index):
@@ -479,6 +483,14 @@ class sdarray(ndarray):
         """Returns **True** is model is 3-dimensional."""
         
         return self._is3d
+
+    def __repr__(self):
+        arr_repr = ndarray.__repr__(self)
+        weights = self._weights
+        if weights is not None:
+            weights_repr = repr(weights)
+            arr_repr += '\nweights=\n{0}'.format(weights_repr)
+        return arr_repr
 
     def numAtoms(self):
         """Returns the number of atoms assuming it is represented by the second axis."""


### PR DESCRIPTION
- Removed Signature to sdarray which is now a subclass of numpy.ndarray.
- Added documentation to `ModeEnsemble` (to be continued).

Notes on `sdarray`:
`sdarray` functions exactly the same as :`numpy.ndarray`, except that `sdarray.mean`, `sdarray.std`, `sdarray.max`, `sdarray.min()` are overriden. Average, standard deviation, minimum, maximum, etc. are weighted and calculated over the first axis by default.

Suppose:
```
In [1]: from prody import sdarray

In [2]: from numpy import mean

In [3]: sdarr = sdarray([[1, 2, 3], [4, 5, 6]], weights=[[0, 1, 1], [1, 1, 1]])
Out[3]:
sdarray([[1, 2, 3],
         [4, 5, 6]])
weights=
array([[0, 1, 1],
       [1, 1, 1]])
```
Then if we use the `sdarray.mean`: 
```
In [4]: sdarr.mean()
Out[4]: array([4., 3.5, 4.5])
```
it will compute the **weighted** average over the modesets (first axis), whereas
```
In [5]: mean(sdarr)
Out[5]: 3.5
```
will just perform a `numpy.mean` calculation, assuming `axis=None` and **unweighted**.