### PR TITLE
bug fix so mapChainByChain returns multiple chains if desired

### DIFF
--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -1026,14 +1026,29 @@ def mapOntoChain(atoms, chain, **kwargs):
 
 def mapChainByChain(atoms, ref, **kwargs):
     """This function is similar to :func:`.mapOntoChain` but correspondence 
-    of chains is found by their chain identifiers. """
+    of chains is found by their chain identifiers. 
+    
+    :arg atoms: atoms to map onto the reference
+    :type atoms: :class:`Atomic`
+    
+    :arg ref: reference structure for mapping
+    :type ref: :class:`Atomic`
+    
+    :arg return_all: whether to return all mappings.
+        If False, only mappings for the first chain will be returned. 
+        Default is True
+    :arg return_all: bool
+    """
+    mappings = []
     hv = atoms.getHierView()
     for chain in ref.getHierView().iterChains():
         for target_chain in hv.iterChains():
             if target_chain.getChid() == chain.getChid():
-                mappings = mapOntoChainByAlignment(target_chain, chain, **kwargs)
-                return mappings
-    return []
+                mappings.append(mapOntoChainByAlignment(target_chain, chain, **kwargs))
+
+    if len(mappings) == 1:
+        mappings = mappings[0]
+    return mappings
 
 def mapOntoChainByAlignment(atoms, chain, **kwargs):
     """This function is similar to :func:`.mapOntoChain` but correspondence 


### PR DESCRIPTION
It still has the right formatting for buildPDBEnsemble if the reference is a single chain but otherwise it returns mappings for all the chains.