### PR TITLE
bug fix to matchModes 

### DIFF
--- a/prody/dynamics/compare.py
+++ b/prody/dynamics/compare.py
@@ -375,7 +375,7 @@ def matchModes(*modesets, **kwargs):
     if index:
         try:
             ret = [modeset0.getIndices()]
-        except:
+        except AttributeError:
             ret = [list(range(modeset0.numModes()))] # If modeset0 is not a modeset
     else:
         ret = [modeset0]

--- a/prody/dynamics/compare.py
+++ b/prody/dynamics/compare.py
@@ -373,10 +373,7 @@ def matchModes(*modesets, **kwargs):
 
     modeset0 = modesets[0]
     if index:
-        try:
-            ret = [modeset0.getIndices()]
-        except AttributeError:
-            ret = [list(range(modeset0.numModes()))] # If modeset0 is not a modeset
+        ret = [modeset0.getIndices()]
     else:
         ret = [modeset0]
 

--- a/prody/dynamics/compare.py
+++ b/prody/dynamics/compare.py
@@ -373,7 +373,10 @@ def matchModes(*modesets, **kwargs):
 
     modeset0 = modesets[0]
     if index:
-        ret = [modeset0.getIndices()]
+        try:
+            ret = [modeset0.getIndices()]
+        except:
+            ret = [list(range(modeset0.numModes()))] # If modeset0 is not a modeset
     else:
         ret = [modeset0]
 

--- a/prody/dynamics/nma.py
+++ b/prody/dynamics/nma.py
@@ -309,4 +309,10 @@ class NMA(object):
 
         self._clear()
 
+    def getIndices(self):
+      if self._indices is not None:
+        return self._indices
+      else:
+        return np.arange(self.numModes())
+
 


### PR DESCRIPTION
so we can get indices without starting with modesets

Before, it would fail because ANM objects don't have getIndices. Now it can cope with that.