### PR TITLE
Improve documentation, add arrows option

### DIFF
--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -11,7 +11,7 @@ from collections import defaultdict
 import numpy as np
 
 from prody import LOGGER, SETTINGS, PY3K
-from prody.utilities import showFigure, addEnds
+from prody.utilities import showFigure, addEnds, showMatrix
 from prody.atomic import AtomGroup, Selection, Atomic, sliceAtoms, sliceAtomicData
 
 from .nma import NMA
@@ -491,26 +491,32 @@ def showOverlapTable(modes_x, modes_y, **kwargs):
 
     if SETTINGS['auto_show']:
         plt.figure()
-    show = (plt.pcolor(overlap, cmap=cmap, norm=norm, **kwargs),
-            plt.colorbar())
-
-    x_range = np.arange(1, modes_x.numModes() + 1)
+    
+    x_range = np.arange(1, modes_x.numModes()+1)
     if isinstance(modes_x, ModeSet):
         x_ticklabels = modes_x._indices+1
     else:
         x_ticklabels = x_range
-    plt.xticks(x_range-0.5, x_ticklabels)
-    plt.xlabel(str(modes_x))
 
-    y_range = np.arange(1, modes_y.numModes() + 1)
+    x_ticklabels = kwargs.pop('xticklabels', x_ticklabels)
+
+    y_range = np.arange(1, modes_y.numModes()+1)
     if isinstance(modes_y, ModeSet):
         y_ticklabels = modes_y._indices+1
     else:
         y_ticklabels = y_range
-    plt.yticks(y_range-0.5, y_ticklabels)
-    plt.ylabel(str(modes_y))
 
-    plt.axis([0, modes_x.numModes(), 0, modes_y.numModes()])
+    y_ticklabels = kwargs.pop('yticklabels', y_ticklabels)
+
+    allticks = kwargs.pop('allticks', True)
+
+    show = showMatrix(overlap, cmap=cmap, norm=norm, 
+                      xticklabels=x_ticklabels, yticklabels=y_ticklabels, allticks=allticks,
+                      **kwargs)
+
+    plt.xlabel(str(modes_x))
+    plt.ylabel(str(modes_y))
+    
     if SETTINGS['auto_show']:
         showFigure()
     return show
@@ -526,19 +532,13 @@ def showCrossCorr(modes, *args, **kwargs):
     if SETTINGS['auto_show']:
         plt.figure()
 
-    arange = np.arange(modes.numAtoms())
-    cross_correlations = np.zeros((arange[-1]+2, arange[-1]+2))
-    cross_correlations[arange[0]+1:,
-                       arange[0]+1:] = calcCrossCorr(modes)
+    cross_correlations = calcCrossCorr(modes)
     if not 'interpolation' in kwargs:
         kwargs['interpolation'] = 'bilinear'
     if not 'origin' in kwargs:
         kwargs['origin'] = 'lower'
-    show = showAtomicMatrix(cross_correlations, *args, **kwargs)#, plt.colorbar()
-    #plt.axis([arange[0]+0.5, arange[-1]+1.5, arange[0]+0.5, arange[-1]+1.5])
+    show = showAtomicMatrix(cross_correlations, *args, **kwargs)
     plt.title('Cross-correlations for {0}'.format(str(modes)))
-    plt.xlabel('Indices')
-    plt.ylabel('Indices')
     if SETTINGS['auto_show']:
         showFigure()
     return show
@@ -1242,8 +1242,6 @@ def showAtomicMatrix(matrix, x_array=None, y_array=None, atoms=None, **kwargs):
     :arg interactive: turn on or off the interactive options
     :type interactive: bool
     """ 
-
-    from prody.utilities import showMatrix
     from matplotlib.pyplot import figure
     from matplotlib.figure import Figure
 
@@ -1724,6 +1722,9 @@ def showDomainBar(domains, x=None, loc=0., axis='x', **kwargs):
     show_text = kwargs.pop('show_text', True)
     show_text = kwargs.pop('text', show_text)
     text_color = kwargs.pop('text_color', 'k')
+    text_color = kwargs.pop('textcolor', text_color)
+    font_dict = kwargs.pop('font_dict', None)
+    font_dict = kwargs.pop('fontdict', font_dict)
 
     barwidth = kwargs.pop('barwidth', 5)
     barwidth = kwargs.pop('bar_width', barwidth)
@@ -1814,11 +1815,13 @@ def showDomainBar(domains, x=None, loc=0., axis='x', **kwargs):
                     txt = text(d_loc, pos, chid, rotation=-90, 
                                                 color=text_color,
                                                 horizontalalignment=halign, 
-                                                verticalalignment='center')
+                                                verticalalignment='center',
+                                                fontdict=font_dict)
                 else:
                     txt = text(pos, d_loc, chid, color=text_color,
                                                 horizontalalignment='center', 
-                                                verticalalignment=valign)
+                                                verticalalignment=valign,
+                                                fontdict=font_dict)
                 texts.append(txt)
     
     if len(color_order):
@@ -1842,7 +1845,7 @@ def showDomainBar(domains, x=None, loc=0., axis='x', **kwargs):
         gca().autoscale_view()
 
     start, stop = lim()
-    lim(round(start, 2) + 0.006, stop)
+    lim(start, stop)
     
     return bars, texts
 

--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -22,19 +22,21 @@ def view3D(*alist, **kwargs):
     
     GNM/ANM Coloring
     
-    An array of fluctuation values (flucts) can be provided with the flucts kwarg
+    An array of fluctuation values (data) can be provided with the flucts kwarg
     for visualization of GNM/ANM calculations.  The array is assumed to 
     correpond to a calpha selection of the provided protein.
     The default color will be set to a RWB color scheme on a per-residue
     basis.  If the fluctuation vector contains negative values, the
     midpoint (white) will be at zero.  Otherwise the midpoint is the mean.
     
-    An array of displacement vectors (vecs) can be provided with the vecs kwarg.
+    An array of displacement vectors (mode) can be provided with the vecs kwarg.
     The animation of these motions can be controlled with frames (number
     of frames to animate over), amplitude (scaling factor), and animate
-    (3Dmol.js animate options).
+    (3Dmol.js animate options).  If animation isn't enabled, by default
+    arrows are drawn.  Drawing of arrows is controlled by the boolean arrows
+    option and the arrowcolor option.
     
-    If multiple structures are provided with the flucts or vecs arguments, these
+    If multiple structures are provided with the data or mode arguments, these
     arguments must be provided as lists of arrays of the appropriate dimension.
     """
 
@@ -57,6 +59,9 @@ def view3D(*alist, **kwargs):
     interval = kwargs.pop('interval', 1)
     anim = kwargs.pop('anim', False)
     scale = kwargs.pop('scale', 100)
+    arrows = kwargs.pop('arrows',True)
+    arrowcolor = kwargs.pop('arrowcolor', 'darkgrey')
+    arrowcolor = kwargs.pop('arrowColor', arrowcolor)
 
     if modes is None:
         n_modes = 0
@@ -133,14 +138,14 @@ def view3D(*alist, **kwargs):
                     # set the atom property 
                     # TODO: implement something more efficient on the 3Dmol.js side (this is O(n*m)!)
                     view.mapAtomProperties(propmap)
-                else:
+                elif arrows:
                     for j, a in enumerate(atoms.calpha):
                         start = a._getCoords()
                         dcoords = arr[3*j:3*j+3]
                         end = start + dcoords * scale
                         view.addArrow({'start': {'x':start[0], 'y':start[1], 'z':start[2]},
                                        'end': {'x':end[0], 'y':end[1], 'z':end[2]},
-                                       'radius': 0.3})
+                                       'radius': 0.3, 'color': arrowcolor})
             else:
                 if atoms.calpha.numAtoms() != len(arr):
                     raise RuntimeError("Atom count mismatch: {} vs {}. mode styling assumes a calpha selection."


### PR DESCRIPTION
I think the arrows are ugly so I'm providing an option to omit them.

The doc string used the old names for parameters, which still could be documented better.