### PR TITLE
added xtickrotation to showMatrix

### DIFF
--- a/prody/utilities/catchall.py
+++ b/prody/utilities/catchall.py
@@ -486,6 +486,10 @@ def showMatrix(matrix, x_array=None, y_array=None, **kwargs):
 
     :arg interactive: turn on or off the interactive options
     :type interactive: bool
+
+    :arg xtickrotation: turn on or off rotation of the xticklabels
+                        default is False
+    :type xtickrotation: bool
     """
 
     from matplotlib import ticker
@@ -520,6 +524,8 @@ def showMatrix(matrix, x_array=None, y_array=None, **kwargs):
     ticklabels = kwargs.pop('ticklabels', None)
     xticklabels = kwargs.pop('xticklabels', ticklabels)
     yticklabels = kwargs.pop('yticklabels', ticklabels)
+
+    xtickrotation = kwargs.pop('xtickrotation', False)
 
     show_colorbar = kwargs.pop('colorbar', True)
     cb_extend = kwargs.pop('cb_extend', 'neither')
@@ -703,6 +709,9 @@ def showMatrix(matrix, x_array=None, y_array=None, **kwargs):
         from matplotlib.pyplot import connect
         cursor = ImageCursor(ax3, im)
         connect('button_press_event', cursor.onClick)
+
+    if xtickrotation:
+        ax3.tick_params(axis='x', rotation=90)
 
     return im, lines, cb
 


### PR DESCRIPTION
Allows us to get
![rmsd_matrix_xtickrotation](https://user-images.githubusercontent.com/13259162/81060654-ce114e00-8eca-11ea-96bb-7fdd214e2a8a.png)
instead of
![rmsd_matrix](https://user-images.githubusercontent.com/13259162/81060718-eda87680-8eca-11ea-80e5-930e59c4ed2d.png)

