### PR TITLE
added extend_biomol option to parsePDB

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -94,14 +94,14 @@ def parsePDB(*pdb, **kwargs):
     
     You can also provide arguments that you would like passed on to fetchPDB().
 
-    :arg extend_bool: whether to extend the list of results with a list
+    :arg extend_biomol: whether to extend the list of results with a list
         rather than appending, which can create a mixed list, 
         especially when biomol=True.
         Default value is False to reproduce previous behaviour.
         This value is ignored when result is not a list (header=True or model=0).
-    :type extend_bool: bool 
+    :type extend_biomol: bool 
     """
-    extend_bool = kwargs.pop('extend_bool', False)
+    extend_biomol = kwargs.pop('extend_biomol', False)
 
     n_pdb = len(pdb)
     if n_pdb == 1:
@@ -155,7 +155,7 @@ def parsePDB(*pdb, **kwargs):
         else:
             numPdbs = len(results)
 
-            if extend_bool:
+            if extend_biomol:
                 results_old = results
                 results = []
                 for entry in results_old:

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -93,7 +93,15 @@ def parsePDB(*pdb, **kwargs):
         If needed, PDB files are downloaded using :func:`.fetchPDB()` function.
     
     You can also provide arguments that you would like passed on to fetchPDB().
+
+    :arg extend_bool: whether to extend the list of results with a list
+        rather than appending, which can create a mixed list, 
+        especially when biomol=True.
+        Default value is False to reproduce previous behaviour.
+        This value is ignored when result is not a list (header=True or model=0).
+    :type extend_bool: bool 
     """
+    extend_bool = kwargs.pop('extend_bool', False)
 
     n_pdb = len(pdb)
     if n_pdb == 1:
@@ -146,6 +154,15 @@ def parsePDB(*pdb, **kwargs):
             numPdbs = len(results[0])
         else:
             numPdbs = len(results)
+
+            if extend_bool:
+                results_old = results
+                results = []
+                for entry in results_old:
+                    if isinstance(entry, AtomGroup):
+                        results.append(entry)
+                    else:
+                        results.extend(entry)
 
         LOGGER.info('{0} PDBs were parsed in {1:.2f}s.'
                      .format(numPdbs, time.time()-start))


### PR DESCRIPTION
This is so as to make it easier to handle biomols. The current situation is that we get a mixed list containing atomgroups and lists that needs to be dealt with by the user e.g. 

```
In [1]: from prody import *                                                                                                

In [2]: results = parsePDB(['3hsy','3o21'], subset='ca', biomol=True)                                                      
@> 2 PDBs were parsed in 0.13s.

In [3]: results                                                                                                            
Out[3]: 
[<AtomGroup: 3hsy_ca biomolecule 1 (730 atoms)>,
 [<AtomGroup: 3o21_ca biomolecule 1 (739 atoms)>,
  <AtomGroup: 3o21_ca biomolecule 2 (750 atoms)>]]
```

With the new option, we have the option to create a uniform list of atomgroups:

```
In [4]: results2 = parsePDB(['3hsy','3o21'], subset='ca', biomol=True, extend_bool=True)                                   
@> 2 PDBs were parsed in 0.13s.

In [5]: results2                                                                                                           
Out[5]: 
[<AtomGroup: 3hsy_ca biomolecule 1 (730 atoms)>,
 <AtomGroup: 3o21_ca biomolecule 1 (739 atoms)>,
 <AtomGroup: 3o21_ca biomolecule 2 (750 atoms)>]
```
