### PR TITLE
fix for showSignatureVariances (showSignatureDistribution) with 1 mode

### DIFF
--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -1484,11 +1484,15 @@ def showSignatureDistribution(signature, **kwargs):
 
     colors = []
     for patch_i in patches:
-        colors.append(patch_i[0].get_facecolor())
+        if len(patches) == 1:
+            colors.append(patch_i.get_facecolor())
+        else:
+            colors.append(patch_i[0].get_facecolor())
 
-    for i, patch_i in enumerate(patches):
-        for j, patch_j in enumerate(patch_i):
-            patch_j.set_color(colors[-(i+1)])
+    if len(patches) > 1:
+        for i, patch_i in enumerate(patches):
+            for j, patch_j in enumerate(patch_i):
+                patch_j.set_color(colors[-(i+1)])
 
     if show_legend:
         legend()

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -1484,13 +1484,13 @@ def showSignatureDistribution(signature, **kwargs):
 
     colors = []
     for patch_i in patches:
-        if len(patches) == 1:
-            colors.append(patch_i.get_facecolor())
-        else:
+        if isinstance(patch_i, list):
             colors.append(patch_i[0].get_facecolor())
+        else:
+            colors.append(patch_i.get_facecolor())
 
-    if len(patches) > 1:
-        for i, patch_i in enumerate(patches):
+    for i, patch_i in enumerate(patches):
+        if isinstance(patch_i, list):
             for j, patch_j in enumerate(patch_i):
                 patch_j.set_color(colors[-(i+1)])
 


### PR DESCRIPTION
Otherwise the error is

```
showSignatureVariances(anm_ens_20[:,0], fract=False)                                                           
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-25-c113ce977cda> in <module>
----> 1 showSignatureVariances(anm_ens_20[:,0], fract=False)

~/Documents/code/ProDy/prody/dynamics/signature.py in showSignatureVariances(mode_ensemble, **kwargs)
   1562     labels = ['mode %d'%(i+1) for i in indices][::-1]
   1563 
-> 1564     show = showSignatureDistribution(sig, label=labels, **kwargs)
   1565 
   1566     xlabel('Variance')

~/Documents/code/ProDy/prody/dynamics/signature.py in showSignatureDistribution(signature, **kwargs)
   1507         figure(fig_num)
   1508 
-> 1509     W = signature.getArray()[:, ::-1] # reversed to accommodate with matplotlib.pyplot.hist
   1510     weights = np.ones_like(W)/float(len(W))
   1511 

IndexError: too many indices for array
```