### PR TITLE
bug fixes to alignChains and buildPDBEnsemble finding non-protein residues

### DIFF
--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -458,7 +458,6 @@ def buildPDBEnsemble(atomics, ref=None, title='Unknown', labels=None, unmapped=N
         target = ref._atoms
     else:
         target = ref
-    
     # initialize a PDBEnsemble with reference atoms and coordinates
     isrefset = False
     if isinstance(ref, PDBEnsemble):

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -1699,6 +1699,13 @@ def alignChains(atoms, target, match_func=bestMatch, **kwargs):
     and :func:`.combineAtomMaps`. Please check out those two functions for details 
     about the parameters.
     """
+    if len(atoms.protein) != len(atoms):
+        raise ValueError('Please provide only protein atoms in {0}'.format(
+            atoms.getTitle()))
+
+    if len(target.protein) != len(target):
+        raise ValueError('Please provide only protein atoms in {0}'.format(
+            target.getTitle()))
 
     mappings = mapOntoChains(atoms, target, match_func, **kwargs)
     m, n = mappings.shape


### PR DESCRIPTION
This is needed because SimpleChain removes non-protein residues.

The errors otherwise are
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-4-f5af22be1969> in <module>
----> 1 atommaps = alignChains(atoms, target)

~/Documents/code/ProDy/prody/proteins/compare.py in alignChains(atoms, target, match_func, **kwargs)
   1707         return []
   1708 
-> 1709     atommaps = combineAtomMaps(mappings, target, **kwargs)
   1710 
   1711     return atommaps

~/Documents/code/ProDy/prody/proteins/compare.py in combineAtomMaps(mappings, target, **kwargs)
   1638     # optimize atommaps based on superposition if target is given
   1639     if target is not None and len(nodes):
-> 1640         atommaps = _optimize(atommaps)
   1641         i = 2
   1642 

~/Documents/code/ProDy/prody/proteins/compare.py in _optimize(atommaps)
   1555         # extract nonoverlaping mappings
   1556         if len(atommaps):
-> 1557             atommaps, rmsds = rankAtomMaps(atommaps, target)
   1558             debug['rmsd'] = list(rmsds)
   1559 

~/Documents/code/ProDy/prody/proteins/compare.py in rankAtomMaps(atommaps, target)
   1682         weights = atommap.getFlags('mapped')
   1683         coords = atommap.getCoords()
-> 1684         rcoords, t = superpose(coords, coords0, weights)
   1685         rmsd = calcRMSD(rcoords, coords0, weights)
   1686 

~/Documents/code/ProDy/prody/measure/transform.py in superpose(mobile, target, weights)
    211     and the transformation that minimizes the RMSD."""
    212 
--> 213     t = calcTransformation(mobile, target, weights)
    214     result = applyTransformation(t, mobile)
    215     return (result, t)

~/Documents/code/ProDy/prody/measure/transform.py in calcTransformation(mobile, target, weights)
    115 
    116     if mob.shape != tar.shape:
--> 117         raise ValueError('reference and target coordinate arrays '
    118                          'must have same number of atoms')
    119 

ValueError: reference and target coordinate arrays must have same number of atoms
```
and
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
~/Documents/code/ProDy/prody/ensemble/pdbensemble.py in addCoordset(self, coords, weights, label, **kwargs)
    272         try:
--> 273             checkCoords(coords, csets=True, natoms=n_atoms)
    274         except:

~/Documents/code/ProDy/prody/utilities/checkers.py in checkCoords(coords, csets, natoms, dtype, name)
     46     elif natoms and shape[-2] != natoms:
---> 47         raise ValueError(str(name) + '.shape[-2] must match number of atoms')
     48 

ValueError: coords.shape[-2] must match number of atoms

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
~/non-cloud-documents/GABAA/morphs_and_rmsds.py in <module>
     14     recs = [ag.select('not chain G') for ag in ags]
     15 
---> 16     ens = buildPDBEnsemble(recs, superpose=False, unmapped=[])
     17     saveEnsemble(ens, 'GABAA_models')
     18 

~/Documents/code/ProDy/prody/ensemble/functions.py in buildPDBEnsemble(atomics, ref, title, labels, unmapped, **kwargs)
    517                 lbl += '_%s'%strchids
    518             ensemble.addCoordset(atommap, weights=atommap.getFlags('mapped'), 
--> 519                                 label=lbl, degeneracy=degeneracy)
    520 
    521             if not isrefset:

~/Documents/code/ProDy/prody/ensemble/pdbensemble.py in addCoordset(self, coords, weights, label, **kwargs)
    274         except:
    275             try:
--> 276                 checkCoords(coords, csets=True, natoms=n_select)
    277             except TypeError:
    278                 raise TypeError('coords must be a numpy array or an object '

~/Documents/code/ProDy/prody/utilities/checkers.py in checkCoords(coords, csets, natoms, dtype, name)
     45 
     46     elif natoms and shape[-2] != natoms:
---> 47         raise ValueError(str(name) + '.shape[-2] must match number of atoms')
     48 
     49     elif dtype:

ValueError: coords.shape[-2] must match number of atoms
```