### PR TITLE
added missing checks to reorderMatrix

### DIFF
--- a/prody/utilities/catchall.py
+++ b/prody/utilities/catchall.py
@@ -495,25 +495,14 @@ def reorderMatrix(matrix, tree, names=None):
     if np.shape(matrix)[0] != np.shape(matrix)[1]:
         raise ValueError('matrix should be a square matrix')
 
-    no_names = False
     if names is None:
-        no_names = True
-        names = [str(i) for i in range(len(matrix))]
+        raise ValueError('names must be provided')
 
     if np.isscalar(names):
         raise TypeError('names should be list-like')
     
     if not isinstance(names[0], str):
         raise TypeError('names should be a list-like of strings')
-
-    try:
-        terminal_names = [terminal.name for terminal in tree.get_terminals()]
-        _ = np.where(np.array(terminal_names) == names[0])[0][0]
-    except:
-        if no_names:
-            raise ValueError("names must be provided as indices don't work with this tree")
-        else:
-            raise ValueError("names contains entries that don't match those in the tree")
 
     if not isinstance(tree, Phylo.BaseTree.Tree):
         raise TypeError('tree should be a BioPython Tree')

--- a/prody/utilities/catchall.py
+++ b/prody/utilities/catchall.py
@@ -495,8 +495,25 @@ def reorderMatrix(matrix, tree, names=None):
     if np.shape(matrix)[0] != np.shape(matrix)[1]:
         raise ValueError('matrix should be a square matrix')
 
-    if not names:
+    no_names = False
+    if names is None:
+        no_names = True
         names = [str(i) for i in range(len(matrix))]
+
+    if np.isscalar(names):
+        raise TypeError('names should be list-like')
+    
+    if not isinstance(names[0], str):
+        raise TypeError('names should be a list-like of strings')
+
+    try:
+        terminal_names = [terminal.name for terminal in tree.get_terminals()]
+        _ = np.where(np.array(terminal_names) == names[0])[0][0]
+    except:
+        if no_names:
+            raise ValueError("names must be provided as indices don't work with this tree")
+        else:
+            raise ValueError("names contains entries that don't match those in the tree")
 
     if not isinstance(tree, Phylo.BaseTree.Tree):
         raise TypeError('tree should be a BioPython Tree')

--- a/prody/utilities/catchall.py
+++ b/prody/utilities/catchall.py
@@ -464,7 +464,7 @@ def showMatrix(matrix, x_array=None, y_array=None, **kwargs):
 
     return im, lines, cb
 
-def reorderMatrix(matrix, tree, names=None):
+def reorderMatrix(matrix, tree, names):
     """
     Reorder a matrix based on a tree and return the reordered matrix 
     and indices for reordering other things.
@@ -494,9 +494,6 @@ def reorderMatrix(matrix, tree, names=None):
 
     if np.shape(matrix)[0] != np.shape(matrix)[1]:
         raise ValueError('matrix should be a square matrix')
-
-    if names is None:
-        raise ValueError('names must be provided')
 
     if np.isscalar(names):
         raise TypeError('names should be list-like')


### PR DESCRIPTION
reorderMatrix needs names that can be found on the tree in the order that corresponds to the input matrix. If none are provided then it generates a list of indices converted to strings ('1', '2', '3', ...), which in most cases doesn't help. We therefore get an error when we don't provide names when the step that searches for the names in the tree fails. I instead made it so that we get an error if no names are provided as well as type checks, which were missing.