### PR TITLE
bug fix for getModeSets with int index

### DIFF
--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -228,9 +228,12 @@ class ModeEnsemble(object):
 
         if index is None:
             return self._modesets
-        elif isinstance(index, Integral):
-            return self[index]
-        return self[index]._modesets
+
+        subset = self[index]
+        if isinstance(subset, ModeSet):
+            return subset
+        else:
+            return subset._modesets
 
     def getArray(self, mode_index=0):
         """Returns a sdarray of row arrays."""

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -228,7 +228,7 @@ class ModeEnsemble(object):
 
         if index is None:
             return self._modesets
-        elif isinstance(index, int):
+        elif isinstance(index, Integral):
             return self[index]
         return self[index]._modesets
 

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -228,6 +228,8 @@ class ModeEnsemble(object):
 
         if index is None:
             return self._modesets
+        elif isinstance(index, int):
+            return self[index]
         return self[index]._modesets
 
     def getArray(self, mode_index=0):


### PR DESCRIPTION
The error otherwise is

```
In [64]: anm_ens.getModeSets(0)                                                                                    
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-64-78d2e854bb26> in <module>
----> 1 anm_ens.getModeSets(0)

~/Documents/code/ProDy/prody/dynamics/signature.py in getModeSets(self, index)
    229         if index is None:
    230             return self._modesets
--> 231         return self[index]._modesets
    232 
    233     def getArray(self, mode_index=0):

AttributeError: 'ModeSet' object has no attribute '_modesets'
```