### PR TITLE
fixes to py3Dmol support

### DIFF
--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -171,7 +171,7 @@ def view3D(*alist, **kwargs):
     for i, atoms in enumerate(alist):
         pdb = createStringIO()
         writePDBStream(pdb, atoms)
-        view.addModel(pdb.getvalue(), 'pdb')
+        view.addModels(pdb.getvalue(), 'pdb')
         view.setStyle({'model': -1}, {'cartoon': {'color':'spectrum'}})
         view.setStyle({'model': -1, 'hetflag': True}, {'stick':{}})
         view.setStyle({'model': -1, 'bonds': 0}, {'sphere':{'radius': 0.5}})    

--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -171,7 +171,7 @@ def view3D(*alist, **kwargs):
     for i, atoms in enumerate(alist):
         pdb = createStringIO()
         writePDBStream(pdb, atoms)
-        view.addModels(pdb.getvalue(), 'pdb')
+        view.addAsOneMolecule(pdb.getvalue(), 'pdb')
         view.setStyle({'model': -1}, {'cartoon': {'color':'spectrum'}})
         view.setStyle({'model': -1, 'hetflag': True}, {'stick':{}})
         view.setStyle({'model': -1, 'bonds': 0}, {'sphere':{'radius': 0.5}})    

--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -148,7 +148,7 @@ def view3D(*alist, **kwargs):
         data_list = wrap_data(data_list)
         n_data = len(data_list)
 
-    view = py3Dmol.view(width=width, height=height, js=kwargs.get('js','http://3dmol.csb.pitt.edu/build/3Dmol.js'))
+    view = py3Dmol.view(width=width, height=height, js=kwargs.get('js','http://3dmol.csb.pitt.edu/build/3Dmol-min.js'))
 
     def _mapData(atoms, data):
         # construct map from residue to data property

--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -315,7 +315,6 @@ def showProtein(*atoms, **kwargs):
 
     if '3dmol' in method:
         mol = view3D(*alist, **kwargs)
-        mol.show()
         return mol
     else:
         import matplotlib.pyplot as plt

--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -148,7 +148,7 @@ def view3D(*alist, **kwargs):
         data_list = wrap_data(data_list)
         n_data = len(data_list)
 
-    view = py3Dmol.view(width=width, height=height, js=kwargs.get('js','http://3dmol.csb.pitt.edu/build/3Dmol-min.js'))
+    view = py3Dmol.view(width=width, height=height, js=kwargs.get('js','http://3dmol.csb.pitt.edu/build/3Dmol.js'))
 
     def _mapData(atoms, data):
         # construct map from residue to data property
@@ -165,14 +165,14 @@ def view3D(*alist, **kwargs):
         lo = -extreme if np.min(data) < 0 else 0
         mid = np.mean(data) if np.min(data) >= 0 else 0
         view.setColorByProperty({'model': -1}, 'data', 'rwb', [extreme,lo,mid])
-        view.setStyle({'model': -1, 'cartoon':{'style':'trace'}})    
+        view.setStyle({'model': -1},{'cartoon':{'style':'trace'}})    
 
 
     for i, atoms in enumerate(alist):
         pdb = createStringIO()
         writePDBStream(pdb, atoms)
         view.addModel(pdb.getvalue(), 'pdb')
-        view.setStyle({'model': -1, 'cartoon': {'color':'spectrum'}})
+        view.setStyle({'model': -1}, {'cartoon': {'color':'spectrum'}})
         view.setStyle({'model': -1, 'hetflag': True}, {'stick':{}})
         view.setStyle({'model': -1, 'bonds': 0}, {'sphere':{'radius': 0.5}})    
 


### PR DESCRIPTION
Previous changes disabled the ability to view ensembles of molecules.  Also, two viewers were being created.  This restores the previous behavior, although you may want to consider adding a kwarg option for loading multiple coordinate sets into frames (addModelsAsFrames instead of addaddAsOneMolecule).

Example of code that was broken and is fixed with this patch:
```
import prody
import py3Dmol
ubi = prody.parsePDB('2lz3')
prody.showProtein(ubi)
```