### PR TITLE
Add pyproject.toml to resolve build dependency on NumPy

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.rst
 include setup.py
+include pyproject.toml
 include prody/*.py
 include prody/*/*.py
 include prody/*/*.c

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy>=1.10"]


### PR DESCRIPTION
Hello!

When trying to install ProDy into a clean environment using pip and `requirements.txt`, sometimes pip tries to install ProDy before NumPy, and it causes `No files/directories in /tmp/pip-build-xxxxxxx/prody/pip-egg-info (from PKG-INFO)` error (which is not very helpful).

Here's a `Dockerfile` to reproduce (same on 18.04):

```Dockerfile
FROM ubuntu:16.04
RUN apt-get update && apt-get -y install python3 virtualenv build-essential && apt-get clean
RUN virtualenv -p python3 venv
RUN printf "numpy>=1.10\nscipy>=0.16\nprody>=1.8.2" > /requirements.txt
RUN bash -c 'source venv/bin/activate && pip install -r /requirements.txt'
CMD ["/bin/bash"]
```

Doing `pip install` in two-step (first, install NumPy and SciPy, and only afterward install ProDy) works, but is rather inconvenient.

ProDy is [far from the first project that encountered this problem](https://github.com/pypa/pip/issues/2381), and it seems the way to solve it is by using `pyproject.toml`.

Unfortunately, it is supported only by recent versions of pip>=10.0. However, if one is using VirtualEnv, that should be okay.

I haven't tested the proposed solution extensively, but it solves the issue for me at least.