### PR TITLE
Improvements to parsePfamPDBs to use residue numbers

### DIFF
--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -489,7 +489,8 @@ def parsePfamPDBs(**kwargs):
     with gzip.GzipFile('pdbmap.gz', 'rb') as f:
         data = f.read()
 
-    fields = ['PDB_ID', 'chain', 'nothing', 'PFAM_Name', 'PFAM_ACC', 'UniprotID', 'PdbRange']
+    fields = ['PDB_ID', 'chain', 'nothing', 'PFAM_Name', 'PFAM_ACC', 
+              'UniprotID', 'UniprotResnumRange']
     
     data_dicts = []
     for line in data.split('\n'):

--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -506,11 +506,25 @@ def parsePfamPDBs(**kwargs):
     ags, headers = parsePDB(*pdb_ids, chain=chains, header=True, **kwargs)
 
     ags = list(ags)
+    headers = list(headers)
+    no_dbrefs = []
     for i, ag in enumerate(ags):
-        ags[i] = ag.select('resnum {0} to {1}'.format(
-            data_dicts[i]['PdbRange'].split('-')[0],
-            data_dicts[i]['PdbRange'].split('-')[1])).copy()
+        if headers[i][data_dicts[i]['chain']].dbrefs != []:
+            dbrefs0 = headers[i][data_dicts[i]['chain']].dbrefs[0]
+            ags[i] = ag.select('resnum {0} to {1}'.format(
+                int(data_dicts[i]['UniprotResnumRange'].split('-')[0])
+                - (dbrefs0.first[-1] - dbrefs0.first[0]),
+                int(data_dicts[i]['UniprotResnumRange'].split('-')[1])
+                - (dbrefs0.first[-1] - dbrefs0.first[0]))).copy()
+        else:
+            no_dbrefs.append(i)
+
+    for i in reversed(no_dbrefs):
+        ags.pop(i)
+        headers.pop(i)
+
     ags = tuple(ags)
+    headers = tuple(headers)
     
     if header:
         results = ags, headers

--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -511,10 +511,11 @@ def parsePfamPDBs(**kwargs):
     for i, ag in enumerate(ags):
         if headers[i][data_dicts[i]['chain']].dbrefs != []:
             resnumRange = data_dicts[i]['UniprotResnumRange'].split('-')
-            dbrefs0 = headers[i][data_dicts[i]['chain']].dbrefs[0]
+            first = headers[i][data_dicts[i]['chain']].dbrefs[0].first
+            
             ags[i] = ag.select('resnum {0} to {1}'.format(
-                int(resnumRange[0]) - (dbrefs0.first[-1] - dbrefs0.first[0]),
-                int(resnumRange[1]) - (dbrefs0.first[-1] - dbrefs0.first[0])))
+                int(resnumRange[0]) - (first[-1] - first[0]),
+                int(resnumRange[1]) - (first[-1] - first[0])))
                 .copy()
         else:
             no_dbrefs.append(i)

--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -510,12 +510,12 @@ def parsePfamPDBs(**kwargs):
     no_dbrefs = []
     for i, ag in enumerate(ags):
         if headers[i][data_dicts[i]['chain']].dbrefs != []:
+            resnumRange = data_dicts[i]['UniprotResnumRange'].split('-')
             dbrefs0 = headers[i][data_dicts[i]['chain']].dbrefs[0]
             ags[i] = ag.select('resnum {0} to {1}'.format(
-                int(data_dicts[i]['UniprotResnumRange'].split('-')[0])
-                - (dbrefs0.first[-1] - dbrefs0.first[0]),
-                int(data_dicts[i]['UniprotResnumRange'].split('-')[1])
-                - (dbrefs0.first[-1] - dbrefs0.first[0]))).copy()
+                int(resnumRange[0]) - (dbrefs0.first[-1] - dbrefs0.first[0]),
+                int(resnumRange[1]) - (dbrefs0.first[-1] - dbrefs0.first[0])))
+                .copy()
         else:
             no_dbrefs.append(i)
 

--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -515,8 +515,7 @@ def parsePfamPDBs(**kwargs):
             
             ags[i] = ag.select('resnum {0} to {1}'.format(
                 int(resnumRange[0]) - (first[-1] - first[0]),
-                int(resnumRange[1]) - (first[-1] - first[0])))
-                .copy()
+                int(resnumRange[1]) - (first[-1] - first[0]))) 
         else:
             no_dbrefs.append(i)
 


### PR DESCRIPTION
I realised these are actually uniprot numbers and in most cases the discrepancy can be extracted from the pdb header.