### PR TITLE
added option for showOverlap to show diagonals from NMA or ModeSet co…

### DIFF
--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -820,8 +820,8 @@ def showContactMap(enm, **kwargs):
 def showOverlap(mode, modes, *args, **kwargs):
     """Show overlap :func:`~matplotlib.pyplot.bar`.
 
-    :arg mode: a single mode/vector
-    :type mode: :class:`.Mode`, :class:`.Vector`
+    :arg mode: a single mode/vector or multiple modes if **diag** is set to True
+    :type mode: :class:`.Mode`, :class:`.Vector`, :class:`.ModeSet`, :class:`.ANM`, :class:`.GNM`, :class:`.PCA`
 
     :arg modes: multiple modes
     :type modes: :class:`.ModeSet`, :class:`.ANM`, :class:`.GNM`, :class:`.PCA`
@@ -833,13 +833,22 @@ def showOverlap(mode, modes, *args, **kwargs):
     if SETTINGS['auto_show']:
         plt.figure()
 
-    if not isinstance(mode, (Mode, Vector)):
-        raise TypeError('mode must be Mode or Vector, not {0}'
-                        .format(type(mode)))
+    diag = kwargs.pop('diag', False)
+
+    if diag is False:
+        if not isinstance(mode, (Mode, Vector)):
+            raise TypeError('mode must be Mode or Vector, not {0}'
+                                .format(type(mode)))
+    else:
+        if not isinstance(mode, (NMA, ModeSet)):
+            raise TypeError('mode must be NMA or ModeSet, not {0}, when diag=True'
+                            .format(type(modes)))
+
     if not isinstance(modes, (NMA, ModeSet)):
         raise TypeError('modes must be NMA or ModeSet, not {0}'
                         .format(type(modes)))
-    overlap = abs(calcOverlap(mode, modes))
+
+    overlap = abs(calcOverlap(mode, modes, diag=diag))
     if isinstance(modes, NMA):
         arange = np.arange(len(modes)) + 1
     else:

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -820,8 +820,12 @@ def showContactMap(enm, **kwargs):
 def showOverlap(mode, modes, *args, **kwargs):
     """Show overlap :func:`~matplotlib.pyplot.bar`.
 
-    :arg mode: a single mode/vector or multiple modes if **diag** is set to True
-    :type mode: :class:`.Mode`, :class:`.Vector`, :class:`.ModeSet`, :class:`.ANM`, :class:`.GNM`, :class:`.PCA`
+    :arg mode: a single mode/vector or multiple modes.
+        If multiple modes are provided, then the overlaps are calculated 
+        by going through them one by one, i.e. mode i from this set is 
+        compared with mode i from the other set.
+    :type mode: :class:`.Mode`, :class:`.Vector`, :class:`.ModeSet`, 
+        :class:`.ANM`, :class:`.GNM`, :class:`.PCA`
 
     :arg modes: multiple modes
     :type modes: :class:`.ModeSet`, :class:`.ANM`, :class:`.GNM`, :class:`.PCA`
@@ -833,22 +837,15 @@ def showOverlap(mode, modes, *args, **kwargs):
     if SETTINGS['auto_show']:
         plt.figure()
 
-    diag = kwargs.pop('diag', False)
-
-    if diag is False:
-        if not isinstance(mode, (Mode, Vector)):
-            raise TypeError('mode must be Mode or Vector, not {0}'
-                                .format(type(mode)))
-    else:
-        if not isinstance(mode, (NMA, ModeSet)):
-            raise TypeError('mode must be NMA or ModeSet, not {0}, when diag=True'
-                            .format(type(modes)))
+    if not isinstance(mode, (Mode, Vector, NMA, ModeSet)):
+        raise TypeError('mode must be Mode, Vector, NMA or ModeSet, not {0}'
+                        .format(type(mode)))
 
     if not isinstance(modes, (NMA, ModeSet)):
         raise TypeError('modes must be NMA or ModeSet, not {0}'
                         .format(type(modes)))
 
-    overlap = abs(calcOverlap(mode, modes, diag=diag))
+    overlap = abs(calcOverlap(mode, modes, diag=True))
     if isinstance(modes, NMA):
         arange = np.arange(len(modes)) + 1
     else:


### PR DESCRIPTION
…mparisons

```
plt.figure(); showOverlap(anm_mod2, anm, diag=True);
```
yields ![adding_100_to_gamma_for_15-30A_apart_cysteines_3o21_CD_ANM_abs_diag_overlaps](https://user-images.githubusercontent.com/13259162/84851603-9b727d80-b052-11ea-8637-a510c25916f2.png), which is the diagonal of 
![adding_100_to_gamma_for_15-30A_apart_cysteines_3o21_CD_ANM_abs_overlaps](https://user-images.githubusercontent.com/13259162/84851613-a7f6d600-b052-11ea-87b0-460f7aae41df.png)

