### PR TITLE
Few changes to SignDy functions

### DIFF
--- a/prody/dynamics/perturb.py
+++ b/prody/dynamics/perturb.py
@@ -70,17 +70,17 @@ def calcPerturbResponse(model, **kwargs):
             raise ValueError('model and atoms must have the same number atoms')
 
     n_atoms = model.numAtoms()
-    LOGGER.timeit('_prody_prs_all')
-    LOGGER.info('Calculating covariance matrix')
-    LOGGER.timeit('_prody_cov')
+    # LOGGER.timeit('_prody_prs_all')
+    # LOGGER.info('Calculating covariance matrix')
+    # LOGGER.timeit('_prody_cov')
 
     cov = model.getCovariance()
 
-    LOGGER.clear()
-    LOGGER.report('Covariance matrix calculated in %.1fs.', '_prody_cov')
+    # LOGGER.clear()
+    # LOGGER.report('Covariance matrix calculated in %.1fs.', '_prody_cov')
 
-    LOGGER.info('Calculating perturbation response')
-    LOGGER.timeit('_prody_prs_mat')
+    # LOGGER.info('Calculating perturbation response')
+    # LOGGER.timeit('_prody_prs_mat')
     if not model.is3d():
         prs_matrix = cov**2
 
@@ -102,9 +102,9 @@ def calcPerturbResponse(model, **kwargs):
             j3p3 += 3                
             prs_matrix[:,j] = (n_by_3n_cov_squared[:,j3:j3p3]).sum(1)
 
-    LOGGER.clear()
-    LOGGER.report('Perturbation response matrix calculated in %.1fs.',
-                  '_prody_prs_mat')
+    # LOGGER.clear()
+    # LOGGER.report('Perturbation response matrix calculated in %.1fs.',
+    #               '_prody_prs_mat')
 
     norm_prs_matrix = np.zeros((n_atoms, n_atoms))
     self_dp = np.diag(prs_matrix)  
@@ -120,8 +120,8 @@ def calcPerturbResponse(model, **kwargs):
     effectiveness = np.average(norm_prs_matrix, weights=W, axis=1)
     sensitivity = np.average(norm_prs_matrix, weights=W, axis=0)
 
-    LOGGER.report('Perturbation response scanning completed in %.1fs.',
-                  '_prody_prs_all')
+    # LOGGER.report('Perturbation response scanning completed in %.1fs.',
+    #               '_prody_prs_all')
 
     if atoms is not None:
         try:

--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -11,7 +11,7 @@ from prody import LOGGER
 from prody.atomic import Atomic, sliceAtoms
 from prody.atomic.atomgroup import checkLabel
 from prody.measure import getRMSD, calcDeformVector
-from prody.utilities import importLA, checkCoords, checkWeights, copy
+from prody.utilities import importLA, checkCoords, checkWeights, copy, isListLike
 
 from .conformation import *
 
@@ -281,6 +281,22 @@ class Ensemble(object):
         if self._indices is None or not selected:
             return self._coords.copy()
         return self._coords[self._indices].copy()
+
+    def getIndices(self):
+        """Returns a copy of indices of selected columns"""
+
+        return copy(self._indices)
+
+    def setIndices(self, value):
+        if not isListLike(value):
+            raise TypeError('value must be a list or numpy.ndarray instance')
+
+        array = asarray(value)
+
+        if len(array) != self._n_atoms:
+            raise ValueError('length mismatch between this ensemble '
+                             '(%d) and indices (%d)'%(self._n_atoms, len(array)))
+        self._indices = value
 
     def _getCoords(self, selected=True):
         """Returns a view of reference coordinates for selected atoms."""


### PR DESCRIPTION
- Added `trimModel` that simply slice the connectivity matrix (instead of modes as does by `sliceModel`).
- Added `calcSignaturePerturbResponse`.
- `calcENM` now accepts `numpy.ndarray` as input.
- Added `getIndices` and `setIndices` to `Ensemble` (and `PDBEnsemble`).