### PR TITLE
set default behaviour of _parseEMDLines based on n_nodes

### DIFF
--- a/prody/proteins/emdfile.py
+++ b/prody/proteins/emdfile.py
@@ -91,14 +91,20 @@ def parseEMD(emd, **kwargs):
 
     return result
 
-def _parseEMDLines(atomgroup, stream, cutoff=None, n_nodes=1000, num_iter=20, map=True, make_nodes=False):
+def _parseEMDLines(atomgroup, stream, cutoff=None, n_nodes=0, num_iter=20, map=False, make_nodes=False):
     """ Returns an AtomGroup. see also :func:`.parseEMDStream()`.
 
     :arg stream: stream from parser.
     """
 
-    if not n_nodes > 0:
-        raise ValueError('n_nodes should be larger than 0')
+    if not isinstance(n_nodes, int):
+        raise TypeError('n_nodes should be an integer')
+        
+    if n_nodes > 0:
+        make_nodes = True
+    else:
+        map = True
+        LOGGER.info('As n_nodes is less than or equal to 0, no nodes will be made and the raw map will be returned')
 
     emd = EMDMAP(stream, cutoff)
 

--- a/prody/proteins/emdfile.py
+++ b/prody/proteins/emdfile.py
@@ -190,7 +190,7 @@ def parseEMDStream(stream, **kwargs):
 
     if make_nodes:
         if map:
-            return emd, atomgroup
+            return atomgroup, emd
         else:
             return atomgroup
     else:


### PR DESCRIPTION
If no kwargs are provided to parseEMD then the default values for _parseEMDLines mean that we return the raw EMD map but if the user sets n_nodes > 0 then it make nodes with TRN and does not return the EMD map unless the user specifically ask for it. 