### PR TITLE
bug fix on writing PSF without parsing PSF file

### DIFF
--- a/prody/trajectory/psffile.py
+++ b/prody/trajectory/psffile.py
@@ -144,6 +144,9 @@ def writePSF(filename, atoms):
     *filename*.  This function will write available atom and bond information
     only."""
 
+    if not filename.endswith('.psf'):
+        filename = filename + '.psf'
+
     try:
         n_atoms, segments, rnums, rnames, names, types, charges, masses = (
         atoms.numAtoms(), atoms._getSegnames(), atoms._getResnums(),
@@ -168,7 +171,10 @@ def writePSF(filename, atoms):
         raise ValueError('atom names are not set')
 
     if types is None:
-        atomtypes = zeros(n_atoms, array(['a']).dtype.char + '1')
+        types = zeros(n_atoms, ATOMIC_FIELDS['type'].dtype)
+
+    if charges is None:
+        charges = zeros(n_atoms, ATOMIC_FIELDS['charge'].dtype)
 
     long_fields = array([len(tp) for tp in types]).max() > 4
 


### PR DESCRIPTION
Otherwise we get

```
(base) Jamess-MBP-2:peptide_models jkrieger$ ipython
Python 3.7.1 (default, Dec 14 2018, 13:28:58) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.13.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import * 
   ...: import numpy as np 
   ...: import matplotlib.pyplot as plt 
   ...: plt.ion()                                                                                                                 

In [2]: ag = parsePDB('3hsy')                                                                                                     
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 3hsy downloaded (3hsy.pdb.gz)
@> PDB download via FTP completed (1 downloaded, 0 failed).
@> 6508 atoms and 1 coordinate set(s) were parsed in 0.09s.
@> Secondary structures were assigned to 474 residues.

In [3]: writePSF('3hsy', ag)                                                                                                      
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-35c749239992> in <module>
----> 1 writePSF('3hsy', ag)

~/Documents/code/ProDy/prody/trajectory/psffile.py in writePSF(filename, atoms)
    171         atomtypes = zeros(n_atoms, array(['a']).dtype.char + '1')
    172 
--> 173     long_fields = array([len(tp) for tp in types]).max() > 4
    174 
    175     out = openFile(filename, 'w')

TypeError: 'NoneType' object is not iterable
```