### PR TITLE
bug fix on sdarray numAtoms being a float

### DIFF
--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -749,7 +749,7 @@ class sdarray(ndarray):
                 n_atoms = self.shape[1]
             if self.is3d():
                 n_atoms /= 3
-            return n_atoms
+            return int(n_atoms)
         except IndexError:
             LOGGER.warn('{0} is not related to the number of atoms'.format(self.getTitle()))
             return 0


### PR DESCRIPTION
Otherwise, we get the following error:

```
In [14]: showSignatureMode(anm_ens[:,0])                                                                           
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/anaconda3/lib/python3.7/site-packages/numpy/core/fromnumeric.py in _wrapfunc(obj, method, *args, **kwds)
     60     try:
---> 61         return bound(*args, **kwds)
     62     except TypeError:

TypeError: 'float' object cannot be interpreted as an integer

During handling of the above exception, another exception occurred:

TypeError                                 Traceback (most recent call last)
<ipython-input-14-e59f87640106> in <module>
----> 1 showSignatureMode(anm_ens[:,0])

~/Documents/code/ProDy/prody/dynamics/signature.py in showSignatureMode(mode_ensemble, **kwargs)
   1183     mode = mode_ensemble.getEigvec() * scale
   1184     show_zero = kwargs.pop('show_zero', True)
-> 1185     return showSignature1D(mode, atoms=atoms, show_zero=show_zero, **kwargs)
   1186 
   1187 def showSignatureSqFlucts(mode_ensemble, **kwargs):

~/Documents/code/ProDy/prody/dynamics/signature.py in showSignature1D(signature, linespec, **kwargs)
   1134 
   1135     if V.is3d():
-> 1136         meanV = np.reshape(meanV, (V.numAtoms(), 3)).T
   1137         stdV = np.reshape(stdV, (V.numAtoms(), 3)).T
   1138         minV = np.reshape(minV, (V.numAtoms(), 3)).T

<__array_function__ internals> in reshape(*args, **kwargs)

/anaconda3/lib/python3.7/site-packages/numpy/core/fromnumeric.py in reshape(a, newshape, order)
    299            [5, 6]])
    300     """
--> 301     return _wrapfunc(a, 'reshape', newshape, order=order)
    302 
    303 

/anaconda3/lib/python3.7/site-packages/numpy/core/fromnumeric.py in _wrapfunc(obj, method, *args, **kwds)
     68         # Call _wrapit from within the except clause to ensure a potential
     69         # exception has a traceback chain.
---> 70         return _wrapit(obj, method, *args, **kwds)
     71 
     72 

/anaconda3/lib/python3.7/site-packages/numpy/core/fromnumeric.py in _wrapit(obj, method, *args, **kwds)
     45     except AttributeError:
     46         wrap = None
---> 47     result = getattr(asarray(obj), method)(*args, **kwds)
     48     if wrap:
     49         if not isinstance(result, mu.ndarray):

TypeError: 'float' object cannot be interpreted as an integer
```