### PR TITLE
bug fix to showProtein with mode and scale

### DIFF
--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -209,7 +209,7 @@ def showProtein(*atoms, **kwargs):
 
     method = kwargs.pop('draw', None)
     modes = kwargs.pop('mode', None)
-    scale = kwargs.get('scale', 100)
+    scale = kwargs.pop('scale', 100)
 
     # modes need to be specifically a list or a tuple (cannot be an array)
     if modes is None:

--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -208,7 +208,7 @@ def showProtein(*atoms, **kwargs):
     from prody.dynamics.mode import Mode
 
     method = kwargs.pop('draw', None)
-    modes = kwargs.get('mode', None)
+    modes = kwargs.pop('mode', None)
     scale = kwargs.get('scale', 100)
 
     # modes need to be specifically a list or a tuple (cannot be an array)

--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -117,6 +117,7 @@ def view3D(*alist, **kwargs):
                 is3d = mode.is3d()
             except AttributeError:
                 arr = mode
+                is3d = len(arr) == atoms.calpha.numAtoms()*3
 
             if is3d:
                 if atoms.calpha.numAtoms()*3 != len(arr):
@@ -208,8 +209,8 @@ def showProtein(*atoms, **kwargs):
     from prody.dynamics.mode import Mode
 
     method = kwargs.pop('draw', None)
-    modes = kwargs.pop('mode', None)
-    scale = kwargs.pop('scale', 100)
+    modes = kwargs.get('mode', None)
+    scale = kwargs.get('scale', 100)
 
     # modes need to be specifically a list or a tuple (cannot be an array)
     if modes is None:
@@ -239,6 +240,9 @@ def showProtein(*atoms, **kwargs):
         mol = view3D(*alist, **kwargs)
         return mol
     else:
+        kwargs.pop('mode', None)
+        kwargs.pop('scale', 100)
+
         import matplotlib.pyplot as plt
         from mpl_toolkits.mplot3d import Axes3D
         cf = plt.gcf()

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -554,10 +554,12 @@ def bin2dec(x):
 
 
 def wrapModes(modes):
-    try:
-        arr = modes.getArray()
-        modes = [arr]
-    except AttributeError:
+    if hasattr(modes, 'getArray'):
+        try:
+            modes = [mode for mode in modes]
+        except TypeError:
+            modes = [modes]
+    else:
         if isscalar(modes[0]):
             modes = [modes]
     return modes


### PR DESCRIPTION
Otherwise, we get the following:

```
In [8]: showProtein(kg2, mode=anm[0])
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-8-30ce98251e8d> in <module>()
----> 1 showProtein(kg2, mode=anm[0])

/data/jkrieger/programs/ProDy/prody/proteins/functions.pyc in showProtein(*atoms, **kwargs)
    333                             xyz2 = XYZ2[i]
    334                             mutation_scale = kwargs.pop('mutation_scale', 10)
--> 335                             drawArrow3D(xyz, xyz2, mutation_scale=mutation_scale, **kwargs)
    336 
    337             water = atoms.select('water and noh')

/data/jkrieger/programs/ProDy/prody/utilities/drawtools.pyc in drawArrow3D(*xyz, **kwargs)
     46         kwargs['color'] = 'k'
     47 
---> 48     arrow = Arrow3D(xs, ys, zs, *args, **kwargs)
     49     ax.add_artist(arrow)
     50     return arrow

/data/jkrieger/programs/ProDy/prody/utilities/drawtools.pyc in __init__(self, xs, ys, zs, *args, **kwargs)
     14     https://stackoverflow.com/a/29188796."""
     15     def __init__(self, xs, ys, zs, *args, **kwargs):
---> 16         super(Arrow3D, self).__init__((0,0), (0,0), *args, **kwargs)
     17         self._verts3d = xs, ys, zs
     18 

/data/jkrieger/programs/anaconda2/lib/python2.7/site-packages/matplotlib/patches.pyc in __init__(self, posA, posB, path, arrowstyle, arrow_transmuter, connectionstyle, connector, patchA, patchB, shrinkA, shrinkB, mutation_scale, mutation_aspect, dpi_cor, **kwargs)
   4114         %(Patch)s
   4115         """
-> 4116         Patch.__init__(self, **kwargs)
   4117 
   4118         if posA is not None and posB is not None and path is None:

/data/jkrieger/programs/anaconda2/lib/python2.7/site-packages/matplotlib/patches.pyc in __init__(self, edgecolor, facecolor, color, linewidth, linestyle, antialiased, hatch, fill, capstyle, joinstyle, **kwargs)
    101 
    102         if len(kwargs):
--> 103             self.update(kwargs)
    104 
    105     def get_verts(self):

/data/jkrieger/programs/anaconda2/lib/python2.7/site-packages/matplotlib/artist.pyc in update(self, props)
    886         try:
    887             ret = [_update_property(self, k, v)
--> 888                    for k, v in props.items()]
    889         finally:
    890             self.eventson = store

/data/jkrieger/programs/anaconda2/lib/python2.7/site-packages/matplotlib/artist.pyc in _update_property(self, k, v)
    879                 func = getattr(self, 'set_' + k, None)
    880                 if not callable(func):
--> 881                     raise AttributeError('Unknown property %s' % k)
    882                 return func(v)
    883 

AttributeError: Unknown property mode

```