### PR TITLE
Improved how dummy nodes are treated in SignDy functions

### DIFF
--- a/prody/dynamics/nma.py
+++ b/prody/dynamics/nma.py
@@ -320,7 +320,14 @@ class NMA(object):
 
 class MaskedNMA(NMA):
     def __init__(self, name='Unknown', mask=False, masked=True):
-        super(MaskedNMA, self).__init__(name)
+        if isinstance(name, str):
+            super(MaskedNMA, self).__init__(name)
+        else:
+            model = name
+            name = model.getTitle()
+            super(MaskedNMA, self).__init__(name)
+            self.__dict__.update(model.__dict__)
+            
         self.mask = False
         self.masked = masked
         self._maskedarray = None

--- a/prody/dynamics/perturb.py
+++ b/prody/dynamics/perturb.py
@@ -11,7 +11,7 @@ from prody.proteins import parsePDB
 from prody.atomic import AtomGroup, Selection, Atomic, sliceAtomicData
 from prody.ensemble import Ensemble, Conformation
 from prody.trajectory import TrajBase
-from prody.utilities import importLA
+from prody.utilities import importLA, div0
 from numpy import sqrt, arange, log, polyfit, array
 
 from .nma import NMA
@@ -109,7 +109,8 @@ def calcPerturbResponse(model, **kwargs):
     norm_prs_matrix = np.zeros((n_atoms, n_atoms))
     self_dp = np.diag(prs_matrix)  
     self_dp = self_dp.reshape(n_atoms, 1)
-    norm_prs_matrix = prs_matrix / np.repeat(self_dp, n_atoms, axis=1)
+    re_self_dp = np.repeat(self_dp, n_atoms, axis=1)
+    norm_prs_matrix = div0(prs_matrix, re_self_dp)
 
     if no_diag:
        # suppress the diagonal (self displacement) to facilitate

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -1915,7 +1915,8 @@ def showTree(tree, format='matplotlib', **kwargs):
     type tree: :class:`~Bio.Phylo.BaseTree.Tree`
     
     arg format: depending on the format, you will see different forms of trees. 
-        Acceptable formats are ``"plt"``, ``"ascii"`` and ``"networkx"``
+        Acceptable formats are ``"plt"`` (or ``"mpl"`` or ``"matplotlib"``), 
+        ``"ascii"`` and ``"networkx"``. Default is ``"matplotlib"``.
     type format: str
     
     keyword font_size: font size for branch labels

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -201,8 +201,7 @@ class PDBEnsemble(Ensemble):
         self._trans = trans
 
     def iterpose(self, rmsd=0.0001):
-
-        confs = self._confs.copy()
+        confs = copy(self._confs)
         Ensemble.iterpose(self, rmsd)
         self._confs = confs
         LOGGER.info('Final superposition to calculate transformations.')

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -1522,7 +1522,7 @@ def combineAtomMaps(mappings, target=None, **kwargs):
                 else:
                     cov_matrix[i, j] = mapping[3] / 100.
                     cost_matrix[i, j] = 1 - cov_matrix[i, j]
-    
+
         # uses LAP to find the optimal mappings of chains
         atommaps = []
         (R, C), crrpds = multilap(cost_matrix, nodes, BIG_NUMBER)
@@ -1665,7 +1665,10 @@ def combineAtomMaps(mappings, target=None, **kwargs):
                           label='_atommap_lap')
     
     if len(atommaps) == 0:
-        LOGGER.warn('no atommaps were found. Consider inceasing rmsd_reject or drmsd')
+        if np.count_nonzero(cov_matrix) == 0:
+            LOGGER.warn('no atommaps were available. Consider adjusting accepting criteria')
+        else:
+            LOGGER.warn('no atommaps were found. Consider inceasing rmsd_reject or drmsd')
     return atommaps
 
 def rankAtomMaps(atommaps, target):

--- a/prody/utilities/catchall.py
+++ b/prody/utilities/catchall.py
@@ -196,9 +196,9 @@ def calcTree(names, distance_matrix, method='upgma', linkage=False):
 
     if method in ['ward', 'single', 'average', 'weighted', 'centroid', 'median']:
         from scipy.cluster.hierarchy import linkage as hlinkage
-        from scipy.spatial.distance import pdist
+        from scipy.spatial.distance import squareform
         
-        Z = hlinkage(pdist(distance_matrix), method=method)
+        Z = hlinkage(squareform(distance_matrix), method=method)
         tree = getTreeFromLinkage(names, Z)
     else:
         matrix = []

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -521,7 +521,7 @@ def fastin(a, B):
             return True
     return False
 
-def div0(a, b):
+def div0(a, b, defval=0.):
     """ Performs ``true_divide`` but ignores the error when division by zero 
     (result is set to zero instead). """
 
@@ -531,9 +531,9 @@ def div0(a, b):
         c = true_divide(a, b)
         if isscalar(c):
             if not isfinite(c):
-                c = 0
+                c = defval
         else:
-            c[~isfinite(c)] = 0.  # -inf inf NaN
+            c[~isfinite(c)] = defval  # -inf inf NaN
     return c
 
 def wmean(array, weights, axis=None):
@@ -544,7 +544,7 @@ def wmean(array, weights, axis=None):
     except ZeroDivisionError:
         numer = sum(array*weights, axis=axis)
         denom = sum(weights, axis=axis)
-        avg = div0(numer, denom)
+        avg = div0(numer, denom, nan)
     return avg
 
 def bin2dec(x):


### PR DESCRIPTION
Basically now SignDy excludes dummy atoms from mode calculations (before they will be represented by ensemble-averaged coordinates). In this way, columns with zero occupancies will not give extra zero modes and unrealistic spikes in results (they were basically free particles since the average coordinate for them will be [0, 0, 0]). 