### PR TITLE
Rework of the structure mapping functions

### DIFF
--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -520,7 +520,7 @@ class Ensemble(object):
         else:
             raise IndexError('conformation index out of range')
 
-    def superpose(self, ref=None):
+    def superpose(self, **kwargs):
         """Superpose the ensemble onto the reference coordinates.
         
         :arg ref: index of the reference coordinate. If **None**, the average 
@@ -528,12 +528,13 @@ class Ensemble(object):
         :type ref: int
         """
 
+        ref = kwargs.pop('ref', None)
         if self._coords is None:
             raise ValueError('coordinates are not set, use `setCoords`')
         if self._confs is None or len(self._confs) == 0:
             raise ValueError('conformations are not set, use `addCoordset`')
         LOGGER.timeit('_prody_ensemble')
-        self._superpose(ref=ref, trans=True)  # trans kwarg is used by PDBEnsemble
+        self._superpose(ref=ref)  # trans kwarg is used by PDBEnsemble
         LOGGER.report('Superposition completed in %.2f seconds.',
                       '_prody_ensemble')
 

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -6,7 +6,7 @@ from numbers import Integral
 
 import numpy as np
 
-from prody.proteins import fetchPDB, parsePDB, writePDB, mapOntoChain
+from prody.proteins import fetchPDB, parsePDB, writePDB, mapOntoChains, bestMatch
 from prody.utilities import openFile, showFigure, copy, isListLike, pystr
 from prody import LOGGER, SETTINGS
 from prody.atomic import AtomMap, Chain, AtomGroup, Selection, Segment, Select, AtomSubset
@@ -380,34 +380,34 @@ def alignPDBEnsemble(ensemble, suffix='_aligned', outdir='.', gzip=False):
 
 
 def buildPDBEnsemble(PDBs, ref=None, title='Unknown', labels=None, 
-                     mapping_func=mapOntoChain, unmapped=None, **kwargs):
+                     mapping_func=bestMatch, unmapped=None, **kwargs):
     """Builds a PDB ensemble from a given reference structure and a list of PDB structures. 
     Note that the reference structure should be included in the list as well.
 
-    :arg PDBs: A list of PDB structures
+    :arg PDBs: a list of PDB structures
     :type PDBs: iterable
 
-    :arg ref: Reference structure or the index to the reference in ``PDBs``. If **None**,
+    :arg ref: reference structure or the index to the reference in ``PDBs``. If **None**,
         then the first item in ``PDBs`` will be considered as the reference. 
         Default is **None**
     :type ref: int, :class:`.Chain`, :class:`.Selection`, or :class:`.AtomGroup`
 
-    :arg title: The title of the ensemble
+    :arg title: the title of the ensemble
     :type title: str
 
     :arg labels: labels of the conformations
     :type labels: list
 
-    :arg occupancy: Minimal occupancy of columns (range from 0 to 1). Columns whose occupancy
-        is below this value will be trimmed.
+    :arg occupancy: minimal occupancy of columns (range from 0 to 1). Columns whose occupancy
+        is below this value will be trimmed
     :type occupancy: float
 
-    :arg unmapped: A list of PDB IDs that cannot be included in the ensemble. This is an 
-        output argument. 
+    :arg unmapped: a list of PDB IDs that cannot be included in the ensemble. This is an 
+        output argument
     :type unmapped: list
 
-    :arg subset: A subset for selecting particular atoms from the input structures.
-        Default is calpha
+    :arg subset: a subset for selecting particular atoms from the input structures.
+        Default is ``"calpha"``
     :type subset: str
 
     :arg superpose: if set to ``'iter'``, :func:`.PDBEnsemble.iterpose` will be used to 

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -428,7 +428,7 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
 
     if 'mapping_func' in kwargs:
         raise DeprecationWarning('mapping_func is deprecated. Please see release notes for '
-                                 'how to adapt your code: http://prody.csb.pitt.edu/manual/release/v1.11_series.html')
+                                 'more details: http://prody.csb.pitt.edu/manual/release/v1.11_series.html')
     start = time.time()
 
     if len(atomics) == 1:

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -387,7 +387,8 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
     :type atomics: list
 
     :arg ref: reference structure or the index to the reference in *atomics*. If **None**,
-        then the first item in *atomics* will be considered as the reference. 
+        then the first item in *atomics* will be considered as the reference. If it is a 
+        :class:`.PDBEnsemble` instance, then *atomics* will be appended to the existing ensemble.
         Default is **None**
     :type ref: int, :class:`.Chain`, :class:`.Selection`, or :class:`.AtomGroup`
 
@@ -440,17 +441,12 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
 
     if ref is None:
         target = atomics[0]
-        refidx = 0
     elif isinstance(ref, Integral):
         target = atomics[ref]
-        refidx = ref
     elif isinstance(ref, PDBEnsemble):
         target = ref._atoms
     else:
         target = ref
-        if target not in atomics:
-            raise ValueError('ref should be also in atomics')
-        refidx = atomics.index(ref)
     
     # initialize a PDBEnsemble with reference atoms and coordinates
     if isinstance(ref, PDBEnsemble):
@@ -504,7 +500,7 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
         ensemble = trimPDBEnsemble(ensemble, occupancy=occupancy)
 
     if superpose != 'iter':
-        ensemble.superpose(ref=refidx)
+        ensemble.superpose()
     else:
         ensemble.iterpose()
     

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -398,6 +398,10 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
     :arg labels: labels of the conformations
     :type labels: list
 
+    :arg degeneracy: whether only the active coordinate set (**True**) or all the coordinate sets 
+        (**False**) of each structure should be added to the ensemble. Default is **True**
+    :type degeneracy: bool
+
     :arg occupancy: minimal occupancy of columns (range from 0 to 1). Columns whose occupancy
         is below this value will be trimmed
     :type occupancy: float
@@ -478,8 +482,7 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
         if subset != 'all':
             atoms = atoms.select(subset)
 
-        atommaps = []
-        # find the mapping of the atoms to each reference chain
+        # find the mapping of chains of atoms to those of target
         atommaps = alignChains(atoms, target, **kwargs)
 
         if len(atommaps) == 0:

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -426,6 +426,9 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
     superpose = kwargs.pop('superpose', 'iter')
     superpose = kwargs.pop('iterpose', superpose)
 
+    if 'mapping_func' in kwargs:
+        raise DeprecationWarning('mapping_func is deprecated. Please see release notes for '
+                                 'how to adapt your code: http://prody.csb.pitt.edu/manual/release/v1.11_series.html')
     start = time.time()
 
     if len(atomics) == 1:

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -154,6 +154,21 @@ class PDBEnsemble(Ensemble):
                 raise IndexError('invalid label: %s'%index)
         else:
             raise IndexError('invalid index')
+    
+    def superpose(self, **kwargs):
+        """Superpose the ensemble onto the reference coordinates obtained by 
+        :meth:`getCoords`.
+        """
+
+        trans = kwargs.pop('trans', True)
+        if self._coords is None:
+            raise ValueError('coordinates are not set, use `setCoords`')
+        if self._confs is None or len(self._confs) == 0:
+            raise ValueError('conformations are not set, use `addCoordset`')
+        LOGGER.timeit('_prody_ensemble')
+        self._superpose(trans=trans)  # trans kwarg is used by PDBEnsemble
+        LOGGER.report('Superposition completed in %.2f seconds.',
+                      '_prody_ensemble')
 
     def _superpose(self, **kwargs):
         """Superpose conformations and update coordinates."""

--- a/prody/measure/transform.py
+++ b/prody/measure/transform.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from prody import LOGGER
-from prody.atomic import AtomPointer
+from prody.atomic import AtomPointer, AtomMap
 from prody.utilities import importLA, checkWeights
 
 from .measure import calcCenter
@@ -119,6 +119,15 @@ def calcTransformation(mobile, target, weights=None):
 
     if mob.shape[1] != 3:
         raise ValueError('reference and target must be coordinate arrays')
+    
+    if weights is None:
+        if isinstance(mobile, AtomMap):
+            LOGGER.warn('mobile is an AtomMap instance, consider assign weights=mobile.getFlags("mapped") '
+                        'if there are dummy atoms in mobile')
+
+        if isinstance(target, AtomMap):
+            LOGGER.warn('target is an AtomMap instance, consider assign weights=target.getFlags("mapped") '
+                        'if there are dummy atoms in target')
 
     if weights is not None:
         weights = checkWeights(weights, mob.shape[0])

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -825,7 +825,7 @@ def mapOntoChain(atoms, chain, **kwargs):
     """
 
     if not isinstance(atoms, (AtomGroup, AtomSubset)):
-        raise TypeError('atoms must be an AtomGroup or a AtomSubset(Chain, '
+        raise TypeError('atoms must be an AtomGroup or a AtomSubset (Chain, '
                         'Segment, etc.) instance')
     if not isinstance(chain, Chain):
         raise TypeError('chain must be Chain instance')
@@ -1195,10 +1195,10 @@ def mapOntoChains(atoms, ref, match_func=bestMatch, **kwargs):
     """
     
     if not isinstance(atoms, (AtomGroup, AtomSubset)):
-        raise TypeError('atoms must be an AtomGroup or a AtomSubset(Chain, '
+        raise TypeError('atoms must be an AtomGroup or a AtomSubset (Chain, '
                         'Segment, etc.) instance')
     if not isinstance(ref, (AtomGroup, AtomSubset)):
-        raise TypeError('ref must be an AtomGroup or a AtomSubset(Chain, '
+        raise TypeError('ref must be an AtomGroup or a AtomSubset (Chain, '
                         'Segment, etc.) instance')
 
     subset = str(kwargs.get('subset', 'calpha')).lower()
@@ -1217,18 +1217,15 @@ def mapOntoChains(atoms, ref, match_func=bestMatch, **kwargs):
     chs_ref = [chain for chain in target.getHierView().iterChains()]
 
     # iterate through chains of both target and mobile
-    mappings = []
-    for chain in chs_ref:
+    mappings = [[None]*len(chs_atm)]*len(chs_ref)
+    for i, chain in enumerate(chs_ref):
         simple_chain = SimpleChain(chain, False)
-        for target_chain in chs_atm:
+        for j, target_chain in enumerate(chs_atm):
             if not match_func(chain, target_chain):
                 continue
 
             simple_target = SimpleChain(target_chain, False)
-            mapping = mapChainOntoChain(simple_target, simple_chain, **kwargs)
-            if mapping is not None:
-                mappings.append(mapping)
-    
+            mappings[i][j] = mapChainOntoChain(simple_target, simple_chain, **kwargs)
 
     return mappings
 

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -1504,10 +1504,7 @@ def combineAtomMaps(mappings):
         am, am_r, s, c = mappings
         return am
     
-    mappings = np.asarray(mappings)
-    
-    if mappings.ndim == 1:
-        mappings = np.array([mappings])
+    mappings = np.atleast_2d(mappings)
 
     if mappings.ndim == 2:
         m, n = mappings.shape

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -1502,7 +1502,7 @@ def combineAtomMaps(mappings, mode='optimal'):
         return am
     
     mappings = np.asarray(mappings)
-    atommaps = []
+    
     if mappings.ndim == 1:
         mappings = np.array([mappings])
 
@@ -1512,8 +1512,26 @@ def combineAtomMaps(mappings, mode='optimal'):
         for i in range(m):
             for j in range(n):
                 mapping = mappings[i, j]
-                S[i, j] = mapping[3] / 100.
-        
+                if mapping is None:
+                    S[i, j] = 0.
+                else:
+                    S[i, j] = mapping[3] / 100.
+
+        atommaps = []
+        if mode == 'optimal':
+            crrpds = multilap(1. - S)
+            for row_ind, col_ind in crrpds:
+                if len(row_ind) != m:
+                    continue
+                atommap = None
+                for r, c in zip(row_ind, col_ind):
+                    atommap_ = mappings[r, c][0]
+                    if atommap_ is None:
+                        raise ValueError('no valid mappings')
+                    if atommap is None:
+                        atommap += atommap_
+                atommaps.append(atommap)
+
     else:
         raise ValueError('mappings can only be either an 1-D or 2-D array.')
 

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -1071,8 +1071,21 @@ def mapChainOntoChain(mobile, target, **kwargs):
        *Protein engineering* **1998** 11(9):739-47.
     """
 
+    if isinstance(mobile, Chain):
+        simple_mobile = SimpleChain(mobile, False)
+    elif isinstance(mobile, SimpleChain):
+        simple_mobile = mobile
+        mobile = mobile._chain
+
+    if isinstance(target, Chain):
+        simple_target = SimpleChain(target, False)
+    elif isinstance(target, SimpleChain):
+        simple_target = target
+        target = target._chain
+
     if not isinstance(mobile, Chain):
         raise TypeError('mobile must be a Chain instance')
+
     if not isinstance(target, Chain):
         raise TypeError('target must be Chain instance')
 
@@ -1092,16 +1105,14 @@ def mapChainOntoChain(mobile, target, **kwargs):
     map_ag = mobile.getAtomGroup()
     target_ag = target.getAtomGroup()
 
-    simple_target = SimpleChain(target, False)
-    LOGGER.debug('Trying to map atoms based on residue numbers and '
-                'identities:')
-
     mapping = None
-    simple_mobile = SimpleChain(mobile, False)
     if len(simple_mobile) == 0:
         LOGGER.debug('  Skipping {0}, which does not contain any amino '
                     'acid residues.'.format(simple_mobile))
+        return mapping
     else:
+        LOGGER.debug('Trying to map atoms based on residue numbers and '
+                'identities:')
         LOGGER.debug('  Comparing {0} (len={1}) with {2}:'
                     .format(simple_mobile.getTitle(), len(simple_mobile),
                             simple_target.getTitle()))

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -498,7 +498,7 @@ def matchChains(atoms1, atoms2, **kwargs):
     """Returns pairs of chains matched based on sequence similarity.  Makes an
     all-to-all comparison of chains in *atoms1* and *atoms2*.  Chains are
     obtained from hierarchical views (:class:`.HierView`) of atom groups.
-    This function returns a list of matching chains in a tuples that contain
+    This function returns a list of matching chains in a tuple that contain
     4 items:
 
       * matching chain from *atoms1* as a :class:`.AtomMap`
@@ -1469,11 +1469,11 @@ def getCEAlignMapping(target, chain):
 
     return amatch, bmatch, n_match, n_mapped
 
-def combineAtomMaps(mappings):
+def combineAtomMaps(mappings, mode='optimal'):
     """ build a grand :class:`.AtomMap` instance based on *mappings* obtained from 
     :func:`.mapOntoChains`. The function also accepts the output :func:`.mapOntoChain` 
     but will trivially return all the :class:`.AtomMap` in *mappings*. 
-    *mappings* should be a list or an array of matching chains in a tuples that contain
+    *mappings* should be a list or an array of matching chains in a tuple that contain
     4 items:
 
       * matching chain from *atoms1* as a :class:`.AtomMap`
@@ -1482,6 +1482,12 @@ def combineAtomMaps(mappings):
         instance,
       * percent sequence identity of the match,
       * percent sequence overlap of the match.
+
+    :arg mappings: a list or an array of matching chains in a tuple, or just the tuple
+    :type mappings: tuple, list, :class:`~numpy.ndarray`
+
+    :arg mode: in what way the :class:`.AtomMap` instances should be combined.
+    :type mode: str
 
     """
 
@@ -1501,7 +1507,13 @@ def combineAtomMaps(mappings):
         mappings = np.array([mappings])
 
     if mappings.ndim == 2:
-        pass
+        m, n = mappings.shape
+        S = zeros((m, n), dtype=float)
+        for i in range(m):
+            for j in range(n):
+                mapping = mappings[i, j]
+                S[i, j] = mapping[3] / 100.
+        
     else:
         raise ValueError('mappings can only be either an 1-D or 2-D array.')
 

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -24,7 +24,7 @@ if PY3K:
     basestring = str
 
 __all__ = ['matchChains', 'matchAlign', 'mapChainOntoChain', 'mapOntoChain', 'alignChains',
-           'mapChainByChain', 'mapOntoChains', 'bestMatch', 'sameChid', 'userDefined', 
+           'mapOntoChains', 'bestMatch', 'sameChid', 'userDefined', 
            'mapOntoChainByAlignment', 'getMatchScore', 'setMatchScore',
            'getMismatchScore', 'setMismatchScore', 'getGapPenalty', 
            'setGapPenalty', 'getGapExtPenalty', 'setGapExtPenalty',
@@ -1069,80 +1069,6 @@ def mapChainOntoChain(mobile, target, **kwargs):
 
         mapping = (atommap, selection, _seqid, _cover)
     return mapping
-
-def mapChainByChain(atoms, target, **kwargs):
-    """This function is similar to :func:`.mapOntoChain` but correspondence 
-    of chains is found by their chain identifiers. 
-    
-    :arg atoms: atoms to be mapped onto *target*
-    :type atoms: :class:`.Atomic`
-    
-    :arg target: reference structure for mapping
-    :type target: :class:`.Atomic`
-    
-    :arg return_all: whether to return all mappings.
-        If False, only mappings for the first chain will be returned. 
-        Default is **True**
-    :arg return_all: bool
-
-    :arg correspondence: chain IDs in atoms corresponding to those in ref
-        Default is to use the same chain IDs as in ref.
-    :type correspondence: str, list, dict
-    """
-
-    mappings = []
-
-    if isinstance(target, AtomGroup):
-        chs_ref_ag = target.iterChains()
-    else:
-        chs_ref_ag = target.getAtomGroup().iterChains()
-
-    id_atm = atoms.getTitle()
-    id_ref = target.getTitle()
-    
-    chs_atm = [chain for chain in atoms.getHierView().iterChains()]
-    chs_ref = [chain for chain in target.getHierView().iterChains()]
-
-    corr_input = kwargs.get('correspondence', None)
-
-    if isinstance(corr_input, dict):
-        correspondence = corr_input
-    elif corr_input is None:
-        correspondence = {}
-    elif isinstance(corr_input, str):
-        correspondence = {}
-        correspondence[atoms.getTitle()] = corr_input
-    else:
-        correspondence = {}
-        try:
-            correspondence[id_atm] = corr_input[0]
-            correspondence[id_ref] = corr_input[1]
-        except (IndexError, TypeError):
-            raise TypeError('correspondence should be a dict with keys being titles of atoms and ref, '
-                            'and values are str indicating chID correspondences')
-
-    if not id_atm in correspondence:
-        correspondence[id_atm] = ''.join([chain.getChid() for chain in chs_atm])
-
-    if not id_ref in correspondence:
-        correspondence[id_ref] = ''.join([chain.getChid() for chain in chs_ref_ag])
-
-    corr_tar = correspondence[id_atm]
-    corr_ref = correspondence[id_ref]
-    for chain in chs_ref:
-        try:
-            i = corr_ref.index(chain.getChid())
-            chid = corr_tar[i]
-        except ValueError:
-            continue
-
-        for target_chain in chs_atm:
-            if target_chain.getChid() == chid:
-                mappings_ = mapOntoChainByAlignment(target_chain, chain, **kwargs)
-                if len(mappings_):
-                    mappings.append(mappings_[0])
-        
-    return mappings
 
 def userDefined(chain1, chain2, correspondence):
     id1 = chain1.getTitle()

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -23,7 +23,7 @@ if PY2K:
 if PY3K:
     basestring = str
 
-__all__ = ['matchChains', 'matchAlign', 'mapChainOntoChain', 'mapOntoChain', 
+__all__ = ['matchChains', 'matchAlign', 'mapChainOntoChain', 'mapOntoChain', 'alignChains',
            'mapChainByChain', 'mapOntoChains', 'bestMatch', 'sameChid', 'combineAtomMaps',
            'mapOntoChainByAlignment', 'getMatchScore', 'setMatchScore',
            'getMismatchScore', 'setMismatchScore', 'getGapPenalty', 
@@ -1525,11 +1525,11 @@ def combineAtomMaps(mappings, ret_info=False):
                 continue
             atommap = None
             for r, c in zip(row_ind, col_ind):
-                if mappings[r, c] is None: # unlikely to happen
-                    continue
+                # if one of the chains failed to match then discard the entire atommap
+                if mappings[r, c] is None: 
+                    atommap = None
+                    break
                 atommap_ = mappings[r, c][0]
-                if atommap_ is None:
-                    raise ValueError('no valid mappings')
                 if atommap is None:
                     atommap = atommap_
                 else:
@@ -1542,7 +1542,7 @@ def combineAtomMaps(mappings, ret_info=False):
     if ret_info:
         return atommaps, S, crrpds
     else:
-        atommaps
+        return atommaps
 
 def alignChains(atoms, target, match_func=bestMatch, **kwargs):
     """Aligns chains of *atoms* to those of *target* using :func:`.mapOntoChains` 

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -1029,19 +1029,19 @@ def mapChainByChain(atoms, ref, **kwargs):
     of chains is found by their chain identifiers. 
     
     :arg atoms: atoms to map onto the reference
-    :type atoms: :class:`Atomic`
+    :type atoms: :class:`.Atomic`
     
     :arg ref: reference structure for mapping
-    :type ref: :class:`Atomic`
+    :type ref: :class:`.Atomic`
     
     :arg return_all: whether to return all mappings.
         If False, only mappings for the first chain will be returned. 
-        Default is True
+        Default is **True**
     :arg return_all: bool
 
     :arg correspondence: chain IDs in atoms corresponding to those in ref
         Default is to use the same chain IDs as in ref.
-    :type correspondence: str, list, tuple, :class:`~numpy.ndarray`, dict
+    :type correspondence: str, list, dict
     """
     mappings = []
 

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -24,11 +24,11 @@ if PY3K:
     basestring = str
 
 __all__ = ['matchChains', 'matchAlign', 'mapChainOntoChain', 'mapOntoChain', 'alignChains',
-           'mapChainByChain', 'mapOntoChains', 'bestMatch', 'sameChid', 'combineAtomMaps',
+           'mapChainByChain', 'mapOntoChains', 'bestMatch', 'sameChid', 'userDefined', 
            'mapOntoChainByAlignment', 'getMatchScore', 'setMatchScore',
            'getMismatchScore', 'setMismatchScore', 'getGapPenalty', 
            'setGapPenalty', 'getGapExtPenalty', 'setGapExtPenalty',
-           'getTrivialSeqId', 'setTrivialSeqId', 'getTrivialCoverage', 
+           'getTrivialSeqId', 'setTrivialSeqId', 'getTrivialCoverage', 'combineAtomMaps',
            'setTrivialCoverage', 'getAlignmentMethod', 'setAlignmentMethod']
 
 TRIVIAL_SEQID = 90.
@@ -890,7 +890,7 @@ def mapChainOntoChain(mobile, target, **kwargs):
         performed, otherwise **0**
     :type seqid: float
 
-    :keyword overlap: percent overlap, default is **70**
+    :keyword overlap: percent overlap with *target*, default is **70**
     :type overlap: float
 
     :keyword mapping: what method will be used if the trivial mapping based on residue numbers 
@@ -967,7 +967,7 @@ def mapChainOntoChain(mobile, target, **kwargs):
         simple_target, simple_mobile)
     if n_mapped > 0:
         _seqid = n_match * 100 / n_mapped
-        _cover = n_mapped * 100 / max(len(simple_target), len(simple_mobile))
+        _cover = n_mapped * 100 / len(simple_target) # max(len(simple_target), len(simple_mobile))
 
     trivial_seqid = TRIVIAL_SEQID if pwalign else seqid
     trivial_cover = TRIVIAL_COVERAGE if pwalign else coverage
@@ -1016,8 +1016,7 @@ def mapChainOntoChain(mobile, target, **kwargs):
             target_list, chain_list, n_match, n_mapped = result
             if n_mapped > 0:
                 _seqid = n_match * 100 / n_mapped
-                _cover = n_mapped * 100 / max(len(simple_target),
-                                                len(simple_mobile))
+                _cover = n_mapped * 100 / len(simple_target) # max(len(simple_target), len(simple_mobile))
             else:
                 _seqid = 0
                 _cover = 0

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -24,7 +24,7 @@ if PY3K:
     basestring = str
 
 __all__ = ['matchChains', 'matchAlign', 'mapChainOntoChain', 'mapOntoChain', 
-           'mapChainByChain', 
+           'mapChainByChain', 'mapOntoChains', 'bestMatch', 'sameChid', 'combineAtomMaps',
            'mapOntoChainByAlignment', 'getMatchScore', 'setMatchScore',
            'getMismatchScore', 'setMismatchScore', 'getGapPenalty', 
            'setGapPenalty', 'getGapExtPenalty', 'setGapExtPenalty',

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -1081,9 +1081,9 @@ def mapChainOntoChain(mobile, target, **kwargs):
     coverage = kwargs.get('coverage', coverage) 
     pwalign = kwargs.get('pwalign', True)
     pwalign = kwargs.get('mapping', pwalign)
+    alignment = None
 
     if isinstance(pwalign, basestring):
-        alignment = None
         pwalign = pystr(pwalign).strip().lower()
     elif not isinstance(pwalign, bool):
         alignment = pwalign

--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -345,7 +345,7 @@ def showProtein(*atoms, **kwargs):
                           color=wcolor,
                           ls='None', marker=kwargs.get('wmarker', '.'),
                           ms=kwargs.get('wsize', 6))
-            hetero = atoms.select('not protein and not nucleic and not water')
+            hetero = atoms.select('not protein and not nucleic and not water and not dummy')
             if hetero:
                 for res in HierView(hetero).iterResidues():
                     xyz = res._getCoords()

--- a/prody/utilities/catchall.py
+++ b/prody/utilities/catchall.py
@@ -431,6 +431,10 @@ def showMatrix(matrix, x_array=None, y_array=None, **kwargs):
         ax3.xaxis.set_major_locator(locator)
         ax3.xaxis.set_minor_locator(minor_locator)
 
+        locator = ticker.AutoLocator()
+        locator.set_params(integer=True)
+        minor_locator = ticker.AutoMinorLocator()
+        
         ax3.yaxis.set_major_locator(locator)
         ax3.yaxis.set_minor_locator(minor_locator)
 

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -2,7 +2,7 @@
 import re
 
 from numpy import unique, linalg, diag, sqrt, dot, chararray, divide, zeros_like, zeros, allclose
-from numpy import diff, where, insert, nan, isnan, loadtxt, array, round, average, min, max
+from numpy import diff, where, insert, nan, isnan, loadtxt, array, round, average, min, max, delete
 from numpy import sign, arange, asarray, ndarray, subtract, power, sum, isscalar, empty, triu, tril
 from collections import Counter
 import numbers
@@ -18,7 +18,8 @@ __all__ = ['Everything', 'Cursor', 'ImageCursor', 'rangeString', 'alnum', 'impor
            'saxsWater', 'count', 'addEnds', 'copy', 'dictElementLoop', 
            'getDataPath', 'openData', 'chr2', 'toChararray', 'interpY', 'cmp', 'pystr',
            'getValue', 'indentElement', 'isPDB', 'isURL', 'isListLike', 'isSymmetric', 'makeSymmetric',
-           'getDistance', 'fastin', 'createStringIO', 'div0', 'wmean', 'bin2dec', 'wrapModes', 'fixArraySize']
+           'getDistance', 'fastin', 'createStringIO', 'div0', 'wmean', 'bin2dec', 'wrapModes', 'fixArraySize',
+           'multilap']
 
 CURSORS = []
 
@@ -617,3 +618,23 @@ def makeSymmetric(M):
     else:
         M = (M + M.T) / 2.
     return M
+
+def multilap(C):
+    """ Performs LAP (linear assignment problem) multiple times until 
+    each column is assigned to a row. """
+
+    from scipy.optimize import linear_sum_assignment
+
+    _, n = C.shape
+    D = C.copy()
+    N = arange(n)
+
+    mappings = []
+    while len(N):
+        I, J = linear_sum_assignment(D)
+        K = N[J]
+        N = delete(N, J)
+        D = C[:, N]
+        mappings.append((I, K))
+
+    return mappings

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -626,7 +626,7 @@ def multilap(C):
     from scipy.optimize import linear_sum_assignment
 
     _, n = C.shape
-    D = C.copy()
+    D = C
     N = arange(n)
 
     mappings = []


### PR DESCRIPTION
Major changes:
- Implemented `mapChainOntoChain` that maps a `Chain` instance onto another and let `mapOntoChains` use `mapChainOntoChain` when in its loop over chains.
- Implemented `mapOntoChains` that calculates mappings of chains between two structures in a pairwise fashion.
- Implemented `combineAtomMaps` for "optimally" combining atommaps obtained from `mapOntoChains` or `mapOntoChain`.
- Implemented `alignChains` for aligning two structures with `mapOntoChains` and `combineAtomMaps`.
- Rework of `buildPDBEnsemble`. 
Now instead of `mapping_func`, a `match_func` should be passed to the function. The `match_func` takes **exactly two** parameters `chain1` and `chain2` and determines if these two chains should be tried to be mapped. Built-in options for `match_func` includes: 
- `bestMatch` which allows all pairwise mappings between chains, and it is called `bestMatch` because the optimal mapping will be chosen later automatically.
- `sameChid` which only maps the ones with the same chain ID, and the later optimization of mappings would not matter since the same chain IDs usually indicate a unique mapping.
- `userDefined`. It takes three parameters, which are two chains and a `dict` instance indicating correspondence Since it has three parameters, a wrapper is needed. Its usage is demonstrated by the following example:
```
ref = parsePDB('3qel', subset='ca').select('chain A or chain B')
mob = parsePDB('4pe5', subset='ca')

chmap = {'3qel_ca': 'AB', '4pe5_ca': 'CD'}
GluRChains = lambda chain1, chain2: userDefined(chain1, chain2, chmap)
atommaps = alignChains(mob, ref, mapping='ce', match_func=GluRChains)
```

Minor changes:
- Let `showProtein` not display dummy atoms
- Added warnings to `calcTransform` when either mobile or target is an `AtomMap` instance.
- Fixed a bug related to the ticks locator in `showMatrix`.
- Deprecated `mapChainByChain` and `addPDBEnsemble` whose rules are filled respectively by `mapOntoChains` and `buildPDBEnsemble` when `ref` is an `PDBEnsemble` instance. 
