### PR TITLE
 bug fix for initializing PDBEnsembles from Atomgroups and Ensembles 

### DIFF
--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -40,8 +40,13 @@ class Ensemble(object):
 
         self._confs = None       # coordinate sets
 
+        if isinstance(title, Ensemble):
+            self._atoms = title.getAtoms()
+        elif isinstance(title, Atomic):
+            self._atoms = title
+
         if isinstance(title, (Atomic, Ensemble)):
-            self.setCoords(title.getCoords())
+            self.setCoords(title)
             self.addCoordset(title)
 
     def __repr__(self):
@@ -426,11 +431,11 @@ class Ensemble(object):
         raise IndexError('indices must be an integer, a list/array of '
                          'integers, a slice, or None')
 
-    def _getCoordsets(self, indices=None):
+    def _getCoordsets(self, indices=None, selected=True):
 
         if self._confs is None:
             return None
-        if self._indices is None:
+        if self._indices is None or not selected:
             if indices is None:
                 return self._confs
             try:

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -30,9 +30,9 @@ class PDBEnsemble(Ensemble):
     def __init__(self, title='Unknown'):
 
         self._labels = []
-        Ensemble.__init__(self, title)
         self._trans = None
         self._msa = None
+        Ensemble.__init__(self, title)
 
     def __repr__(self):
 


### PR DESCRIPTION
This fixes a few errors in PDBEnsemble initialization (fixes in brackets):
1. Ensemble `_getCoords` method had no argument `selected` (added `selected` and made the behaviour match `getCoords`)
2. PDBEnsemble `_msa` attribute does not exist at the PDBEnsemble `addCoordset` step (reordered `__init__` steps so `_msa` is initialized first)
3. `setCoordset `step complains "coordinates of None are not set" (changed `setCoords(title.getCoords())` to `setCoords(title)`)

I also fixed a perceived bug but now I have a potentially bad/unexpected behaviour:
- initializing from an Atomgroup gives a PDBEnsemble with an MSA but when initializing from an Ensemble it has None so I added a block setting `_atoms` before `addCoordsets` but it means that we always have `_atoms` set even though the user didn't use the `setAtoms` method.

A quick test suggests buildPDBEnsemble is unaffected by my changes regardless of whether I have the _atom block.