### PR TITLE
2nd bug fix to c kwarg in showProjection

### DIFF
--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -259,7 +259,9 @@ def showProjection(ensemble, modes, *args, **kwargs):
 
     c = kwargs.pop('c', 'blue')
     colors = kwargs.pop('color', c)
-    if isinstance(colors, str) or colors is None:
+    if isinstance(colors, np.ndarray):
+        colors = tuple(colors)
+    if isinstance(colors, (str, tuple)) or colors is None:
         colors = [colors] * num
     elif isinstance(colors, list):
         if len(colors) != num:


### PR DESCRIPTION
We can now support RGBA or RGB assignments for colors like we're supposed to be able to and I managed to generate this figure:

![combined_pca_proj2d](https://user-images.githubusercontent.com/13259162/79479761-29a39680-8005-11ea-9161-3e22df417add.png)

The code for it is as follows:

```
labels = ('DruGUI sim 1', 'DruGUI sim 2', 'DruGUI sim 3',
          'DruGUI sim 4', 'DruGUI sim 5', 'DruGUI sim 6',
          'Apo sim 1', 'Apo sim 2', 
          'PTH sim 1', 'PTH sim 2', 'PTH sim 3')
slices = (slice(0, 2000), slice(2000, 4000), slice(4000, 6000),
          slice(6000, 8000), slice(8000, 10000), slice(10000, 12000),
          slice(12000, 13000), slice(13000, 14000), 
          slice(14000, 16000), slice(16000, 18000), slice(18000, 19000))
cols = plt.cm.rainbow(np.linspace(0, 1, len(labels)))

plt.figure()
for l, c, s in zip(labels, cols, slices):
    showProjection(combined_traj[s], whole_pca[:2],
                   label=l, c=c, markersize=3)
xmin, xmax = plt.xlim()
plt.xlim(xmin, xmax+8)
plt.legend(loc='upper right')
plt.savefig('combined_pca_proj2d')
```