### PR TITLE
bug fixes to showProjection around colors

### DIFF
--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -7,7 +7,7 @@ and are prefixed with ``show``.  Function documentations refers to the
 and keyword arguments are passed to the Matplotlib functions."""
 
 from collections import defaultdict
-
+from numbers import Integral
 import numpy as np
 
 from prody import LOGGER, SETTINGS, PY3K
@@ -269,6 +269,9 @@ def showProjection(ensemble, modes, *args, **kwargs):
     else:
         raise TypeError('color must be a string or a list')
 
+    if cmap is not None and isinstance(colors[0], Integral):
+        cmap.N = num
+
     labels = kwargs.pop('label', None)
     if isinstance(labels, str) or labels is None:
         labels = [labels] * num
@@ -315,7 +318,10 @@ def showProjection(ensemble, modes, *args, **kwargs):
         marker, color, label = opts
         kwargs['marker'] = marker
         if cmap is not None:
-            color = cmap.colors[int(float(color))]
+            try:
+                cmap.colors[int(float(color))]
+            except:
+                color = cmap(int(float(color)))
         kwargs['c'] = color
 
         if label:

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -9,7 +9,6 @@ and keyword arguments are passed to the Matplotlib functions."""
 from collections import defaultdict
 from numbers import Number
 import numpy as np
-import matplotlib
 
 from prody import LOGGER, SETTINGS, PY3K
 from prody.utilities import showFigure, addEnds, showMatrix
@@ -230,6 +229,7 @@ def showProjection(ensemble, modes, *args, **kwargs):
       * 3 modes: :meth:`~mpl_toolkits.mplot3d.Axes3D.scatter`"""
 
     import matplotlib.pyplot as plt
+    import matplotlib
 
     cmap = kwargs.pop('cmap', plt.cm.jet)
 

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -7,8 +7,9 @@ and are prefixed with ``show``.  Function documentations refers to the
 and keyword arguments are passed to the Matplotlib functions."""
 
 from collections import defaultdict
-from numbers import Integral
+from numbers import Number
 import numpy as np
+import matplotlib
 
 from prody import LOGGER, SETTINGS, PY3K
 from prody.utilities import showFigure, addEnds, showMatrix
@@ -230,7 +231,7 @@ def showProjection(ensemble, modes, *args, **kwargs):
 
     import matplotlib.pyplot as plt
 
-    cmap = kwargs.pop('cmap', None)
+    cmap = kwargs.pop('cmap', plt.cm.jet)
 
     if SETTINGS['auto_show']:
         fig = plt.figure()
@@ -269,8 +270,9 @@ def showProjection(ensemble, modes, *args, **kwargs):
     else:
         raise TypeError('color must be a string or a list')
 
-    if cmap is not None and isinstance(colors[0], Integral):
-        cmap.N = num
+    color_norm = None
+    if isinstance(colors[0], Number):
+        color_norm = matplotlib.colors.Normalize(vmin=min(colors), vmax=max(colors))
 
     labels = kwargs.pop('label', None)
     if isinstance(labels, str) or labels is None:
@@ -317,11 +319,11 @@ def showProjection(ensemble, modes, *args, **kwargs):
     for opts, indices in indict.items():  # PY3K: OK
         marker, color, label = opts
         kwargs['marker'] = marker
-        if cmap is not None:
+        if color_norm is not None:
             try:
-                cmap.colors[int(float(color))]
+                color = cmap.colors[color_norm(color)]
             except:
-                color = cmap(int(float(color)))
+                color = cmap(color_norm(color))
         kwargs['c'] = color
 
         if label:


### PR DESCRIPTION
An update to matplotlib means cmap changed and it doesn't have an attribute `.color`. This is the fix to the problem. It wasn't necessary to change anything else.