### PR TITLE
Compatibility fix for RTBtools on Windows

### DIFF
--- a/prody/dynamics/rtb.py
+++ b/prody/dynamics/rtb.py
@@ -102,7 +102,7 @@ class RTB(ANMBase):
         from collections import defaultdict
         i = Increment()
         d = defaultdict(i)
-        blocks = np.array([d[b] for b in blocks], np.int64)
+        blocks = np.array([d[b] for b in blocks], dtype='int32')
 
         try:
             from collections import Counter
@@ -126,7 +126,7 @@ class RTB(ANMBase):
                     .format(nblocks, maxsize, natoms))
         nb6 = nblocks * 6 - nones * 3
 
-        coords = coords.T.copy()
+        coords = coords.T.astype(float)
 
         self._hessian = hessian = np.zeros((nb6, nb6), float)
         self._project = project = np.zeros((natoms * 3, nb6), float)

--- a/prody/dynamics/rtb.py
+++ b/prody/dynamics/rtb.py
@@ -126,7 +126,7 @@ class RTB(ANMBase):
                     .format(nblocks, maxsize, natoms))
         nb6 = nblocks * 6 - nones * 3
 
-        coords = coords.T.astype(float)
+        coords = coords.T.astype(float, order='C')
 
         self._hessian = hessian = np.zeros((nb6, nb6), float)
         self._project = project = np.zeros((natoms * 3, nb6), float)

--- a/prody/dynamics/rtbtools.c
+++ b/prody/dynamics/rtbtools.c
@@ -28,9 +28,9 @@ static int iminarg1,iminarg2;
 
 
 /* Other structures */
-typedef struct {float X[3];int model;} Atom_Line;
+typedef struct {float X[3]; int model;} Atom_Line;
 typedef struct {Atom_Line *atom;} PDB_File;
-typedef struct {int **IDX;double *X;} dSparse_Matrix;
+typedef struct {int **IDX; double *X;} dSparse_Matrix;
 
 
 
@@ -89,14 +89,14 @@ double sum(double *a, int n);
    in 'projection'. */
 static PyObject *buildhessian(PyObject *self, PyObject *args, PyObject *kwargs) {
   PDB_File PDB;
-  dSparse_Matrix PP,HH;
+  dSparse_Matrix PP, HH;
   PyArrayObject *coords, *blocks, *hessian, *projection;
-  double *XYZ,*hess,*proj;
+  double *XYZ, *hess, *proj;
   long *BLK;
   double **HB;
   double cutoff = 15., gamma = 1., scl=1., mlo=1., mhi=-1.;
   int natm, nblx, bmx;
-  int hsize,elm,bdim,i,j;
+  int hsize, elm, bdim, i, j;
 
   static char *kwlist[] = {"coords", "blocks", "hessian", "projection",
 			   "natoms", "nblocks", "maxsize", "cutoff",
@@ -128,12 +128,15 @@ static PyObject *buildhessian(PyObject *self, PyObject *args, PyObject *kwargs) 
   }
 
 
-
   /* Find the projection matrix */
   hsize = 18*bmx*nblx > 12*natm ? 12*natm : 18*bmx*nblx;
+  printf("hsize = %d\n", hsize);
+
   HH.IDX = imatrix(1, hsize, 1, 2);
   HH.X = dvector(1, hsize);
   elm = dblock_projections2(&HH, &PDB, natm, nblx, bmx);
+  printf("elm = %d\n", elm);
+
   PP.IDX = imatrix(1, elm, 1, 2);
   PP.X = dvector(1, elm);
   for (i=1; i<=elm; i++){
@@ -950,7 +953,7 @@ double *dvector(long nl, long nh)
 {
 	double *v;
 
-	v=(double *)malloc((size_t) ((nh-nl+1+NR_END)*sizeof(double)));
+	v = (double *)malloc((size_t) ((nh-nl+1+NR_END)*sizeof(double)));
 	if (!v) nrerror("allocation failure in dvector()");
 	return v-nl+NR_END;
 }

--- a/prody/dynamics/rtbtools.c
+++ b/prody/dynamics/rtbtools.c
@@ -448,7 +448,7 @@ int dblock_projections2(dSparse_Matrix *PP, PDB_File *PDB,
   A = dmatrix(1, 3, 1, 3);
   ISQT = dmatrix(1, 3, 1, 3);
 
-  printf('nblx = %d\n', nblx);
+  printf("nblx = %d\n", nblx);
   /* CYCLE THROUGH BLOCKS */
   for(b=1; b<=nblx; b++)
   {
@@ -511,7 +511,7 @@ int dblock_projections2(dSparse_Matrix *PP, PDB_File *PDB,
 
     /* FIND ITS SQUARE ROOT */
     for (i=1; i<=3; i++)
-      for (j=1; j<=3; j++)
+      for (j=1;j<=3; j++)
       {
 	      dd = 0.0;
         for(k=1; k<=3; k++)
@@ -521,9 +521,7 @@ int dblock_projections2(dSparse_Matrix *PP, PDB_File *PDB,
 
     /* UPDATE PP WITH THE RIGID MOTIONS OF THE BLOCK */
     tr = 1.0 / sqrt((double)nbp);
-    printf("b = %d\n", b);
     printf("nbp = %d\n", nbp);
-
     for (i=1; i<=nbp; i++)
     {
 

--- a/prody/dynamics/rtbtools.c
+++ b/prody/dynamics/rtbtools.c
@@ -380,13 +380,22 @@ void copy_prj_ofst(dSparse_Matrix *PP, double *proj, int elm, int bdim)
   for(i=1;i<=max;i++) I1[i]=0;
   for(i=1;i<=elm;i++)
     I1[PP->IDX[i][2]]=PP->IDX[i][2];
-  for(i=1;i<=max;i++){
+  for(i=1;i<=max;i++)
+  {
     if(I1[i]!=0) j++;
     I2[i]=j;
   }
-  for(i=1;i<=elm;i++)
-    if(PP->X[i]!=0.0)
+
+  double s = 0;
+  for(i=1; i<=elm; i++)
+    if(PP->X[i] != 0.0)
+    {
       proj[bdim*(PP->IDX[i][1]-1) + I2[PP->IDX[i][2]]-1] = PP->X[i];
+      s += PP->X[i];
+    }
+
+  printf("proj = %f\n", s);
+
   free_ivector(I1, 1, max);
   free_ivector(I2, 1, max);
 }

--- a/prody/dynamics/rtbtools.c
+++ b/prody/dynamics/rtbtools.c
@@ -448,6 +448,7 @@ int dblock_projections2(dSparse_Matrix *PP, PDB_File *PDB,
   A = dmatrix(1, 3, 1, 3);
   ISQT = dmatrix(1, 3, 1, 3);
 
+  printf('nblx = %d\n', nblx);
   /* CYCLE THROUGH BLOCKS */
   for(b=1; b<=nblx; b++)
   {
@@ -510,7 +511,7 @@ int dblock_projections2(dSparse_Matrix *PP, PDB_File *PDB,
 
     /* FIND ITS SQUARE ROOT */
     for (i=1; i<=3; i++)
-      for (j=1;j<=3; j++)
+      for (j=1; j<=3; j++)
       {
 	      dd = 0.0;
         for(k=1; k<=3; k++)
@@ -520,9 +521,9 @@ int dblock_projections2(dSparse_Matrix *PP, PDB_File *PDB,
 
     /* UPDATE PP WITH THE RIGID MOTIONS OF THE BLOCK */
     tr = 1.0 / sqrt((double)nbp);
-    printf("tr = %f\n", tr);
+    printf("b = %d\n", b);
     printf("nbp = %d\n", nbp);
-    
+
     for (i=1; i<=nbp; i++)
     {
 

--- a/prody/dynamics/rtbtools.c
+++ b/prody/dynamics/rtbtools.c
@@ -112,55 +112,55 @@ static PyObject *buildhessian(PyObject *self, PyObject *args, PyObject *kwargs) 
   hess = (double *) PyArray_DATA(hessian);
   proj = (double *) PyArray_DATA(projection);
 
+  fprintf(stderr,"initializing RTB...\n");
+
+  // /* First allocate a PDB_File object to hold the coordinates and block
+  //    indices of the atoms.  This wastes a bit of memory, but it prevents
+  //    the need to re-write all of the RTB functions that are used in
+  //    standalone C code. */
+  // PDB.atom=malloc((size_t)((natm+2)*sizeof(Atom_Line)));
+  // if(!PDB.atom) return PyErr_NoMemory();
+  // for(i=1;i<=natm;i++){
+  //   PDB.atom[i].model=BLK[i-1];
+  //   for(j=0;j<3;j++)
+  //     PDB.atom[i].X[j]=XYZ[j*natm+i-1];
+  // }
 
 
-  /* First allocate a PDB_File object to hold the coordinates and block
-     indices of the atoms.  This wastes a bit of memory, but it prevents
-     the need to re-write all of the RTB functions that are used in
-     standalone C code. */
-  PDB.atom=malloc((size_t)((natm+2)*sizeof(Atom_Line)));
-  if(!PDB.atom) return PyErr_NoMemory();
-  for(i=1;i<=natm;i++){
-    PDB.atom[i].model=BLK[i-1];
-    for(j=0;j<3;j++)
-      PDB.atom[i].X[j]=XYZ[j*natm+i-1];
-  }
+
+  // /* Find the projection matrix */
+  // hsize = 18*bmx*nblx > 12*natm ? 12*natm : 18*bmx*nblx;
+  // HH.IDX=imatrix(1,hsize,1,2);
+  // HH.X=dvector(1,hsize);
+  // elm=dblock_projections2(&HH,&PDB,natm,nblx,bmx);
+  // PP.IDX=imatrix(1,elm,1,2);
+  // PP.X=dvector(1,elm);
+  // for(i=1;i<=elm;i++){
+  //   PP.IDX[i][1]=HH.IDX[i][1];
+  //   PP.IDX[i][2]=HH.IDX[i][2];
+  //   PP.X[i]=HH.X[i];
+  // }
+  // free_imatrix(HH.IDX,1,hsize,1,2);
+  // free_dvector(HH.X,1,hsize);
+  // dsort_PP2(&PP,elm,1);
 
 
-
-  /* Find the projection matrix */
-  hsize = 18*bmx*nblx > 12*natm ? 12*natm : 18*bmx*nblx;
-  HH.IDX=imatrix(1,hsize,1,2);
-  HH.X=dvector(1,hsize);
-  elm=dblock_projections2(&HH,&PDB,natm,nblx,bmx);
-  PP.IDX=imatrix(1,elm,1,2);
-  PP.X=dvector(1,elm);
-  for(i=1;i<=elm;i++){
-    PP.IDX[i][1]=HH.IDX[i][1];
-    PP.IDX[i][2]=HH.IDX[i][2];
-    PP.X[i]=HH.X[i];
-  }
-  free_imatrix(HH.IDX,1,hsize,1,2);
-  free_dvector(HH.X,1,hsize);
-  dsort_PP2(&PP,elm,1);
+  // /* Calculate the block Hessian */
+  // HB=dmatrix(1,6*nblx,1,6*nblx);
+  // bdim=calc_blessian_mem(&PDB,&PP,natm,nblx,elm,HB,cutoff,gamma,scl,mlo,mhi);
 
 
-  /* Calculate the block Hessian */
-  HB=dmatrix(1,6*nblx,1,6*nblx);
-  bdim=calc_blessian_mem(&PDB,&PP,natm,nblx,elm,HB,cutoff,gamma,scl,mlo,mhi);
+  // /* Cast the block Hessian and projection matrix into 1D arrays. */
+  // copy_prj_ofst(&PP,proj,elm,bdim);
+  // for(i=1;i<=bdim;i++)
+  //   for(j=1;j<=bdim;j++)
+  //     hess[bdim*(i-1)+j-1]=HB[i][j];
 
 
-  /* Cast the block Hessian and projection matrix into 1D arrays. */
-  copy_prj_ofst(&PP,proj,elm,bdim);
-  for(i=1;i<=bdim;i++)
-    for(j=1;j<=bdim;j++)
-      hess[bdim*(i-1)+j-1]=HB[i][j];
-
-
-  free(PDB.atom);
-  free_imatrix(PP.IDX,1,elm,1,2);
-  free_dvector(PP.X,1,elm);
-  free_dmatrix(HB,1,6*nblx,1,6*nblx);
+  // free(PDB.atom);
+  // free_imatrix(PP.IDX,1,elm,1,2);
+  // free_dvector(PP.X,1,elm);
+  // free_dmatrix(HB,1,6*nblx,1,6*nblx);
 
 
   Py_RETURN_NONE;

--- a/prody/dynamics/rtbtools.c
+++ b/prody/dynamics/rtbtools.c
@@ -113,7 +113,7 @@ static PyObject *buildhessian(PyObject *self, PyObject *args, PyObject *kwargs) 
   hess = (double *) PyArray_DATA(hessian);
   proj = (double *) PyArray_DATA(projection);
 
-  printf("cutoff = %f\n", cutoff);
+  // printf("cutoff = %f\n", cutoff);
 
   /* First allocate a PDB_File object to hold the coordinates and block
      indices of the atoms.  This wastes a bit of memory, but it prevents
@@ -123,7 +123,7 @@ static PyObject *buildhessian(PyObject *self, PyObject *args, PyObject *kwargs) 
   if (!PDB.atom) return PyErr_NoMemory();
   for (i=1; i<=natm; i++){
     PDB.atom[i].model = BLK[i-1];
-    printf("%d: %d\n", i, BLK[i-1]);
+    // printf("%d: %d\n", i, BLK[i-1]);
     for(j=0; j<3; j++)
       PDB.atom[i].X[j] = XYZ[j*natm+i-1];
   }
@@ -131,12 +131,12 @@ static PyObject *buildhessian(PyObject *self, PyObject *args, PyObject *kwargs) 
 
   /* Find the projection matrix */
   hsize = 18*bmx*nblx > 12*natm ? 12*natm : 18*bmx*nblx;
-  printf("hsize = %d\n", hsize);
+  // printf("hsize = %d\n", hsize);
 
   HH.IDX = imatrix(1, hsize, 1, 2);
   HH.X = dvector(1, hsize);
   elm = dblock_projections2(&HH, &PDB, natm, nblx, bmx);
-  printf("elm = %d\n", elm);
+  // printf("elm = %d\n", elm);
 
   PP.IDX = imatrix(1, elm, 1, 2);
   PP.X = dvector(1, elm);
@@ -161,9 +161,9 @@ static PyObject *buildhessian(PyObject *self, PyObject *args, PyObject *kwargs) 
     for (j=1; j<=bdim; j++)
       hess[bdim*(i-1)+j-1] = HB[i][j];
 
-  double s;
-  s = sum(hess, bdim*bdim);
-  printf("hess = %f\n", s);
+  // double s;
+  // s = sum(hess, bdim*bdim);
+  // printf("hess = %f\n", s);
 
   free(PDB.atom);
   free_imatrix(PP.IDX, 1, elm, 1, 2);
@@ -390,15 +390,15 @@ void copy_prj_ofst(dSparse_Matrix *PP, double *proj, int elm, int bdim)
     I2[i]=j;
   }
 
-  double s = 0;
+  // double s = 0;
   for(i=1; i<=elm; i++)
     if(PP->X[i] != 0.0)
     {
       proj[bdim*(PP->IDX[i][1]-1) + I2[PP->IDX[i][2]]-1] = PP->X[i];
-      s += PP->X[i];
+      // s += PP->X[i];
     }
 
-  printf("proj = %f\n", s);
+  // printf("proj = %f\n", s);
 
   free_ivector(I1, 1, max);
   free_ivector(I2, 1, max);

--- a/prody/dynamics/rtbtools.c
+++ b/prody/dynamics/rtbtools.c
@@ -114,53 +114,53 @@ static PyObject *buildhessian(PyObject *self, PyObject *args, PyObject *kwargs) 
 
   fprintf(stderr,"initializing RTB...\n");
 
-  // /* First allocate a PDB_File object to hold the coordinates and block
-  //    indices of the atoms.  This wastes a bit of memory, but it prevents
-  //    the need to re-write all of the RTB functions that are used in
-  //    standalone C code. */
-  // PDB.atom=malloc((size_t)((natm+2)*sizeof(Atom_Line)));
-  // if(!PDB.atom) return PyErr_NoMemory();
-  // for(i=1;i<=natm;i++){
-  //   PDB.atom[i].model=BLK[i-1];
-  //   for(j=0;j<3;j++)
-  //     PDB.atom[i].X[j]=XYZ[j*natm+i-1];
-  // }
+  /* First allocate a PDB_File object to hold the coordinates and block
+     indices of the atoms.  This wastes a bit of memory, but it prevents
+     the need to re-write all of the RTB functions that are used in
+     standalone C code. */
+  PDB.atom=malloc((size_t)((natm+2)*sizeof(Atom_Line)));
+  if(!PDB.atom) return PyErr_NoMemory();
+  for(i=1;i<=natm;i++){
+    PDB.atom[i].model=BLK[i-1];
+    for(j=0;j<3;j++)
+      PDB.atom[i].X[j]=XYZ[j*natm+i-1];
+  }
 
 
 
-  // /* Find the projection matrix */
-  // hsize = 18*bmx*nblx > 12*natm ? 12*natm : 18*bmx*nblx;
-  // HH.IDX=imatrix(1,hsize,1,2);
-  // HH.X=dvector(1,hsize);
-  // elm=dblock_projections2(&HH,&PDB,natm,nblx,bmx);
-  // PP.IDX=imatrix(1,elm,1,2);
-  // PP.X=dvector(1,elm);
-  // for(i=1;i<=elm;i++){
-  //   PP.IDX[i][1]=HH.IDX[i][1];
-  //   PP.IDX[i][2]=HH.IDX[i][2];
-  //   PP.X[i]=HH.X[i];
-  // }
-  // free_imatrix(HH.IDX,1,hsize,1,2);
-  // free_dvector(HH.X,1,hsize);
-  // dsort_PP2(&PP,elm,1);
+  /* Find the projection matrix */
+  hsize = 18*bmx*nblx > 12*natm ? 12*natm : 18*bmx*nblx;
+  HH.IDX=imatrix(1,hsize,1,2);
+  HH.X=dvector(1,hsize);
+  elm=dblock_projections2(&HH,&PDB,natm,nblx,bmx);
+  PP.IDX=imatrix(1,elm,1,2);
+  PP.X=dvector(1,elm);
+  for(i=1;i<=elm;i++){
+    PP.IDX[i][1]=HH.IDX[i][1];
+    PP.IDX[i][2]=HH.IDX[i][2];
+    PP.X[i]=HH.X[i];
+  }
+  free_imatrix(HH.IDX,1,hsize,1,2);
+  free_dvector(HH.X,1,hsize);
+  dsort_PP2(&PP,elm,1);
 
 
-  // /* Calculate the block Hessian */
-  // HB=dmatrix(1,6*nblx,1,6*nblx);
-  // bdim=calc_blessian_mem(&PDB,&PP,natm,nblx,elm,HB,cutoff,gamma,scl,mlo,mhi);
+  /* Calculate the block Hessian */
+  HB=dmatrix(1,6*nblx,1,6*nblx);
+  bdim=calc_blessian_mem(&PDB,&PP,natm,nblx,elm,HB,cutoff,gamma,scl,mlo,mhi);
 
 
-  // /* Cast the block Hessian and projection matrix into 1D arrays. */
-  // copy_prj_ofst(&PP,proj,elm,bdim);
-  // for(i=1;i<=bdim;i++)
-  //   for(j=1;j<=bdim;j++)
-  //     hess[bdim*(i-1)+j-1]=HB[i][j];
+  /* Cast the block Hessian and projection matrix into 1D arrays. */
+  copy_prj_ofst(&PP,proj,elm,bdim);
+  for(i=1;i<=bdim;i++)
+    for(j=1;j<=bdim;j++)
+      hess[bdim*(i-1)+j-1]=HB[i][j];
 
 
-  // free(PDB.atom);
-  // free_imatrix(PP.IDX,1,elm,1,2);
-  // free_dvector(PP.X,1,elm);
-  // free_dmatrix(HB,1,6*nblx,1,6*nblx);
+  free(PDB.atom);
+  free_imatrix(PP.IDX,1,elm,1,2);
+  free_dvector(PP.X,1,elm);
+  free_dmatrix(HB,1,6*nblx,1,6*nblx);
 
 
   Py_RETURN_NONE;

--- a/prody/dynamics/rtbtools.c
+++ b/prody/dynamics/rtbtools.c
@@ -123,6 +123,7 @@ static PyObject *buildhessian(PyObject *self, PyObject *args, PyObject *kwargs) 
   if (!PDB.atom) return PyErr_NoMemory();
   for (i=1; i<=natm; i++){
     PDB.atom[i].model = BLK[i-1];
+    printf("%d: %ld\n", i, BLK[i-1]);
     for(j=0; j<3; j++)
       PDB.atom[i].X[j] = XYZ[j*natm+i-1];
   }
@@ -448,7 +449,6 @@ int dblock_projections2(dSparse_Matrix *PP, PDB_File *PDB,
   A = dmatrix(1, 3, 1, 3);
   ISQT = dmatrix(1, 3, 1, 3);
 
-  printf("nblx = %d\n", nblx);
   /* CYCLE THROUGH BLOCKS */
   for(b=1; b<=nblx; b++)
   {
@@ -521,7 +521,8 @@ int dblock_projections2(dSparse_Matrix *PP, PDB_File *PDB,
 
     /* UPDATE PP WITH THE RIGID MOTIONS OF THE BLOCK */
     tr = 1.0 / sqrt((double)nbp);
-    printf("nbp = %d\n", nbp);
+    // printf("nbp = %d\n", nbp);
+
     for (i=1; i<=nbp; i++)
     {
 

--- a/prody/dynamics/rtbtools.c
+++ b/prody/dynamics/rtbtools.c
@@ -1202,7 +1202,7 @@ void deigsrt(double d[], double **v, int n)
 double sum(double *a, int n)
 {
   int i;
-  double s;
+  double s = 0;
   for (i=0; i<n; i++)
     s += a[i];
 

--- a/prody/dynamics/rtbtools.c
+++ b/prody/dynamics/rtbtools.c
@@ -92,7 +92,7 @@ static PyObject *buildhessian(PyObject *self, PyObject *args, PyObject *kwargs) 
   dSparse_Matrix PP, HH;
   PyArrayObject *coords, *blocks, *hessian, *projection;
   double *XYZ, *hess, *proj;
-  long *BLK;
+  int *BLK;
   double **HB;
   double cutoff = 15., gamma = 1., scl=1., mlo=1., mhi=-1.;
   int natm, nblx, bmx;
@@ -109,7 +109,7 @@ static PyObject *buildhessian(PyObject *self, PyObject *args, PyObject *kwargs) 
     return NULL;
 
   XYZ = (double *) PyArray_DATA(coords);
-  BLK = (long *) PyArray_DATA(blocks);
+  BLK = (int *) PyArray_DATA(blocks);
   hess = (double *) PyArray_DATA(hessian);
   proj = (double *) PyArray_DATA(projection);
 
@@ -123,7 +123,7 @@ static PyObject *buildhessian(PyObject *self, PyObject *args, PyObject *kwargs) 
   if (!PDB.atom) return PyErr_NoMemory();
   for (i=1; i<=natm; i++){
     PDB.atom[i].model = BLK[i-1];
-    printf("%d: %ld\n", i, BLK[i-1]);
+    printf("%d: %d\n", i, BLK[i-1]);
     for(j=0; j<3; j++)
       PDB.atom[i].X[j] = XYZ[j*natm+i-1];
   }

--- a/prody/dynamics/rtbtools.c
+++ b/prody/dynamics/rtbtools.c
@@ -993,9 +993,10 @@ void free_d3tensor(double ***t, long nrl, long nrh, long ncl, long nch,
 void dsvdcmp(double **a, int m, int n, double w[], double **v)
 {
 	double dpythag(double a, double b);
-	int flag,i,its,j,jj,k,l,nm;
-	double anorm,c,f,g,h,s,scale,x,y,z,*rv1;
-	static int maxits=100;
+	int flag, i, its, j, jj, k, l;
+  int nm = 0;
+	double anorm, c, f, g, h, s, scale, x, y, z, *rv1;
+	static int maxits = 100;
 
 	rv1=dvector(1,n);
 	g=scale=anorm=0.0;


### PR DESCRIPTION
C `long` on Windows 64-bit is a 32-bit integer type. So added data type conversion to int32 numpy array in the RTB module to make sure the consistency across platforms. 

In addition, added code to explicitly ensure the `coords` array is in 'C' order.