### PR TITLE
removed unused and confusing code block from reduceModel

### DIFF
--- a/prody/dynamics/editing.py
+++ b/prody/dynamics/editing.py
@@ -275,10 +275,7 @@ def reduceModel(model, atoms, select):
             anm = ANM(model.getTitle() + ' reduced')
             anm.setHessian(matrix)
             return anm, select
-        elif isinstance(model, PCA):
-            eda = PCA(model.getTitle() + ' reduced')
-            eda.setCovariance(matrix)
-            return eda, select
+
 
 def _reduceModel(matrix, system):
     """This is the underlying function that reduces models, which shall 


### PR DESCRIPTION
It already has a return higher up for just slicing the covariance. 