### PR TITLE
bug fix for parsePQR

### DIFF
--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -371,6 +371,10 @@ def buildPDBEnsemble(PDBs, ref=None, title='Unknown', labels=None,
     :arg unmapped: A list of PDB IDs that cannot be included in the ensemble. This is an 
         output argument. 
     :type unmapped: list
+
+    :arg subset: A subset for selecting particular atoms from the input structures.
+        Default is calpha
+    :type subset: str
     """
 
     occupancy = kwargs.pop('occupancy', None)

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -415,6 +415,7 @@ def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
     altlocs = np.zeros(asize, dtype=ATOMIC_FIELDS['altloc'].dtype)
     icodes = np.zeros(asize, dtype=ATOMIC_FIELDS['icode'].dtype)
     serials = np.zeros(asize, dtype=ATOMIC_FIELDS['serial'].dtype)
+    charges = np.zeros(asize, dtype=ATOMIC_FIELDS['charge'].dtype)
     if isPDB:
         segnames = np.zeros(asize, dtype=ATOMIC_FIELDS['segment'].dtype)
         elements = np.zeros(asize, dtype=ATOMIC_FIELDS['element'].dtype)
@@ -422,7 +423,6 @@ def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
         occupancies = np.zeros(asize, dtype=ATOMIC_FIELDS['occupancy'].dtype)
         anisou = None
         siguij = None
-        charges = np.zeros(asize, dtype=ATOMIC_FIELDS['charge'].dtype)
     else:
         radii = np.zeros(asize, dtype=ATOMIC_FIELDS['radius'].dtype)
 


### PR DESCRIPTION
I was surprised to find that subset='calpha' was applied so I added it to the documentation so other users won't be. 