### PR TITLE
Enabled parsePDB to evaluate CONECT entries

### DIFF
--- a/prody/__init__.py
+++ b/prody/__init__.py
@@ -144,6 +144,7 @@ CONFIGURATION = {
     'typo_warnings': (True, None, None),
     'check_updates': (0, None, None),
     'auto_secondary': (False, None, None),
+    'auto_bonds': (False, None, None),
     'selection_warning': (True, None, None),
     'verbosity': ('debug', list(utilities.LOGGING_LEVELS),
                   LOGGER._setverbosity),

--- a/prody/atomic/atomgroup.py
+++ b/prody/atomic/atomgroup.py
@@ -980,7 +980,15 @@ class AtomGroup(Atomic):
         index 1"``.  See :mod:`.select` module documentation for details.
         Also, a data array with number of bonds will be generated and stored
         with label *numbonds*.  This can be used in atom selections, e.g.
-        ``'numbonds 0'`` can be used to select ions in a system."""
+        ``'numbonds 0'`` can be used to select ions in a system. If *bonds* 
+        is empty or **None**, then all bonds will be removed for this 
+        :class:`.AtomGroup`. """
+
+        if bonds is None or len(bonds) == 0:
+            self._bmap = None
+            self._bonds = None
+            self._fragments = None
+            return
 
         if isinstance(bonds, list):
             bonds = np.array(bonds, int)
@@ -996,6 +1004,7 @@ class AtomGroup(Atomic):
         bonds.sort(1)
         bonds = bonds[bonds[:, 1].argsort(), ]
         bonds = bonds[bonds[:, 0].argsort(), ]
+        bonds = np.unique(bonds, axis=0)
 
         self._bmap, self._data['numbonds'] = evalBonds(bonds, n_atoms)
         self._bonds = bonds

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -495,10 +495,12 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
             continue
         
         # add the atommaps to the ensemble
-        for j, atommap in enumerate(atommaps):
+        for atommap in atommaps:
             lbl = pystr(labels[i])
-            if j != 0:
-                lbl += '_%d'%j
+            if len(atommaps) > 1:
+                chids = np.unique(atommap.getChids())
+                strchids = ''.join(chids)
+                lbl += '_%s'%strchids
             ensemble.addCoordset(atommap, weights=atommap.getFlags('mapped'), 
                                 label=lbl, degeneracy=degeneracy)
 

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -271,7 +271,7 @@ def parsePDBStream(stream, **kwargs):
         if header or biomol or secondary:
             hd, split = getHeaderDict(lines)
         bonds = [] if get_bonds else None
-        _parsePDBLines(ag, lines, split, model, chain, subset, altloc, bonds)
+        _parsePDBLines(ag, lines, split, model, chain, subset, altloc, bonds=bonds)
         if ag.numAtoms() > 0:
             LOGGER.report('{0} atoms and {1} coordinate set(s) were '
                           'parsed in %.2fs.'.format(ag.numAtoms(),

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -77,8 +77,6 @@ _parsePDBdoc = _parsePQRdoc + """
 
     If ``model=0`` and ``header=True``, return header dictionary only.
 
-    Note that this function does not evaluate ``CONECT`` records.
-
     """
 
 _PDBSubsets = {'ca': 'ca', 'calpha': 'ca', 'bb': 'bb', 'backbone': 'bb'}

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -215,6 +215,7 @@ def parsePDBStream(stream, **kwargs):
     chain = kwargs.get('chain')
     subset = kwargs.get('subset')
     altloc = kwargs.get('altloc', 'A')
+    get_bonds = kwargs.get('bonds', False)
 
     if model is not None:
         if isinstance(model, Integral):
@@ -269,7 +270,8 @@ def parsePDBStream(stream, **kwargs):
             raise ValueError('empty PDB file or stream')
         if header or biomol or secondary:
             hd, split = getHeaderDict(lines)
-        _parsePDBLines(ag, lines, split, model, chain, subset, altloc)
+        bonds = [] if get_bonds else None
+        _parsePDBLines(ag, lines, split, model, chain, subset, altloc, bonds)
         if ag.numAtoms() > 0:
             LOGGER.report('{0} atoms and {1} coordinate set(s) were '
                           'parsed in %.2fs.'.format(ag.numAtoms(),
@@ -369,7 +371,7 @@ def parsePQR(filename, **kwargs):
 parsePQR.__doc__ += _parsePQRdoc
 
 def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
-                   altloc_torf, format='PDB'):
+                   altloc_torf, format='PDB', bonds=None):
     """Returns an AtomGroup. See also :func:`.parsePDBStream()`.
 
     :arg lines: PDB/PQR lines


### PR DESCRIPTION
Working towards solving #798.

- Now `parsePDB(..., bonds=True)` can evaluate `CONECT` entries in the PDB files. These entries are interpreted as the `Bond` objects in ProDy.
- Added a setting called `auto_binds`, which when set to `True`, `parsePDB` will read `CONECT` entries by default.