### PR TITLE
Improved showAtomicLine

### DIFF
--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -1432,7 +1432,8 @@ def showAtomicLines(y, atoms=None, linespec='-', **kwargs):
             Z = []
             for z in zip(x, y):
                 Z.extend(z)
-            lines, polys = showLines(*Z, linespec, dy=dy, ticklabels=ticklabels, 
+                Z.append(linespec)
+            lines, polys = showLines(*Z, dy=dy, ticklabels=ticklabels, 
                                      gap=True, label=datalabels, **kwargs)
         else:
             lines, polys = showLines(x, y, linespec, dy=dy, ticklabels=ticklabels, 

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -1368,7 +1368,7 @@ def showAtomicLines(y, atoms=None, linespec='-', **kwargs):
             else:
                 ticklabels = atoms.getResnums()
         else:
-            ticklabels = []
+            labels = []
             if gap: 
                 x = []; last_resnum = 0
 
@@ -1376,19 +1376,22 @@ def showAtomicLines(y, atoms=None, linespec='-', **kwargs):
                 chid = chain.getChid()
                 resnums = chain.getResnums()
                 
+                labels.extend('%s:%d'%(chid, resnum) for resnum in resnums)
                 if gap:
                     x.extend(resnums + last_resnum)
                     last_resnum = resnums[-1]
+                    
+            def func_ticklabels(val, pos):
+                #The two args are the value and tick position
+                i = int(round(val))
 
-                    def func_ticklabels(val, pos):
-                    #The two args are the value and tick position
-                        return '{0}/{1}'.format(val, pos)
-                    ticklabels = func_ticklabels
-                else:
-                    ticklabels.extend('%s:%d'%(chid, resnum) for resnum in resnums)
-
+                return '{0}/{1}'.format(val, pos)
+                    
             if gap:
                 x -= x[0]
+                ticklabels = func_ticklabels
+            else:
+                ticklabels = labels
                 
     else:
         if gap:

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -512,6 +512,14 @@ def addPDBEnsemble(ensemble, PDBs, refpdb=None, labels=None, seqid=94, coverage=
     if labels is not None:
         if len(labels) != len(PDBs):
             raise TypeError('Labels and PDBs must have the same lengths.')
+    else:
+        labels = []
+        
+        for pdb in PDBs:
+            if pdb is None:
+                labels.append(None)
+            else:
+                labels.append(pdb.getTitle())
 
     # obtain refchains from the hierarhical view of the reference PDB
     if refpdb is None:
@@ -530,15 +538,15 @@ def addPDBEnsemble(ensemble, PDBs, refpdb=None, labels=None, seqid=94, coverage=
 
     LOGGER.progress('Appending the ensemble...', len(PDBs), '_prody_addPDBEnsemble')
     for i, pdb in enumerate(PDBs):
+        lbl = labels[i]
+        if pdb is None:
+            unmapped.append(labels[i])
+            continue
+
         LOGGER.update(i, 'Mapping %s to the reference...'%pdb.getTitle(), 
                       label='_prody_addPDBEnsemble')
         if not isinstance(pdb, (Chain, Selection, AtomGroup)):
             raise TypeError('PDBs must be a list of Chain, Selection, or AtomGroup.')
-        
-        if labels is None:
-            lbl = pdb.getTitle()
-        else:
-            lbl = labels[i]
 
         atommaps = []
         # find the mapping of the pdb to each reference chain

--- a/prody/utilities/catchall.py
+++ b/prody/utilities/catchall.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from numpy import unique, linalg, diag, sqrt, dot
-from .misctools import addBreaks, interpY
+from .misctools import addEnds, interpY
 
 __all__ = ['calcTree', 'clusterMatrix', 'showLines', 'showMatrix', 'reorderMatrix', 'findSubgroups']
 
@@ -162,9 +162,17 @@ def showLines(*args, **kwargs):
         else:
             raise ValueError('dy should be either 1-D or 2-D.')
         
-        for i, line in enumerate(lines):
-            color = line.get_color()
-            x, y = line.get_data()
+    for i, line in enumerate(lines):
+        color = line.get_color()
+        x, y = line.get_data()
+        
+        if gap:
+            x_new, y_new = addEnds(x, y)
+            line.set_data(x_new, y_new)
+        else:
+            x_new, y_new = x, y
+        
+        if dy is not None:
             if m != 1 and m != len(lines) or n != len(y):
                 raise ValueError('The shapes of dy and y do not match.')
 
@@ -172,22 +180,21 @@ def showLines(*args, **kwargs):
                 _dy = dy
             else:
                 _dy = dy[:, i]
-            
-            if gap:
-                x_new, y_new = addBreaks(x, y)
-                line.set_data(x_new, y_new)
-                _, _dy = addBreaks(x, _dy)
-            else:
-                x_new, y_new = x, y
 
+            if gap:
+                _, _dy = addEnds(x, _dy)
+                
             poly = ax.fill_between(x_new, y_new-_dy, y_new+_dy,
-                                   alpha=alpha, facecolor=color, edgecolor=None,
-                                   linewidth=1, antialiased=True)
+                                    alpha=alpha, facecolor=color, edgecolor=None,
+                                    linewidth=1, antialiased=True)
             polys.append(poly)
 
     ax.margins(x=0)
     if ticklabels is not None:
-        ax.get_xaxis().set_major_formatter(ticker.IndexFormatter(ticklabels))
+        if callable(ticklabels):
+            ax.get_xaxis().set_major_formatter(ticker.FuncFormatter(ticklabels))
+        else:
+            ax.get_xaxis().set_major_formatter(ticker.IndexFormatter(ticklabels))
     
     ax.xaxis.set_major_locator(ticker.AutoLocator())
     ax.xaxis.set_minor_locator(ticker.AutoMinorLocator())

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -11,7 +11,7 @@ from xml.etree.ElementTree import Element
 
 __all__ = ['Everything', 'rangeString', 'alnum', 'importLA', 'dictElement',
            'intorfloat', 'startswith', 'showFigure', 'countBytes', 'sqrtm',
-           'saxsWater', 'count', 'addBreaks', 'copy', 'dictElementLoop', 
+           'saxsWater', 'count', 'addEnds', 'copy', 'dictElementLoop', 
            'getDataPath', 'openData', 'chr2', 'toChararray', 'interpY', 'cmp',
            'getValue', 'indentElement', 'isPDB', 'isURL', 'isListLike',
            'getDistance']
@@ -245,7 +245,7 @@ def getMasses(elements):
 def count(L, a=None):
     return len([b for b in L if b is a])
 
-def addBreaks(x, y, axis=0):
+def addEnds(x, y, axis=0):
     """Finds breaks in *x*, extends them by one position and adds **nan** at the 
     corresponding position in *y*. *x* needs to be an 1-D array, *y* can be a 
     matrix of column (or row) vectors"""


### PR DESCRIPTION
- Added `gap` and `overlay` to `showAtomicLine`. Example code:
```
from prody import *
from pylab import *

ion()

prot = parsePDB('3tt1', subset='ca', chain='AB')
prot.setData('domain', prot.getChids())

part = prot.select('resnum < 50 or resnum > 100')

gnm = GNM()
gnm.buildKirchhoff(prot)
gnm.calcModes()

sqf = calcSqFlucts(gnm[:3])

subsqf = sliceAtomicData(sqf, prot, part)
dy = ones(len(subsqf)) * 0.01
x = part.getResnums()

figure()
subplot(3, 2, 1)
showAtomicLines(subsqf, atoms=part, gap=True)

subplot(3, 2, 2)
showAtomicLines(subsqf, atoms=part, dy=dy, gap=True)

subplot(3, 2, 3)
showAtomicLines(subsqf, atoms=part, gap=False)

subplot(3, 2, 4)
showAtomicLines(subsqf, atoms=part, dy=dy, gap=False)

subplot(3, 2, 5)
showAtomicLines(subsqf, atoms=part, overlay=True)
legend()

subplot(3, 2, 6)
showAtomicLines(subsqf, atoms=part, dy=dy, overlay=True)
legend()
```