### PR TITLE
bug fix to calcSubfamilySpectralOverlaps

### DIFF
--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -1905,7 +1905,6 @@ def calcSubfamilySpectralOverlaps(mode_ens, subfamily_dict, **kwargs):
 
     N_group = len(reverse_dict)
 
-    subfamilies = np.array(reverse_dict.keys())
     subfamily_overlap_matrix = []
     for subfamily_i in subfamilies:
         index_i = reverse_dict[subfamily_i]

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -1939,7 +1939,7 @@ def showSubfamilySpectralOverlaps(mode_ens, subfamily_dict, **kwargs):
     subfamily_overlap_matrix, subfamilies = calcSubfamilySpectralOverlaps(mode_ens, subfamily_dict, **kwargs)
     show = showMatrix(subfamily_overlap_matrix, origin='lower',
                       xticklabels=subfamilies, yticklabels=subfamilies,
-                      vmin=0., vmax=1.6)
+                      allticks=True, vmin=0., vmax=1.6)
 
     show_subfamily_bar = kwargs.get('show_subfamily_bar',False)
     text = kwargs.pop('text',False)

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -1908,10 +1908,10 @@ def calcSubfamilySpectralOverlaps(mode_ens, subfamily_dict, **kwargs):
     subfamily_overlap_matrix = []
     for subfamily_i in subfamilies:
         index_i = reverse_dict[subfamily_i]
-        for temp_cath_j in subfamilies:
-            index_j = reverse_dict[temp_cath_j]
+        for subfamily_j in subfamilies:
+            index_j = reverse_dict[subfamily_j]
             temp_sub_matrix = distm[np.ix_(index_i, index_j)]
-            if subfamily_i == temp_cath_j:
+            if subfamily_i == subfamily_j:
                 subfamily_overlap_matrix.append(temp_sub_matrix[np.triu_indices(
                     np.shape(temp_sub_matrix)[0])].mean())
             else:


### PR DESCRIPTION
The line I deleted is redundant because subfamilies are already defined above and problematic because of the python3 dict_keys type object not splitting into entries in the array.