### PR TITLE
added error for providing parsePDB an empty list

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -105,6 +105,9 @@ def parsePDB(*pdb, **kwargs):
     extend_biomol = kwargs.pop('extend_biomol', False)
 
     n_pdb = len(pdb)
+    if n_pdb == 0:
+        raise ValueError('Please provide a PDB ID or filename')
+
     if n_pdb == 1:
         if isListLike(pdb[0]):
             pdb = pdb[0]


### PR DESCRIPTION
Otherwise, it runs until the LOGGER complains:

```
Python 3.7.1 (default, Dec 14 2018, 13:28:58) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.13.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import os 
   ...: from prody import * 
   ...: import numpy as np 
   ...: import matplotlib.pyplot as plt 
   ...: import matplotlib 
   ...: plt.ion() 
   ...:  
   ...: proc = 3 
   ...:  
   ...: pdb = [f for f in os.listdir('.') 
   ...:        if f.endswith('redocking.pdb')] 
   ...: ag = parsePDB(pdb, model=1) 
   ...:  
   ...: fname = pdb[0] 
   ...: peptide = fname.split('_')[0]                                                                                   
---------------------------------------------------------------------------
AssertionError                            Traceback (most recent call last)
<ipython-input-1-26eb78fb9b0c> in <module>
     10 pdb = [f for f in os.listdir('.')
     11        if f.endswith('redocking.pdb')]
---> 12 ag = parsePDB(pdb, model=1)
     13 
     14 fname = pdb[0]

~/Documents/code/ProDy/prody/proteins/pdbfile.py in parsePDB(*pdb, **kwargs)
    125         start = time.time()
    126         LOGGER.progress('Retrieving {0} PDB structures...'
--> 127                     .format(n_pdb), n_pdb, '_prody_parsePDB')
    128         for i, p in enumerate(pdb):
    129             kwargs = {}

~/Documents/code/ProDy/prody/utilities/logger.py in progress(self, msg, steps, label, **kwargs)
    242         if steps is not None:  # if None then no upperlimit
    243             assert isinstance(steps, numbers.Integral) and steps > 0, \
--> 244                 'steps must be a positive integer'
    245 
    246         self._times[label] = time.time()

AssertionError: steps must be a positive integer
```