### PR TITLE
added adjust_text to showProjection and showCrossProjection

### DIFF
--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -326,11 +326,19 @@ def showProjection(ensemble, modes, *args, **kwargs):
         plot(*(list(projection[indices].T) + args), **kwargs)
 
     if texts:
+        ts = []
         kwargs = {}
         if size:
             kwargs['size'] = size
         for args in zip(*(list(projection.T) + [texts])):
-            text(*args, **kwargs)
+            ts.append(text(*args, **kwargs))
+
+        try: 
+            from adjustText import adjust_text
+        except ImportError:
+            pass
+        else:
+            adjust_text(ts)
 
     if len(modes) == 2:
         plt.xlabel('{0} coordinate'.format(int(modes[0])+1))
@@ -461,12 +469,22 @@ def showCrossProjection(ensemble, mode_x, mode_y, scale=None, *args, **kwargs):
         else:
             kwargs.pop('label', None)
         show = plt.plot(xcoords[indices], ycoords[indices], *args, **kwargs)
+
     if texts:
+        ts = []
         kwargs = {}
         if size:
             kwargs['size'] = size
         for x, y, t in zip(xcoords, ycoords, texts):
-            plt.text(x, y, t, **kwargs)
+            ts.append(plt.text(x, y, t, **kwargs))
+
+        try: 
+            from adjustText import adjust_text
+        except ImportError:
+            pass
+        else:
+            adjust_text(ts)
+
     plt.xlabel('{0} coordinate'.format(mode_x))
     plt.ylabel('{0} coordinate'.format(mode_y))
     if SETTINGS['auto_show']:


### PR DESCRIPTION
This module adjusts text so that it doesn't overlap and changes with zooming. The output becomes 
![pca_proj2d_adjust](https://user-images.githubusercontent.com/13259162/81054925-9a7cf680-8ebf-11ea-9d19-53709714fcd1.png) instead of 

![pca_proj2d](https://user-images.githubusercontent.com/13259162/81054911-94871580-8ebf-11ea-83c1-aa474843d078.png)
