### PR TITLE
bug fix for creating PDBEnsemble from selected Ensemble

### DIFF
--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -318,6 +318,10 @@ class Ensemble(object):
         self._coords = coords
         self._n_atoms = coords.shape[0]
 
+        if isinstance(atoms, Ensemble):
+            self._indices = atoms._indices
+            self._atoms = atoms._atoms
+
     def getWeights(self, selected=True):
         """Returns a copy of weights of selected atoms."""
 

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -318,7 +318,7 @@ class PDBEnsemble(Ensemble):
         else:
             if sequence is None:
                 try:
-                    sequence = self.getAtoms().getSequence()
+                    sequence = self._atoms.getSequence()
                 except AttributeError:
                     if self._msa:
                         sequence = ''.join('X' for _ in range(n_atoms))


### PR DESCRIPTION
Without this change then the PDBEnsemble has an MSA of the wrong size, which matches the selected atoms not the full atoms, and that causes problems for getMSA and hence trimPDBEnsemble:

```
In [57]: lisa_pdbens                                                                                                                        
Out[57]: <PDBEnsemble: Ensemble combined_trajectory_receptor_calpha (0:13000:1) (13000 conformations; selected 451 of 455 atoms)>

In [58]: lisa_pdbens.getAtoms()                                                                                                             
Out[58]: <Selection: 'index 4 to 454' from starting_structure_calpha (451 atoms)>

In [59]: msa = lisa_pdbens.getMSA()                                                                                                         
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-59-08e5a7534dee> in <module>
----> 1 msa = lisa_pdbens.getMSA()

~/Documents/code/ProDy/prody/ensemble/pdbensemble.py in getMSA(self, indices, selected)
    391         indices = indices if indices is not None else slice(None, None, None)
    392 
--> 393         return self._msa[indices, atom_indices]
    394 
    395     def getLabels(self):

~/Documents/code/ProDy/prody/sequence/msa.py in __getitem__(self, index)
    176         else:
    177             try:
--> 178                 msa = self._msa[rows, cols]
    179             except TypeError:
    180                 raise IndexError('invalid index: ' + str(index))

/anaconda3/lib/python3.7/site-packages/numpy/core/defchararray.py in __getitem__(self, obj)
   1990 
   1991     def __getitem__(self, obj):
-> 1992         val = ndarray.__getitem__(self, obj)
   1993 
   1994         if isinstance(val, character):

IndexError: index 451 is out of bounds for axis 1 with size 451

In [60]: lisa_pdbens._msa                                                                                                                   
Out[60]: <MSA: Ensemble combined_trajectory_receptor_calpha (0:13000:1) (13000 sequences, 451 residues)>
```

