### PR TITLE
error fix for buildPDBEnsemble with multi-state PDB

### DIFF
--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -432,7 +432,10 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
                                  'more details: http://prody.csb.pitt.edu/manual/release/v1.11_series.html')
     start = time.time()
 
-    if len(atomics) == 1:
+    if not isListLike(atomics):
+        raise TypeError('atomics should be list-like')
+
+    if len(atomics) == 1 and degeneracy is True:
         raise ValueError('atomics should have at least two items')
 
     if labels is not None:


### PR DESCRIPTION
Two problems are fixed here:

1. The current form accepts single structures and throws an error when it iterates through the atoms in them. Therefore, a list-like has to be checked for instead of just using `len`, which corresponds to `numAtoms` for atomgroups. Only then can we use `len` to check the length of the list-like.

2. The list is allowed to have one element if `degeneracy=False` because then you have multiple structures from one atomic so that gets included in the check too.