### PR TITLE
Option to not renumber serials for writing PDB files

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1182,7 +1182,7 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
         if multi:
             write('MODEL{0:9d}\n'.format(m+1))
         for i, xyz in enumerate(coords):
-            if i == 99999:
+            if pdbline != PDBLINE_GE100K and (i == 99999 or serials[i] >= 10000):
                 pdbline = PDBLINE_GE100K
             write(pdbline % (hetero[i], serials[i],
                          atomnames[i], altlocs[i],

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -399,7 +399,6 @@ def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
     if n_atoms > 0:
         asize = n_atoms
     else:
-        # most PDB files contain less than MAX_N_ATOM (99999) atoms
         asize = len(lines) - split
     addcoords = False
     if atomgroup.numCoordsets() > 0:

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -23,6 +23,8 @@ __all__ = ['parsePDBStream', 'parsePDB', 'parseChainsList', 'parsePQR',
            'writePDBStream', 'writePDB', 'writeChainsList', 'writePQR',
            'writePQRStream']
 
+MAX_N_ATOM = 99999 
+
 class PDBParseError(Exception):
     pass
 
@@ -397,7 +399,7 @@ def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
     if n_atoms > 0:
         asize = n_atoms
     else:
-        # most PDB files contain less than 99999 atoms
+        # most PDB files contain less than MAX_N_ATOM (99999) atoms
         asize = len(lines) - split
     addcoords = False
     if atomgroup.numCoordsets() > 0:
@@ -1171,7 +1173,7 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
         if multi:
             write('MODEL{0:9d}\n'.format(m+1))
         for i, xyz in enumerate(coords):
-            if pdbline != PDBLINE_GE100K and (i == 99999 or serials[i] >= 100000):
+            if pdbline != PDBLINE_GE100K and (i == MAX_N_ATOM or serials[i] > MAX_N_ATOM):
                 LOGGER.warn('Indices are exceeding 99999 and hexadecimal format is being used')
                 pdbline = PDBLINE_GE100K
             write(pdbline % (hetero[i], i+1,

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -997,7 +997,14 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
     """Write *atoms* in PDB format to a *stream*.
 
     :arg stream: anything that implements a :meth:`write` method (e.g. file,
-        buffer, stdout)"""
+        buffer, stdout)
+        
+    :arg renumber: whether to renumber atoms with serial indices
+        Default is True
+    :type renumber: bool
+    """
+
+    renumber = kwargs.get('renumber',True)
 
     remark = str(atoms)
     try:
@@ -1086,6 +1093,7 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
     if resnums is None:
         resnums = np.ones(n_atoms, int)
 
+    indices = [atom.getIndex() for atom in atoms]
 
     icodes = atoms._getIcodes()
     if icodes is None:
@@ -1174,13 +1182,22 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
         for i, xyz in enumerate(coords):
             if i == 99999:
                 pdbline = PDBLINE_GE100K
-            write(pdbline % (hetero[i], i+1,
-                         atomnames[i], altlocs[i],
-                         resnames[i], chainids[i], resnums[i],
-                         icodes[i],
-                         xyz[0], xyz[1], xyz[2],
-                         occupancies[i], bfactors[i],
-                         segments[i], elements[i]))
+            if renumber:
+                write(pdbline % (hetero[i], i+1,
+                            atomnames[i], altlocs[i],
+                            resnames[i], chainids[i], resnums[i],
+                            icodes[i],
+                            xyz[0], xyz[1], xyz[2],
+                            occupancies[i], bfactors[i],
+                            segments[i], elements[i]))
+            else:
+                write(pdbline % (hetero[i], indices[i],
+                            atomnames[i], altlocs[i],
+                            resnames[i], chainids[i], resnums[i],
+                            icodes[i],
+                            xyz[0], xyz[1], xyz[2],
+                            occupancies[i], bfactors[i],
+                            segments[i], elements[i]))
         if multi:
             write('ENDMDL\n')
             altlocs = np.zeros(n_atoms, s_or_u + '1')

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1175,13 +1175,13 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
             if pdbline != PDBLINE_GE100K and (i == MAX_N_ATOM or serials[i] > MAX_N_ATOM):
                 LOGGER.warn('Indices are exceeding 99999 and hexadecimal format is being used')
                 pdbline = PDBLINE_GE100K
-            write(pdbline % (hetero[i], i+1,
-                        atomnames[i], altlocs[i],
-                        resnames[i], chainids[i], resnums[i],
-                        icodes[i],
-                        xyz[0], xyz[1], xyz[2],
-                        occupancies[i], bfactors[i],
-                        segments[i], elements[i]))
+            write(pdbline % (hetero[i], serials[i],
+                             atomnames[i], altlocs[i],
+                             resnames[i], chainids[i], resnums[i],
+                             icodes[i],
+                             xyz[0], xyz[1], xyz[2],
+                             occupancies[i], bfactors[i],
+                             segments[i], elements[i]))
         if multi:
             write('ENDMDL\n')
             altlocs = np.zeros(n_atoms, s_or_u + '1')

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1182,15 +1182,16 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
         if multi:
             write('MODEL{0:9d}\n'.format(m+1))
         for i, xyz in enumerate(coords):
-            if pdbline != PDBLINE_GE100K and (i == 99999 or serials[i] >= 10000):
+            if pdbline != PDBLINE_GE100K and (i == 99999 or serials[i] >= 100000):
+                LOGGER.warn('Indices are exceeding 99999 and hexadecimal format is being used')
                 pdbline = PDBLINE_GE100K
-            write(pdbline % (hetero[i], serials[i],
-                         atomnames[i], altlocs[i],
-                         resnames[i], chainids[i], resnums[i],
-                         icodes[i],
-                         xyz[0], xyz[1], xyz[2],
-                         occupancies[i], bfactors[i],
-                         segments[i], elements[i]))
+            write(pdbline % (hetero[i], i+1,
+                        atomnames[i], altlocs[i],
+                        resnames[i], chainids[i], resnums[i],
+                        icodes[i],
+                        xyz[0], xyz[1], xyz[2],
+                        occupancies[i], bfactors[i],
+                        segments[i], elements[i]))
         if multi:
             write('ENDMDL\n')
             altlocs = np.zeros(n_atoms, s_or_u + '1')

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1093,15 +1093,9 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
     if resnums is None:
         resnums = np.ones(n_atoms, int)
 
-    try:
-        indices = atoms._getIndices()
-    except:
-        try:
-            indices = [atom.getIndex() for atom in atoms]
-        except:
-            indices = None
-    if indices is None:
-        indices = np.ones(n_atoms, int)
+    serials = atoms._getSerials()
+    if serials is None or renumber == True:
+        serials = np.arange(1, n_atoms+1, dtype=int)
 
     icodes = atoms._getIcodes()
     if icodes is None:
@@ -1190,22 +1184,13 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
         for i, xyz in enumerate(coords):
             if i == 99999:
                 pdbline = PDBLINE_GE100K
-            if renumber:
-                write(pdbline % (hetero[i], i+1,
-                            atomnames[i], altlocs[i],
-                            resnames[i], chainids[i], resnums[i],
-                            icodes[i],
-                            xyz[0], xyz[1], xyz[2],
-                            occupancies[i], bfactors[i],
-                            segments[i], elements[i]))
-            else:
-                write(pdbline % (hetero[i], indices[i],
-                            atomnames[i], altlocs[i],
-                            resnames[i], chainids[i], resnums[i],
-                            icodes[i],
-                            xyz[0], xyz[1], xyz[2],
-                            occupancies[i], bfactors[i],
-                            segments[i], elements[i]))
+            write(pdbline % (hetero[i], serials[i],
+                         atomnames[i], altlocs[i],
+                         resnames[i], chainids[i], resnums[i],
+                         icodes[i],
+                         xyz[0], xyz[1], xyz[2],
+                         occupancies[i], bfactors[i],
+                         segments[i], elements[i]))
         if multi:
             write('ENDMDL\n')
             altlocs = np.zeros(n_atoms, s_or_u + '1')

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1083,7 +1083,7 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
         resnums = np.ones(n_atoms, int)
 
     serials = atoms._getSerials()
-    if serials is None or renumber == True:
+    if serials is None or renumber:
         serials = np.arange(1, n_atoms+1, dtype=int)
 
     icodes = atoms._getIcodes()

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1207,7 +1207,12 @@ writePDBStream.__doc__ += _writePDBdoc
 def writePDB(filename, atoms, csets=None, autoext=True, **kwargs):
     """Write *atoms* in PDB format to a file with name *filename* and return
     *filename*.  If *filename* ends with :file:`.gz`, a compressed file will
-    be written."""
+    be written.        
+
+    :arg renumber: whether to renumber atoms with serial indices
+        Default is True
+    :type renumber: bool
+    """
 
     if not ('.pdb' in filename or '.pdb.gz' in filename or
              '.ent' in filename or '.ent.gz' in filename):

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -990,7 +990,7 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
         buffer, stdout)
         
     :arg renumber: whether to renumber atoms with serial indices
-        Default is True
+        Default is **True**
     :type renumber: bool
     """
 
@@ -1194,7 +1194,7 @@ def writePDB(filename, atoms, csets=None, autoext=True, **kwargs):
     be written.        
 
     :arg renumber: whether to renumber atoms with serial indices
-        Default is True
+        Default is **True**
     :type renumber: bool
     """
 

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1093,7 +1093,15 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
     if resnums is None:
         resnums = np.ones(n_atoms, int)
 
-    indices = [atom.getIndex() for atom in atoms]
+    try:
+        indices = atoms._getIndices()
+    except:
+        try:
+            indices = [atom.getIndex() for atom in atoms]
+        except:
+            indices = None
+    if indices is None:
+        indices = np.ones(n_atoms, int)
 
     icodes = atoms._getIcodes()
     if icodes is None:

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1085,7 +1085,7 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
 
     serials = atoms._getSerials()
     if serials is None or renumber:
-        serials = np.arange(1, n_atoms+1, dtype=int)
+        serials = np.arange(n_atoms, dtype=int) + 1
 
     icodes = atoms._getIcodes()
     if icodes is None:


### PR DESCRIPTION
This could be useful for comparing PDB files containing selections back to full PDB files. Some programs use that too e.g. PLUMED for RMSD calculations: "Note that RMSD should be provided a reference structure in pdb format and can contain part of the system but the second column (the index) must reflect that of the full pdb so that PLUMED knows specifically which atom to drag where." (taken from https://plumed.github.io/doc-v2.5/user-doc/html/belfast-5.html#belfast-5-target)