### PR TITLE
bug fix for writeDCD with Ensemble and frame selection

### DIFF
--- a/prody/trajectory/dcdfile.py
+++ b/prody/trajectory/dcdfile.py
@@ -522,7 +522,7 @@ def writeDCD(filename, trajectory, start=None, stop=None, step=None,
         raise TypeError('{0} is not a valid type for trajectory'
                         .format(type(trajectory)))
 
-    irange = list(range(*slice(start, stop,step)
+    irange = list(range(*slice(start, stop, step)
                     .indices(trajectory.numCoordsets())))
     n_csets = len(irange)
     if n_csets == 0:
@@ -575,10 +575,10 @@ def writeDCD(filename, trajectory, start=None, stop=None, step=None,
     time_ = time()
     for j, i in enumerate(irange):
         diff = i - prev
-        if diff > 1:
-            trajectory.skip(diff-1)
         prev = i
         if isTrajectory:
+            if diff > 1:
+                trajectory.skip(diff-1)
             frame = next(trajectory)
             if frame is None:
                 break


### PR DESCRIPTION
The error was
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-5-c8cf0c2e82e5> in <module>
----> 1 writeDCD('step5_protein_1_frame_per_ns', run1, start=27, step=10)

~/Documents/code/ProDy/prody/trajectory/dcdfile.py in writeDCD(filename, trajectory, start, stop, step, align)
    577         diff = i - prev
    578         if diff > 1:
--> 579             trajectory.skip(diff-1)
    580         prev = i
    581         if isTrajectory:

AttributeError: 'Ensemble' object has no attribute 'skip'
```

Ensemble doesn't need that functionality because there's a frame reindexing step in the isEnsemble block anyway. 