### PR TITLE
Changed the argument order in buildPDBEnsemble

### DIFF
--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -334,7 +334,7 @@ def alignPDBEnsemble(ensemble, suffix='_aligned', outdir='.', gzip=False):
         return output
 
 
-def buildPDBEnsemble(PDBs, refpdb=None, title='Unknown', labels=None, seqid=94, coverage=85, 
+def buildPDBEnsemble(PDBs, ref=None, title='Unknown', labels=None, seqid=94, coverage=85, 
                      mapping_func=mapOntoChain, unmapped=None, **kwargs):
     """Builds a PDB ensemble from a given reference structure and a list of PDB structures. 
     Note that the reference structure should be included in the list as well.
@@ -342,10 +342,10 @@ def buildPDBEnsemble(PDBs, refpdb=None, title='Unknown', labels=None, seqid=94, 
     :arg PDBs: A list of PDB structures
     :type PDBs: iterable
 
-    :arg refpdb: Reference structure or the index to the reference in ``PDBs``. If **None**,
+    :arg ref: Reference structure or the index to the reference in ``PDBs``. If **None**,
                  then the first item in ``PDBs`` will be considered as the reference. 
                  Default is **None**
-    :type refpdb: int, :class:`.Chain`, :class:`.Selection`, or :class:`.AtomGroup`
+    :type ref: int, :class:`.Chain`, :class:`.Selection`, or :class:`.AtomGroup`
 
     :arg title: The title of the ensemble
     :type title: str
@@ -377,11 +377,12 @@ def buildPDBEnsemble(PDBs, refpdb=None, title='Unknown', labels=None, seqid=94, 
         if len(labels) != len(PDBs):
             raise ValueError('labels and PDBs must be the same length')
 
-    if refpdb is None:
+    if ref is None:
         refpdb = PDBs[0]
-    elif isinstance(refpdb, Integral):
-        refpdb = PDBs[refpdb]
+    elif isinstance(ref, Integral):
+        refpdb = PDBs[ref]
     else:
+        refpdb = ref
         if refpdb not in PDBs:
             raise ValueError('refpdb should be also in the PDBs')
 

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -2,6 +2,7 @@
 
 import os.path
 import time
+from numbers import Integral
 
 import numpy as np
 
@@ -333,16 +334,18 @@ def alignPDBEnsemble(ensemble, suffix='_aligned', outdir='.', gzip=False):
         return output
 
 
-def buildPDBEnsemble(refpdb, PDBs, title='Unknown', labels=None, seqid=94, coverage=85, 
+def buildPDBEnsemble(PDBs, refpdb=None, title='Unknown', labels=None, seqid=94, coverage=85, 
                      mapping_func=mapOntoChain, unmapped=None, **kwargs):
     """Builds a PDB ensemble from a given reference structure and a list of PDB structures. 
     Note that the reference structure should be included in the list as well.
 
-    :arg refpdb: Reference structure
-    :type refpdb: :class:`.Chain`, :class:`.Selection`, or :class:`.AtomGroup`
-
     :arg PDBs: A list of PDB structures
     :type PDBs: iterable
+
+    :arg refpdb: Reference structure or the index to the reference in ``PDBs``. If **None**,
+                 then the first item in ``PDBs`` will be considered as the reference. 
+                 Default is **None**
+    :type refpdb: int, :class:`.Chain`, :class:`.Selection`, or :class:`.AtomGroup`
 
     :arg title: The title of the ensemble
     :type title: str
@@ -374,8 +377,13 @@ def buildPDBEnsemble(refpdb, PDBs, title='Unknown', labels=None, seqid=94, cover
         if len(labels) != len(PDBs):
             raise ValueError('labels and PDBs must be the same length')
 
-    if refpdb not in PDBs:
-        raise ValueError('refpdb should be also in the PDBs')
+    if refpdb is None:
+        refpdb = PDBs[0]
+    elif isinstance(refpdb, Integral):
+        refpdb = PDBs[refpdb]
+    else:
+        if refpdb not in PDBs:
+            raise ValueError('refpdb should be also in the PDBs')
 
     # obtain refchains from the hierarhical view of the reference PDB
     try:


### PR DESCRIPTION
`refpdb` is renamed to `ref` and moved to the second position. So we should use it like this:
```
ens = buildPDBEnsemble(PDBs, refpdb)
```
`ref` is optional, and if it is omitted then the first structure in PDBs will be assumed to be the reference.

`buildPDBEnsemble` is relatively new function so I doubt if anyone is using it except for us. So this change of behavior, although it affects coding, should be acceptable and should be made early.