### PR TITLE
bug fix for indexing trajectories in python 3

### DIFF
--- a/prody/trajectory/trajectory.py
+++ b/prody/trajectory/trajectory.py
@@ -4,6 +4,7 @@
 import os.path
 
 import numpy as np
+from numbers import Integral
 
 from .trajbase import TrajBase
 from .frame import Frame
@@ -219,7 +220,7 @@ class Trajectory(TrajBase):
 
         if self._closed:
             raise ValueError('I/O operation on closed file')
-        if not isinstance(n, int):
+        if not isinstance(n, Integral):
             raise ValueError('n must be an integer')
         n_csets = self._n_csets
         if n == 0:
@@ -247,7 +248,7 @@ class Trajectory(TrajBase):
 
         if self._closed:
             raise ValueError('I/O operation on closed file')
-        if not isinstance(n, int):
+        if not isinstance(n, Integral):
             raise ValueError('n must be an integer')
         left = self._n_csets - self._nfi
         if n > left:


### PR DESCRIPTION
This now fixes #862. The problem is that Python 3 handles slices differently and gets np.int64 from them not standard int.