### PR TITLE
missing timeout option in openURL() in fetchPfamMSA()

### DIFF
--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -377,7 +377,7 @@ def fetchPfamMSA(acc, alignment='full', compressed=False, **kwargs):
     :arg folder: output folder, default is ``'.'``"""
 
     url = prefix + 'family/acc?id=' + acc
-    handle = openURL(url)
+    handle = openURL(url, timeout=int(kwargs.get('timeout', 60)))
     orig_acc = acc
     acc = handle.readline().strip()
     if PY3K:


### PR DESCRIPTION
This sometimes causes an exception "The read operation timed out"