### PR TITLE
Improvement of LOGGER.progress

### DIFF
--- a/prody/dynamics/pca.py
+++ b/prody/dynamics/pca.py
@@ -112,7 +112,7 @@ class PCA(NMA):
                 cov += np.outer(coords, coords)
                 n_confs += 1
                 LOGGER.update(n_confs, '_prody_pca')
-            LOGGER.clear()
+            LOGGER.finish()
             cov /= n_confs
             coordsum /= n_confs
             mean = coordsum
@@ -147,7 +147,7 @@ class PCA(NMA):
                         deviations = coords - mean
                         cov += np.outer(deviations, deviations)
                         LOGGER.update(n_confs, '_prody_pca')
-                    LOGGER.clear()
+                    LOGGER.finish()
                     cov /= n_confs
                     self._cov = cov
             else:

--- a/prody/dynamics/perturb.py
+++ b/prody/dynamics/perturb.py
@@ -93,7 +93,7 @@ def calcPerturbResponse(model, **kwargs):
     LOGGER.report('Covariance matrix calculated in %.1fs.',
                   '_prody_cov')
 
-    LOGGER.progress('Calculating perturbation response', n_atoms, '_prody_prs_mat')
+    LOGGER.report('Calculating perturbation response', n_atoms, '_prody_prs_mat')
 
     if not model.is3d():
         prs_matrix = cov**2

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -610,8 +610,6 @@ def calcEnsembleENMs(ensemble, model='gnm', trim='trim', n_modes=20, **kwargs):
         
     labels = ensemble.getLabels()
 
-    verb = LOGGER.verbosity
-    LOGGER.verbosity = 'info'
     ### ENMs ###
     ## ENM for every conf
     enms = []
@@ -622,6 +620,7 @@ def calcEnsembleENMs(ensemble, model='gnm', trim='trim', n_modes=20, **kwargs):
                     .format(str_modes, model_type, n_confs), n_confs)
 
     for i in range(n_confs):
+        LOGGER.update(i)
         coords = ensemble.getCoordsets(i, selected=False)
         nodes = coords[0, :, :]
         if atoms is not None:
@@ -632,10 +631,7 @@ def calcEnsembleENMs(ensemble, model='gnm', trim='trim', n_modes=20, **kwargs):
         enms.append(enm)
 
         #lbl = labels[i] if labels[i] != '' else '%d-th conformation'%(i+1)
-        LOGGER.update(i)
-    
-    LOGGER.update(n_confs, 'Finished.')
-    LOGGER.verbosity = verb
+    LOGGER.finish()
 
     min_n_modes = ensemble.numAtoms() * 3
     for enm in enms:

--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -555,8 +555,8 @@ class Ensemble(object):
             else:
                 add(dot(movs[i], rotation),
                     (tar_com - dot(mob_com, rotation)), movs[i])
-            LOGGER.update(i, '_prody_ensemble')
-        LOGGER.clear()
+            LOGGER.update(i + 1, '_prody_ensemble')
+        LOGGER.finish()
 
     def iterpose(self, rmsd=0.0001):
         """Iteratively superpose the ensemble until convergence.  Initially,

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -389,12 +389,9 @@ def buildPDBEnsemble(refpdb, PDBs, title='Unknown', labels=None, seqid=94, cover
     # build the ensemble
     if unmapped is None: unmapped = []
 
-    verb = LOGGER.verbosity
-    LOGGER.verbosity = 'info'
-
     LOGGER.progress('Building the ensemble...', len(PDBs))
     for i, pdb in enumerate(PDBs):
-        LOGGER.update(i, 'Mapping %s to the reference...'%pdb)
+        LOGGER.update(i + 1, 'Mapping %s to the reference...'%pdb)
         try:
             pdb.getHierView()
         except AttributeError:
@@ -429,15 +426,14 @@ def buildPDBEnsemble(refpdb, PDBs, title='Unknown', labels=None, seqid=94, cover
         
         # add the mappings to the ensemble
         ensemble.addCoordset(atommap, weights=atommap.getFlags('mapped'), label = lbl)
-    
-    LOGGER.update(len(PDBs), 'Finished.')
-    LOGGER.verbosity = verb
+
+    LOGGER.finish()
 
     if occupancy is not None:
         ensemble = trimPDBEnsemble(ensemble, occupancy=occupancy)
     ensemble.iterpose()
-
-    LOGGER.debug('Ensemble ({0} conformations) were built in {1:.2f}s.'
+    
+    LOGGER.info('Ensemble ({0} conformations) were built in {1:.2f}s.'
                      .format(ensemble.numConfs(), time.time()-start))
 
     return ensemble

--- a/prody/measure/measure.py
+++ b/prody/measure/measure.py
@@ -562,17 +562,15 @@ def calcMSF(coordsets):
         LOGGER.progress('Evaluating {0} frames from {1}:'
                         .format(ncsets, str(coordsets)), ncsets,
                         '_prody_calcMSF')
-        ncsets = 0
         coordsets.reset()
-        for frame in coordsets:
+        for ncsets, frame in enumerate(coordsets):
             frame.superpose()
             coords = frame._getCoords()
             total += coords
             sqsum += coords ** 2
-            ncsets += 1
-            LOGGER.update(ncsets, '_prody_calcMSF')
+            LOGGER.update(ncsets + 1, '_prody_calcMSF')
         msf = (sqsum/ncsets - (total/ncsets)**2).sum(1)
-        LOGGER.clear()
+        LOGGER.finish()
         coordsets.goto(nfi)
     return msf
 

--- a/prody/measure/measure.py
+++ b/prody/measure/measure.py
@@ -562,13 +562,15 @@ def calcMSF(coordsets):
         LOGGER.progress('Evaluating {0} frames from {1}:'
                         .format(ncsets, str(coordsets)), ncsets,
                         '_prody_calcMSF')
+        ncsets = 0
         coordsets.reset()
-        for ncsets, frame in enumerate(coordsets):
+        for frame in coordsets:
             frame.superpose()
             coords = frame._getCoords()
             total += coords
             sqsum += coords ** 2
-            LOGGER.update(ncsets + 1, '_prody_calcMSF')
+            ncsets += 1
+            LOGGER.update(ncsets, '_prody_calcMSF')
         msf = (sqsum/ncsets - (total/ncsets)**2).sum(1)
         LOGGER.finish()
         coordsets.goto(nfi)

--- a/prody/proteins/pdbclusters.py
+++ b/prody/proteins/pdbclusters.py
@@ -110,7 +110,7 @@ def fetchPDBClusters(sqid=None):
     PDB_CLUSTERS_PATH = os.path.join(getPackagePath(), 'pdbclusters')
     if not os.path.isdir(PDB_CLUSTERS_PATH):
         os.mkdir(PDB_CLUSTERS_PATH)
-    LOGGER.progress('Downloading sequence clusters', len(PDB_CLUSTERS),
+    LOGGER.progress('Downloading sequence clusters', len(keys),
                     '_prody_fetchPDBClusters')
     count = 0
     for i, x in enumerate(keys):
@@ -129,7 +129,7 @@ def fetchPDBClusters(sqid=None):
             out.close()
             count += 1
         LOGGER.update(i, '_prody_fetchPDBClusters')
-    LOGGER.clear()
+    LOGGER.finish()
     if len(PDB_CLUSTERS) == count:
         LOGGER.info('All PDB clusters were downloaded successfully.')
     elif count == 0:

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -96,9 +96,6 @@ def parsePDB(*pdb, **kwargs):
     if n_pdb == 1:
         return _parsePDB(pdb[0], **kwargs)
     else:
-        verb = LOGGER.verbosity
-        LOGGER.verbosity = 'info'
-
         results = []
         lstkwargs = {}
         for key in kwargs:
@@ -123,9 +120,7 @@ def parsePDB(*pdb, **kwargs):
             results.append(result)
 
         results = zip(*results)
-
-        LOGGER.update(n_pdb, '{0} PDB structures retrieved'.format(n_pdb))
-        LOGGER.verbosity = verb
+        LOGGER.finish()
        
         for i in reversed(range(len(results))):
             if all(j is None for j in results[i]):
@@ -892,8 +887,6 @@ def parseChainsList(filename):
     Returns: lists containing an :class:'.AtomGroup' for each PDB, 
     the headers for those PDBs, and the requested :class:`.Chain` objects
     """
-    verb = LOGGER.verbosity
-    LOGGER.verbosity = 'info'
     
     fi = open(filename,'r')
     lines = fi.readlines()
@@ -919,7 +912,7 @@ def parseChainsList(filename):
 
         chains.append(ag.getHierView()[line.strip().split()[1]])
 
-    LOGGER.verbosity = verb
+    LOGGER.finish()
     LOGGER.info('{0} PDBs have been parsed and {1} chains have been extracted. \
                 '.format(len(ags),len(chains)))
 

--- a/prody/trajectory/dcdfile.py
+++ b/prody/trajectory/dcdfile.py
@@ -599,7 +599,7 @@ def writeDCD(filename, trajectory, start=None, stop=None, step=None,
     if isAtomic:
         trajectory.setACSIndex(acsi)
     j += 1
-    LOGGER.clear()
+    LOGGER.finish()
     dcd.close()
     time_ = time() - time_ or 0.01
     dcd_size = 1.0 * (56 + (n_atoms * 3 + 6) * 4 ) * n_csets / (1024*1024)

--- a/prody/utilities/logger.py
+++ b/prody/utilities/logger.py
@@ -11,9 +11,11 @@ import numbers
 
 __all__ = ['PackageLogger', 'LOGGING_LEVELS']
 
+LOGGING_PROGRESS = logging.INFO + 5
+
 LOGGING_LEVELS = {'debug': logging.DEBUG,
                 'info': logging.INFO,
-                'progress': logging.INFO + 5,
+                'progress': LOGGING_PROGRESS,
                 'warning': logging.WARNING,
                 'error': logging.ERROR,
                 'critical': logging.CRITICAL,
@@ -157,9 +159,10 @@ class PackageLogger(object):
     def clear(self):
         """Clear current line in ``sys.stderr``."""
 
-        if self._line and self._level < logging.WARNING:
-            sys.stderr.write('\r' + ' ' * (len(self._line)) + '\r')
-            self._line = ''
+        if self._level != LOGGING_PROGRESS: 
+            if self._line and self._level < logging.WARNING:
+                sys.stderr.write('\r' + ' ' * (len(self._line)) + '\r')
+                self._line = ''
 
     def exit(self, status=0):
         """Exit the interpreter."""
@@ -281,11 +284,11 @@ class PackageLogger(object):
             self.finish()
 
     def finish(self):
-        self.clear()
         if not hasattr(self, '_verb'):
             raise RuntimeError('finish before starting a progress')
         self._setverbosity(self._verb)
         del self._verb
+        self.clear()
 
     def sleep(self, seconds, msg=''):
         """Sleep for seconds while updating screen message every second.

--- a/prody/utilities/logger.py
+++ b/prody/utilities/logger.py
@@ -13,6 +13,7 @@ __all__ = ['PackageLogger', 'LOGGING_LEVELS']
 
 LOGGING_LEVELS = {'debug': logging.DEBUG,
                 'info': logging.INFO,
+                'progress': logging.INFO + 5,
                 'warning': logging.WARNING,
                 'error': logging.ERROR,
                 'critical': logging.CRITICAL,
@@ -243,6 +244,9 @@ class PackageLogger(object):
         self._msg = msg
         self._line = ''
 
+        self._verb = self._getverbosity()
+        self._setverbosity('progress')
+
     def update(self, step, msg=None, label=None):
         """Update progress status to current line in the console."""
 
@@ -273,6 +277,15 @@ class PackageLogger(object):
             sys.stderr.flush()
             self._prev = prev
             self._line = line
+        if i == n:
+            self.finish()
+
+    def finish(self):
+        self.clear()
+        if not hasattr(self, '_verb'):
+            raise RuntimeError('finish before starting a progress')
+        self._setverbosity(self._verb)
+        del self._verb
 
     def sleep(self, seconds, msg=''):
         """Sleep for seconds while updating screen message every second.

--- a/prody/utilities/logger.py
+++ b/prody/utilities/logger.py
@@ -284,11 +284,10 @@ class PackageLogger(object):
             self.finish()
 
     def finish(self):
-        if not hasattr(self, '_verb'):
-            raise RuntimeError('finish before starting a progress')
-        self._setverbosity(self._verb)
-        del self._verb
-        self.clear()
+        if hasattr(self, '_verb'):
+            self._setverbosity(self._verb)
+            del self._verb
+            self.clear()
 
     def sleep(self, seconds, msg=''):
         """Sleep for seconds while updating screen message every second.


### PR DESCRIPTION
- Added a verbosity level called 'progress' that is above 'info' and below 'warn'.
- Now when a `LOGGER.progress` is initiated, the verbosity is automatically set to 'progress'. The original verbosity will be restored by `LOGGER.update` the step to the total steps, or by call `LOGGER.finish`. **It is recommended to call `LOGGER.finish()` after the progress is done.**
- Fixed the flashing problem when progressing.