### PR TITLE
make sure on MacOSX C extensions are compiled using clang compilers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,8 @@ EXTENSIONS = [
 extra_compile_args = []
 if platform.system() == 'Darwin':
     os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.9'
+    os.environ['CC'] = 'clang'
+    os.environ['CXX'] = 'clang++'
     extra_compile_args.append('-stdlib=libc++')
 
 CONTRIBUTED = [


### PR DESCRIPTION
I just came across this commit in my old master. I don't know if it's helpful or not. We still need to find a way of checking what compilers are on the system and not just depend on system type. 