### PR TITLE
Fix a bug in buildBiomolecules()

### DIFF
--- a/prody/proteins/header.py
+++ b/prody/proteins/header.py
@@ -1105,7 +1105,7 @@ def buildBiomolecules(header, atoms, biomol=None):
             translation[2] = line2[3]
             t = Transformation(rotation, translation)
 
-            newag = atoms.select('chain ' + ' '.join(mt[0])).copy()
+            newag = atoms.select('chain ' + ' '.join(mt[times*4+0])).copy()
             if newag is None:
                 continue
             newag.all.setSegnames(segnm.pop(0))


### PR DESCRIPTION
The buildBiomolecules() function may apply the transforms specified in the PDB header to wrong chains if a biomolecule is defined by more than one transform (example: pdbID 4I8O biomolecule 3). This bugfix is supposed to solve the problem.

Explanation:
For each biomolecule, the function iterates through an array of transforms that define the biomolecule. But while each transform has its own set of chains that it should be applied to, current implementation applies all transforms to the set of chains specified for the first transform.

This PR changes the function behaviour so that each transform is applied to its own set of chains.

 