### PR TITLE
Bug fix to extendModel and other changes

### DIFF
--- a/prody/atomic/__init__.py
+++ b/prody/atomic/__init__.py
@@ -205,6 +205,8 @@ chain.HierView = HierView
 
 segment.HierView = HierView
 
+atommap.HierView = HierView
+
 import numpy as np
 
 n_atoms = 10

--- a/prody/atomic/atommap.py
+++ b/prody/atomic/atommap.py
@@ -375,6 +375,11 @@ class AtomMap(AtomPointer):
 
         return 'index ' + rangeString(self._indices)
 
+    def getHierView(self, **kwargs):
+        """Returns a hierarchical view of the this chain."""
+
+        return HierView(self, **kwargs)
+
 
 for fname, field in ATOMIC_FIELDS.items():
 

--- a/prody/atomic/chain.py
+++ b/prody/atomic/chain.py
@@ -164,3 +164,4 @@ class Chain(AtomSubset):
         """Returns a hierarchical view of the this chain."""
 
         return HierView(self, **kwargs)
+        

--- a/prody/atomic/hierview.py
+++ b/prody/atomic/hierview.py
@@ -8,6 +8,7 @@ from prody.utilities.misctools import count
 from .atomgroup import AtomGroup
 from .selection import Selection
 from .chain import Chain
+from .atommap import AtomMap
 from .residue import Residue
 from .segment import Segment
 
@@ -43,8 +44,8 @@ class HierView(object):
 
     def __init__(self, atoms, **kwargs):
 
-        if not isinstance(atoms, (AtomGroup, Selection, Chain, Segment)):
-            raise TypeError('atoms must be an AtomGroup, Selection, Chain, or Segment instance')
+        if not isinstance(atoms, (AtomGroup, Selection, Chain, Segment, AtomMap)):
+            raise TypeError('atoms must be an AtomGroup, Selection, Chain, AtomMap or Segment instance')
 
         self._atoms = atoms
         self.update(**kwargs)

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -1049,7 +1049,7 @@ def showPerturbResponse(model, atoms=None, show_matrix=True, select=None, **kwar
         else:
             show = []
             profiles = sliceAtomicData(prs_matrix, atoms=atoms, select=select)
-            for i, profile in enumerate(profiles):
+            for profile in profiles:
                 kwargs.pop('figure', None); fig = gcf()
                 show.append(showAtomicLines(profile, atoms, **kwargs))
 

--- a/prody/measure/measure.py
+++ b/prody/measure/measure.py
@@ -6,7 +6,7 @@ from numpy import ndarray, power, sqrt, array, zeros, arccos
 from numpy import sign, tile, concatenate, pi, cross, subtract, round, var
 
 from prody.atomic import Atomic, Residue, Atom
-from prody.utilities import importLA, checkCoords
+from prody.utilities import importLA, checkCoords, getDistance
 from prody import LOGGER, PY2K
 
 if PY2K:
@@ -130,14 +130,6 @@ def calcDistance(atoms1, atoms2, unitcell=None):
             raise ValueError('unitcell.shape must be (3,)')
 
     return getDistance(atoms1, atoms2, unitcell)
-
-
-def getDistance(coords1, coords2, unitcell=None):
-
-    diff = coords1 - coords2
-    if unitcell is not None:
-        diff = subtract(diff, round(diff/unitcell)*unitcell, diff)
-    return sqrt(power(diff, 2, diff).sum(axis=-1))
 
 
 def calcAngle(atoms1, atoms2, atoms3, radian=False):

--- a/prody/measure/measure.py
+++ b/prody/measure/measure.py
@@ -3,7 +3,7 @@
 and measuring quantities."""
 
 from numpy import ndarray, power, sqrt, array, zeros, arccos
-from numpy import sign, tile, concatenate, pi, cross, subtract, round, var
+from numpy import sign, tile, concatenate, pi, cross, subtract, var
 
 from prody.atomic import Atomic, Residue, Atom
 from prody.utilities import importLA, checkCoords, getDistance

--- a/prody/utilities/catchall.py
+++ b/prody/utilities/catchall.py
@@ -213,7 +213,7 @@ def showMatrix(matrix, x_array=None, y_array=None, **kwargs):
 
     import matplotlib.pyplot as plt
     from matplotlib import cm, ticker
-    from matplotlib.gridspec import GridSpec, GridSpecFromSubplotSpec
+    from matplotlib.gridspec import GridSpec
     from matplotlib.collections import LineCollection
     from matplotlib.pyplot import imshow, gca, sca, sci
 

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -2,7 +2,7 @@
 import re
 
 from numpy import unique, linalg, diag, sqrt, dot, chararray
-from numpy import diff, where, insert, nan, loadtxt, array
+from numpy import diff, where, insert, nan, loadtxt, array, round
 from numpy import sign, arange, asarray, ndarray, subtract, power
 from collections import Counter
 import numbers

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -3,7 +3,7 @@ import re
 
 from numpy import unique, linalg, diag, sqrt, dot, chararray
 from numpy import diff, where, insert, nan, loadtxt, array
-from numpy import sign, arange, asarray, ndarray
+from numpy import sign, arange, asarray, ndarray, subtract, power
 from collections import Counter
 import numbers
 
@@ -13,7 +13,8 @@ __all__ = ['Everything', 'rangeString', 'alnum', 'importLA', 'dictElement',
            'intorfloat', 'startswith', 'showFigure', 'countBytes', 'sqrtm',
            'saxsWater', 'count', 'addBreaks', 'copy', 'dictElementLoop', 
            'getDataPath', 'openData', 'chr2', 'toChararray', 'interpY', 'cmp',
-           'getValue', 'indentElement', 'isPDB', 'isURL', 'isListLike']
+           'getValue', 'indentElement', 'isPDB', 'isURL', 'isListLike',
+           'getDistance']
 
 # Note that the chain id can be blank (space). Examples:
 # 3TT1, 3tt1A, 3tt1:A, 3tt1_A, 3tt1-A, 3tt1 A
@@ -361,3 +362,10 @@ def indentElement(elem, level=0):
 
 def isListLike(a):
     return isinstance(a, (list, tuple, ndarray))
+
+def getDistance(coords1, coords2, unitcell=None):
+
+    diff = coords1 - coords2
+    if unitcell is not None:
+        diff = subtract(diff, round(diff/unitcell)*unitcell, diff)
+    return sqrt(power(diff, 2, diff).sum(axis=-1))


### PR DESCRIPTION
- [extendModel] fixed the bug of duplicated atoms generated in, for example, a backbone model (see #636).
- [sliceAtomicData, extendAtomicData] Generalized these two functions for any axis (or axes), which should be more consistent with `numpy`.
- [HiewView] Added `getHiewView` to `AtomMap`.