### PR TITLE
 made searchPfam try with accession then sequence if it gets a bad Uniprot ID.

### DIFF
--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -216,6 +216,14 @@ def searchPfam(query, **kwargs):
     if xml.find(b'There was a system error on your last request.') > 0:
         LOGGER.warn('No Pfam matches found for: ' + seq)
         return None
+    elif xml.find(b'No valid UniProt accession or ID') > 0:
+        try:
+            ag = parsePDB(seq[:4], chain=seq[4:], subset='ca')
+            seq = ag.getSequence()
+            return searchPfam(seq)
+        except:
+            LOGGER.warn('No valid UniProt accession or ID for: ' + seq)
+            return None
 
     try:
         root = ET.XML(xml)

--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -180,6 +180,7 @@ def searchPfam(query, **kwargs):
                     if dbref.database != 'UniProt':
                         continue
                     idcode = dbref.idcode
+                    accession = dbref.accession
                     LOGGER.info('UniProt ID code {0} for {1} chain '
                                 '{2} will be used.'
                                 .format(idcode, seq[:4], poly.chid))
@@ -218,12 +219,16 @@ def searchPfam(query, **kwargs):
         return None
     elif xml.find(b'No valid UniProt accession or ID') > 0:
         try:
-            ag = parsePDB(seq[:4], chain=seq[4:], subset='ca')
-            seq = ag.getSequence()
-            return searchPfam(seq)
+            url = prefix + 'protein/' + accession + '?output=xml'
+            xml = openURL(url, timeout=timeout).read()
         except:
-            LOGGER.warn('No valid UniProt accession or ID for: ' + seq)
-            return None
+            try:
+                ag = parsePDB(seq, subset='ca')
+                seq = ag.getSequence()
+                return searchPfam(seq)
+            except:
+                LOGGER.warn('No valid UniProt accession or ID for: ' + seq)
+                return None
 
     try:
         root = ET.XML(xml)


### PR DESCRIPTION
This fixes issue #362, which is due to the PDB file containing an incorrect Uniprot ID. The fix is to try the Uniprot accession instead and if that fails then to use parsePDB and repeat with the sequence from the Atomgroup.