### PR TITLE
Mass weighted calcGyradius bugs

### DIFF
--- a/prody/measure/measure.py
+++ b/prody/measure/measure.py
@@ -488,6 +488,7 @@ def calcGyradius(atoms, weights=None):
             raise ValueError('coords must have shape ([n_csets,]n_atoms,3)')
     if weights is not None:
         weights = weights.flatten()
+        weights = weights.reshape(weights.shape[0], 1)
         if len(weights) != coords.shape[-2]:
             raise ValueError('length of weights must match number of atoms')
         wsum = weights.sum()
@@ -499,9 +500,8 @@ def calcGyradius(atoms, weights=None):
             com = coords.mean(0)
             d2sum = ((coords - com)**2).sum()
         else:
-
-            com = (coords * weights).mean(0) / wsum
-            d2sum = (((coords - com)**2).sum(1) * weights).sum()
+            com = (coords * weights).sum(0) / wsum
+            d2sum = (((coords - com)**2) * weights).sum()
     else:
         rgyr = []
         for coords in coords:
@@ -510,9 +510,8 @@ def calcGyradius(atoms, weights=None):
                 d2sum = ((coords - com)**2).sum()
                 rgyr.append(d2sum)
             else:
-
-                com = (coords * weights).mean(0) / wsum
-                d2sum = (((coords - com)**2).sum(1) * weights).sum()
+                com = (coords * weights).sum(0) / wsum
+                d2sum = (((coords - com)**2) * weights).sum()
                 rgyr.append(d2sum)
         d2sum = array(rgyr)
     return (d2sum / wsum) ** 0.5


### PR DESCRIPTION
Corrections to avoid:
1) ValueError (operands could not be broadcast together with shapes ...) when calling calcGyradius(p, weights=p.getMasses())
2) Uncorrect calculation of the (mass weighted) radius of gyration