### PR TITLE
Modified mapping functions to be compatible with SimpleChain input

### DIFF
--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -638,6 +638,7 @@ class Ensemble(object):
         if weights is not None:
             if weights.ndim == 3:
                 weightsum = weights.sum(axis=0)
+                weightsum[weightsum==0.] = 1. # add pseudocount to avoid nan
             else:
                 weightsum = length
 

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -9,7 +9,7 @@ import numpy as np
 from prody.proteins import fetchPDB, parsePDB, writePDB, alignChains
 from prody.utilities import openFile, showFigure, copy, isListLike, pystr
 from prody import LOGGER, SETTINGS
-from prody.atomic import AtomMap, Chain, AtomGroup, Selection, Segment, Select, AtomSubset
+from prody.atomic import Atomic, AtomMap, Chain, AtomGroup, Selection, Segment, Select, AtomSubset
 from prody.atomic.fields import DTYPE
 
 from .ensemble import *
@@ -411,7 +411,7 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
     :type unmapped: list
 
     :arg subset: a subset for selecting particular atoms from the input structures.
-        Default is ``"calpha"``
+        Default is ``"all"``
     :type subset: str
 
     :arg superpose: if set to ``'iter'``, :func:`.PDBEnsemble.iterpose` will be used to 
@@ -422,7 +422,7 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
 
     occupancy = kwargs.pop('occupancy', None)
     degeneracy = kwargs.pop('degeneracy', True)
-    subset = str(kwargs.get('subset', 'calpha')).lower()
+    subset = str(kwargs.get('subset', 'all')).lower()
     superpose = kwargs.pop('superpose', 'iter')
     superpose = kwargs.pop('iterpose', superpose)
     debug = kwargs.pop('debug', {})
@@ -457,6 +457,7 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
         target = ref
     
     # initialize a PDBEnsemble with reference atoms and coordinates
+    isrefset = False
     if isinstance(ref, PDBEnsemble):
         ensemble = ref
     else:
@@ -464,8 +465,13 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
         if subset != 'all':
             target = target.select(subset)
         ensemble = PDBEnsemble(title)
-        ensemble.setAtoms(target)
-        ensemble.setCoords(target.getCoords())
+        if isinstance(target, Atomic):
+            ensemble.setAtoms(target)
+            ensemble.setCoords(target.getCoords())
+            isrefset = True
+        else:
+            ensemble._n_atoms = len(target)
+            isrefset = False
     
     # build the ensemble
     if unmapped is None: unmapped = []
@@ -503,12 +509,16 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
                 lbl += '_%s'%strchids
             ensemble.addCoordset(atommap, weights=atommap.getFlags('mapped'), 
                                 label=lbl, degeneracy=degeneracy)
+            
+            if not isrefset:
+                ensemble.setCoords(atommap.getCoords())
+                isrefset = True
 
     LOGGER.finish()
 
     if occupancy is not None:
         ensemble = trimPDBEnsemble(ensemble, occupancy=occupancy)
-
+    
     if superpose == 'iter':
         ensemble.iterpose()
     elif superpose is not False:


### PR DESCRIPTION
Despite being checked, objects of `SimpleChain` are avoided to be mentioned in error or warning messages in order not to confuse users (`SimpleChain` is not designed to be exposed to users).