### PR TITLE
bug fix to mapChainByChain handling flexible cases

### DIFF
--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -1087,8 +1087,8 @@ def mapChainByChain(atoms, ref, **kwargs):
             i = corr_ref.index(chain.getChid())
             chid = corr_tar[i]
         except ValueError:
-            pass
-            #chid = chain.getChid()
+            continue
+
         for target_chain in chs_atm:
             if target_chain.getChid() == chid:
                 mappings_ = mapOntoChainByAlignment(target_chain, chain, **kwargs)


### PR DESCRIPTION
The previous code passes the assignment of chid so that the previous value of chid is used in the next code block. The fix is that we continue on to the next round of the loop and don't run that code at all if no match is found. 