### PR TITLE
added calcInertiaTensor, calcPrincAxes and _solveEig

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+This is a first draft, which is based on the ProDy website page http://prody.csb.pitt.edu/manual/devel/develop.html. Please see that page for updates.
+
+
+Install Git and a GUI
+
+ProDy source code is managed using Git distributed revision controlling system. You need to install git, and if you prefer a GUI for it, on your computer to be able to contribute to development of ProDy.
+
+On Debian/Ubuntu Linux, for example, you can run the following to install git and gitk:
+
+$ sudo apt-get install git gitk
+
+For other operating systems, you can obtain installation instructions and files from Git.
+
+You will only need to use a few basic git commands. These commands are provided below, but usually without an adequate description. Please refer to Git book and Git docs for usage details and examples.
+Fork and Clone ProDy
+
+ProDy source code an issue tracker are hosted on Github. You need to create an account on this service, if you do not have one already.
+
+If you work on Mac OS or Windows, you may consider getting GitHub Mac or GitHub Windows to help you manage a copy of the repository.
+
+Once you have an account, you need to make a fork of ProDy, which is creating a copy of the repository in your account. You will see a link for this on ProDy source code page. You will have write access to this fork and later will use it share your changes with others.
+
+The next step is cloning the fork from your online account to your local system. If you are not using the GitHub software, you can do it as follows:
+
+$ git clone https://github.com/prody/ProDy.git
+
+This will create ProDy folder with a copy of the project files in it:
+
+$ cd ProDy
+$ ls
+bdist_wininst.bat  docs   INSTALL.rst  LICENSE.rst  Makefile
+MANIFEST.in        prody  README.rst   scripts      setup.py
+
+Setup Working Environment
+
+You can use ProDy directly from this clone by adding ProDy folder to your PYTHONPATH environment variable, e.g.:
+
+export PYTHONPATH=$PYTHONPATH:$/home/USERNAME/path/to/ProDy
+
+This will not be enough though, since you also need to compile C extensions. You can run the following series of commands to build and copy C modules to where they need to be:
+
+$ cd ProDy
+$ python setup.py build_ext --inplace --force
+
+or, on Linux you can:
+
+$ make build
+
+You may also want to make sure that you can run ProDy Applications from anywhere on your system. One way to do this by adding ProDy/scripts folder to your PATH environment variable, e.g.:
+
+export PATH=$PATH:$/home/USERNAME/path/to/ProDy/scripts
+
+Modify, Test, and Commit
+
+When modifying ProDy files you may want to follow the Style Guide for ProDy. Closely following the guidelines therein will allow for incorporation of your changes to ProDy quickly.
+
+If you changed .py files, you should ensure to check the integrity of the package. To do this, you should at least run fast ProDy tests as follows:
+
+$ cd ProDy
+$ nosetests
+
+See Testing ProDy for alternate and more comprehensive ways of testing. ProDy unittest suit may not include a test for the function or the class that you just changed, but running the tests will ensure that the ProDy package can be imported and run without problems.
+
+After ensuring that the package runs, you can commit your changes as follows:
+
+$ git commit modified_file_1.py modified_file_2.py
+
+or:
+
+$ git commit -a
+
+This command will open a text editor for you to describe the changes that you just committed.
+Push and Pull Request
+
+After you have committed your changes, you will need to push them to your Bitbucket account:
+
+git push origin master
+
+This step will ask for your account user name. If you are going to push to your GitHub/Bitbucket account frequently, you may add an SSH key for automatic authentication. To add an SSH key for your system, go to Edit Your Profile ‣ SSH keys page on GitHub or Manage Account ‣ SSH keys page on Bitbucket.
+
+After pushing your changes, you will need to make a pull request from your to notify ProDy developers of the changes you made and facilitate their incorporation to ProDy.
+Update Local Copy
+
+You can also keep an up-to-date copy of ProDy by pulling changes from the master ProDy repository on a regular basis. You need add to the master repository as a remote to your local copy. You can do this running the following command from the ProDy project folder:
+
+$ cd prody
+$ git remote add prodymaster git@github.com:abakan/ProDy.git
+
+or:
+
+$ cd prody
+$ git remote add prodymaster git@bitbucket.org:abakan/prody.git
+
+You may use any name other than prodymaster, but origin, which points to the ProDy fork in your account.
+
+After setting up this remote, calling git pull command will fetch latest changes from ProDy master repository and merge them to your local copy:
+
+$ git pull prodymaster master
+
+Note that when there are changes in C modules, you need to run the following commands again to update the binary module files:
+
+$ python setup.py build_ext --inplace --force
+

--- a/prody/apps/apptools.py
+++ b/prody/apps/apptools.py
@@ -1,4 +1,4 @@
-"""This module define tools for application development."""
+"""This module defines tools for application development."""
 
 from copy import copy
 try:

--- a/prody/atomic/fields.py
+++ b/prody/atomic/fields.py
@@ -11,7 +11,7 @@ below.  :class:`Atomic` classes, such as :class:`.Selection`, offer ``get`` and
 
 from numpy import array
 
-from prody.utilities import wrapText
+from prody.utilities import wrapText, DTYPE
 
 from .flags import FIELDS as FLAG_FIELDS
 
@@ -117,8 +117,6 @@ class Field(object):
             return wrapText(docstr)
 
 HVNONE = ['_hv', 'segindex', 'chindex', 'resindex']
-
-DTYPE = array(['a']).dtype.char  # 'S' for PY2K and 'U' for PY3K
 
 ATOMIC_FIELDS = {
     'name':      Field('name', DTYPE + '6', selstr=('name CA CB',)),

--- a/prody/atomic/functions.py
+++ b/prody/atomic/functions.py
@@ -21,8 +21,8 @@ from .selection import Selection
 from .hierview import HierView
 
 __all__ = ['iterFragments', 'findFragments', 'loadAtoms', 'saveAtoms',
-           'isReserved', 'listReservedWords', 'sortAtoms', 'sliceAtoms', 
-           'extendAtoms', 'sliceAtomicData', 'extendAtomicData']
+           'isReserved', 'listReservedWords', 'sortAtoms', 
+           'sliceAtoms', 'extendAtoms', 'sliceAtomicData', 'extendAtomicData']
 
 
 SAVE_SKIP_ATOMGROUP = set(['numbonds', 'fragindex'])

--- a/prody/atomic/functions.py
+++ b/prody/atomic/functions.py
@@ -339,6 +339,8 @@ def extendAtoms(nodes, atoms, is3d=False):
     #LOGGER.progress('Extending atoms...', n_nodes, '_prody_extendAtoms_extend')
     for i, node in enumerate(i_nodes):
         #LOGGER.update(i, label='_prody_extendAtoms')
+        if node is None:
+            continue
         res = get(node.getChid() or None, node.getResnum(),
                   node.getIcode() or None, node.getSegname() or None)
         if res is None:

--- a/prody/database/goa.py
+++ b/prody/database/goa.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """This module defines functions for interfacing with the EBI's
-GO association (goa) databases for analysing gene/protein functions 
+Gene Ontology Annotation (GOA) database for analysing gene/protein functions 
 through the Gene Ontology (GO).
 
 This module is based on the tutorial notebook at 

--- a/prody/dynamics/__init__.py
+++ b/prody/dynamics/__init__.py
@@ -248,7 +248,6 @@ from . import rtb
 from .rtb import *
 __all__.extend(rtb.__all__)
 
-
 from . import gnm
 from .gnm import *
 __all__.extend(gnm.__all__)

--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -18,7 +18,6 @@ from .nma import NMA
 from .modeset import ModeSet
 from .mode import VectorBase, Mode, Vector
 from .gnm import GNMBase
-from .functions import calcENM
 
 __all__ = ['calcCollectivity', 'calcCovariance', 'calcCrossCorr',
            'calcFractVariance', 'calcSqFlucts', 'calcTempFactors',

--- a/prody/dynamics/bbenm.py
+++ b/prody/dynamics/bbenm.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-"""This module defines a class and a function for rotating translating blocks
-(RTB) calculations."""
+"""This module defines a class and a function for using the tensorial network model, 
+which includes bond-bending and twist elasticities."""
 
 import numpy as np
 

--- a/prody/dynamics/entropy.py
+++ b/prody/dynamics/entropy.py
@@ -2,17 +2,12 @@
 """This module defines functions for calculating entropy transfer from normal
 modes."""
 
-import time
-
 import numpy as np
 
 from prody import LOGGER
 from prody.proteins import parsePDB
-from prody.atomic import AtomGroup, Selection
-from prody.ensemble import Ensemble, Conformation
-from prody.trajectory import TrajBase
 from prody.utilities import importLA
-from numpy import sqrt, arange, log, polyfit, array
+from numpy import arange, log
 
 from .nma import NMA
 

--- a/prody/dynamics/functions.py
+++ b/prody/dynamics/functions.py
@@ -7,7 +7,7 @@ from os.path import abspath, join, isfile, isdir, split, splitext
 import numpy as np
 
 from prody import LOGGER, SETTINGS, PY3K
-from prody.atomic import Atomic, AtomGroup, AtomSubset
+from prody.atomic import Atomic, AtomSubset
 from prody.utilities import openFile, isExecutable, which, PLATFORM, addext
 
 from .nma import NMA, MaskedNMA

--- a/prody/dynamics/imanm.py
+++ b/prody/dynamics/imanm.py
@@ -4,7 +4,6 @@
 import numpy as np
 
 from prody import LOGGER
-from prody.atomic import Atomic, AtomGroup
 from prody.utilities import importLA, checkCoords, copy
 from numpy import sqrt, zeros, ones, array, ceil, dot
 

--- a/prody/dynamics/perturb.py
+++ b/prody/dynamics/perturb.py
@@ -7,12 +7,8 @@ import time
 import numpy as np
 
 from prody import LOGGER
-from prody.proteins import parsePDB
 from prody.atomic import AtomGroup, Selection, Atomic, sliceAtomicData
-from prody.ensemble import Ensemble, Conformation
-from prody.trajectory import TrajBase
-from prody.utilities import importLA, div0
-from numpy import sqrt, arange, log, polyfit, array
+from prody.utilities import div0
 
 from .nma import NMA
 from .modeset import ModeSet

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -622,16 +622,16 @@ def showMode(mode, *args, **kwargs):
     if mode.is3d():
         a3d = mode.getArrayNx3()
         show = []
-        show.append(showAtomicLines(a3d[:, 0], atoms=atoms, label='x-component', final=False, **kwargs))
-        show.append(showAtomicLines(a3d[:, 1], atoms=atoms, label='y-component', final=False, **kwargs))
-        show.append(showAtomicLines(a3d[:, 2], atoms=atoms, label='z-component', final=final, **kwargs))
+        show.append(showAtomicLines(a3d[:, 0], label='x-component', final=False, **kwargs))
+        show.append(showAtomicLines(a3d[:, 1], label='y-component', final=False, **kwargs))
+        show.append(showAtomicLines(a3d[:, 2], label='z-component', final=final, **kwargs))
     else:
         a1d = mode._getArray()
         show = showAtomicLines(a1d, *args, **kwargs)
         if show_hinges and isinstance(mode, Mode):
             hinges = calcHinges(mode)
             if hinges is not None:
-                showAtomicLines(hinges, a1d[hinges], 'r*', atoms=atoms, final=False)
+                showAtomicLines(hinges, a1d[hinges], 'r*', final=False)
 
     if atoms is not None:
         title(str(atoms))

--- a/prody/dynamics/rtb.py
+++ b/prody/dynamics/rtb.py
@@ -26,16 +26,10 @@ class Increment(object):
 class RTB(ANMBase):
 
     """Class for Rotations and Translations of Blocks (RTB) method ([FT00]_).
-    Optional arguments permit imposing constraints along Z-direction as in
-    *imANM* method described in [TL12]_.
 
     .. [FT00] Tama F, Gadea FJ, Marques O, Sanejouand YH. Building-block
        approach for determining low-frequency normal modes of macromolecules.
        *Proteins* **2000** 41:1-7.
-
-    .. [TL12] Lezon TR, Bahar I, Constraints Imposed by the Membrane
-       Selectively Guide the Alternating Access Dynamics of the Glutamate
-       Transporter GltPh
 
     """
 

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -1467,10 +1467,10 @@ def showSignatureOverlaps(mode_ensemble, **kwargs):
         overlap_triu = overlaps[:, :, r, c]
 
         if std:
-            stdV = overlap_triu.std(axis=-1).std(axis=-1)
+            stdV = overlap_triu.std(axis=-1)
             show = showMatrix(stdV)
         else:
-            meanV = overlap_triu.mean(axis=-1).mean(axis=-1)
+            meanV = overlap_triu.mean(axis=-1)
             show = showMatrix(meanV)
     
     return show

--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -9,11 +9,10 @@ import numpy as np
 import warnings
 
 from prody import LOGGER, SETTINGS
-from prody.utilities import showFigure, showMatrix, copy, checkWeights, openFile
+from prody.utilities import showFigure, showMatrix, copy, checkWeights, openFile, DTYPE
 from prody.utilities import getValue, importLA, wmean, div0
 from prody.ensemble import Ensemble, Conformation
 from prody.atomic import AtomGroup
-from prody.atomic.fields import DTYPE
 
 from .nma import NMA
 from .modeset import ModeSet

--- a/prody/dynamics/vmdfile.py
+++ b/prody/dynamics/vmdfile.py
@@ -6,26 +6,18 @@ Questions/Problems: karolami@pitt.edu
 __all__ = ['writeVMDstiffness', 'writeDeformProfile', 'calcChainsNormDistFluct']
 
 import os
-from os.path import abspath, join, split, splitext
 
 import numpy as np
 
-from prody import LOGGER, SETTINGS, PY3K
-from prody.atomic import AtomGroup, sliceAtoms
-from prody.utilities import openFile, isExecutable, which, PLATFORM, addext, checkCoords
+from prody import LOGGER
+from prody.atomic import sliceAtoms
+from prody.utilities import openFile, addext, checkCoords
 from prody.proteins import writePDB
 
-from .nma import NMA
-from .anm import ANM
-from .gnm import GNM, ZERO
-from .pca import PCA
-from .mode import Vector, Mode
-from .modeset import ModeSet
 from .nmdfile import viewNMDinVMD, pathVMD, getVMDpath, setVMDpath
 
 def writeVMDstiffness(stiffness, pdb, indices, k_range, filename='vmd_out', \
                       select='protein and name CA', loadToVMD=False):
-   
     """
     Returns three files starting with the provided filename and having 
     their own extensions:

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -6,11 +6,10 @@ from numbers import Integral
 
 import numpy as np
 
-from prody.proteins import fetchPDB, parsePDB, writePDB, alignChains
-from prody.utilities import openFile, showFigure, copy, isListLike, pystr
+from prody.proteins import alignChains
+from prody.utilities import openFile, showFigure, copy, isListLike, pystr, DTYPE
 from prody import LOGGER, SETTINGS
 from prody.atomic import Atomic, AtomMap, Chain, AtomGroup, Selection, Segment, Select, AtomSubset
-from prody.atomic.fields import DTYPE
 
 from .ensemble import *
 from .pdbensemble import *

--- a/prody/measure/measure.py
+++ b/prody/measure/measure.py
@@ -2,11 +2,11 @@
 """This module defines a class and methods and for comparing coordinate data
 and measuring quantities."""
 
-from numpy import ndarray, power, sqrt, array, zeros, arccos
+from numpy import ndarray, power, sqrt, array, zeros, arccos, dot
 from numpy import sign, tile, concatenate, pi, cross, subtract, var
 
 from prody.atomic import Atomic, Residue, Atom
-from prody.utilities import importLA, checkCoords, getDistance, getCoords
+from prody.utilities import importLA, _solveEig, checkCoords, getDistance, getCoords
 from prody import LOGGER, PY2K
 
 if PY2K:
@@ -18,7 +18,8 @@ __all__ = ['buildDistMatrix', 'calcDistance',
            'calcMSF', 'calcRMSF',
            'calcDeformVector',
            'buildADPMatrix', 'calcADPAxes', 'calcADPs',
-           'pickCentral', 'pickCentralAtom', 'pickCentralConf', 'getWeights']
+           'pickCentral', 'pickCentralAtom', 'pickCentralConf', 'getWeights',
+           'calcInertiaTensor', 'calcPrincAxes']
 
 RAD2DEG = 180 / pi
 
@@ -798,3 +799,19 @@ def buildADPMatrix(atoms):
         element[1, 2] = element[2, 1] = anisou[5]
         adp[i*3:(i+1)*3, i*3:(i+1)*3] = element
     return adp
+
+
+def calcInertiaTensor(coords):
+    """"Calculate inertia tensor from coords"""
+    coords = getCoords(coords)
+
+    center = calcCenter(coords)
+    coords = coords - center
+    return dot(coords.transpose(), coords)
+
+
+def calcPrincAxes(coords, turbo=True):
+    """Calculate principal axes from coords"""
+    M = calcInertiaTensor(coords)
+    _, vectors = _solveEig(M, 3)
+    return vectors

--- a/prody/measure/measure.py
+++ b/prody/measure/measure.py
@@ -6,7 +6,7 @@ from numpy import ndarray, power, sqrt, array, zeros, arccos, dot
 from numpy import sign, tile, concatenate, pi, cross, subtract, var
 
 from prody.atomic import Atomic, Residue, Atom
-from prody.utilities import importLA, _solveEig, checkCoords, getDistance, getCoords
+from prody.utilities import importLA, solveEig, checkCoords, getDistance, getCoords
 from prody import LOGGER, PY2K
 
 if PY2K:
@@ -813,5 +813,5 @@ def calcInertiaTensor(coords):
 def calcPrincAxes(coords, turbo=True):
     """Calculate principal axes from coords"""
     M = calcInertiaTensor(coords)
-    _, vectors = _solveEig(M, 3)
+    _, vectors = solveEig(M, 3)
     return vectors

--- a/prody/proteins/__init__.py
+++ b/prody/proteins/__init__.py
@@ -150,10 +150,11 @@ and/or parse results:
 Execute EMD
 ===========
 
-Following functions can be used to execute EMDMAP structural analysis program
-and/or parse results:
+Use the following to parse and access header data in EMD files:
 
-  * :func:`.parseSTRIDE` - parse structural data from :program:`EMDMAP` output
+  * :func:`.parseEMD` - parse structural data from :file:`.emd` files
+  * :class:`.EMDMAP` - access structural data from :file:`.emd` files
+  * :class:`.TRNET` - fit pseudoatoms to EM density maps using the TRN algorithm
 
 """
 
@@ -183,9 +184,9 @@ from . import psiblast
 from .psiblast import *
 __all__.extend(psiblast.__all__)
 
-from . import blastpdbUniProtKB
-from .blastpdbUniProtKB import *
-__all__.extend(blastpdbUniProtKB.__all__)
+from . import blastUniProtKB
+from .blastUniProtKB import *
+__all__.extend(blastUniProtKB.__all__)
 
 from . import pdbligands
 from .pdbligands import *

--- a/prody/proteins/__init__.py
+++ b/prody/proteins/__init__.py
@@ -66,8 +66,8 @@ Parse mmCIF files
 
 Following ProDy functions are for parsing :file:`.cif` files:
 
-  * :func:`.parseCIF` - parse :file:`.cif` formated file
-  * :func:`.parseCIFStream` - parse :file:`.cif` formated stream
+  * :func:`.parseMMCIF` - parse :file:`.cif` formated file
+  * :func:`.parseMMCIFStream` - parse :file:`.cif` formated stream
 
 .. seealso::
 

--- a/prody/proteins/blastUniProtKB.py
+++ b/prody/proteins/blastUniProtKB.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
-"""This module defines functions for blast searching Protein Data Bank."""
+"""This module defines functions for blast searching UniProtKB."""
 
 import os.path
 
 from prody import LOGGER
 from prody.utilities import dictElement, openURL
 
-__all__ = ['SwissProtBlastRecord', 'blastPDBUniProtKB']
+__all__ = ['UniProtBlastRecord', 'blastPDBUniProtKB']
 
 def blastPDBUniProtKB(sequence, filename=None, **kwargs):
     """Returns a :class:`PDBBlastRecord` instance that contains results from
-    blast searching of ProteinDataBank database *sequence* using NCBI blastp.
+    blast searching of UniProt knowledge base *sequence* using NCBI blastp.
 
     :arg sequence: single-letter code amino acid sequence of the protein
         without any gap characters, all white spaces will be removed
@@ -132,11 +132,11 @@ def blastPDBUniProtKB(sequence, filename=None, **kwargs):
         out.write(results)
         out.close()
         LOGGER.info('Results are saved as {0}.'.format(repr(filename)))
-    return SwissProtBlastRecord(results, sequence)
+    return UniProtBlastRecord(results, sequence)
 
-class SwissProtBlastRecord(object):
+class UniProtBlastRecord(object):
 
-    """A class to store results from ProteinDataBank blast search."""
+    """A class to store results from a UniProt blast search."""
 
 
     def __init__(self, xml, sequence=None):

--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -19,12 +19,12 @@ from prody import LOGGER, SETTINGS
 from .header import getHeaderDict, buildBiomolecules, assignSecstr
 from .localpdb import fetchPDB
 
-__all__ = ['parseCIFStream', 'parseCIF',]
+__all__ = ['parseMMCIFStream', 'parseMMCIF',]
 
 class CIFParseError(Exception):
     pass
 
-_parseCIFdoc = """
+_parseMMCIFdoc = """
     :arg title: title of the :class:`.AtomGroup` instance, default is the
         PDB filename or PDB identifier
     :type title: str
@@ -52,13 +52,13 @@ _parseCIFdoc = """
 
 _PDBSubsets = {'ca': 'ca', 'calpha': 'ca', 'bb': 'bb', 'backbone': 'bb'}
 
-def parseCIF(pdb, **kwargs):
+def parseMMCIF(pdb, **kwargs):
     """Returns an :class:`.AtomGroup` and/or dictionary containing header data
     parsed from an mmCIF file. If not found, the mmCIF file will be downloaded
     from the PDB. It will be downloaded in uncompressed format regardless of
     the compressed keyword.
 
-    This function extends :func:`.parseCIFStream`.
+    This function extends :func:`.parseMMCIFStream`.
 
     See :ref:`parsecif` for a detailed usage example.
 
@@ -97,11 +97,11 @@ def parseCIF(pdb, **kwargs):
             title = title[3:]
         kwargs['title'] = title
     cif = openFile(pdb, 'rt')
-    result = parseCIFStream(cif, **kwargs)
+    result = parseMMCIFStream(cif, **kwargs)
     cif.close()
     return result
 
-def parseCIFStream(stream, **kwargs):
+def parseMMCIFStream(stream, **kwargs):
     """Returns an :class:`.AtomGroup` and/or dictionary containing header data
     parsed from a stream of CIF lines.
     :arg stream: Anything that implements the method ``readlines``
@@ -157,7 +157,7 @@ def parseCIFStream(stream, **kwargs):
                 raise err
         if not len(lines):
             raise ValueError('empty PDB file or stream')
-        ag = _parseCIFLines(ag, lines, model, chain, subset, altloc)
+        ag = _parseMMCIFLines(ag, lines, model, chain, subset, altloc)
         if ag.numAtoms() > 0:
             LOGGER.report('{0} atoms and {1} coordinate set(s) were '
                           'parsed in %.2fs.'.format(ag.numAtoms(),
@@ -168,9 +168,9 @@ def parseCIFStream(stream, **kwargs):
             'check the input file.')
         return ag
 
-parseCIFStream.__doc__ += _parseCIFdoc
+parseMMCIFStream.__doc__ += _parseMMCIFdoc
 
-def _parseCIFLines(atomgroup, lines, model, chain, subset,
+def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
                    altloc_torf):
     """Returns an AtomGroup. See also :func:`.parsePDBStream()`.
 

--- a/prody/proteins/emdfile.py
+++ b/prody/proteins/emdfile.py
@@ -20,41 +20,42 @@ import numpy as np
 
 __all__ = ['parseEMDStream', 'parseEMD', 'writeEMD', 'TRNET', 'EMDMAP']
 
+
 class EMDParseError(Exception):
     pass
 
-""" For  documentation"""
 
 def parseEMD(emd, **kwargs):
-    """Returns an :class:`.AtomGroup` containing the information parsed from EMD file. 
+    """Parses an EM density map in EMD/MRC2015 format and 
+    optionally returns an :class:`.AtomGroup` containing  
+    beads built in the density using the TRN algorithm [_]. 
 
     This function extends :func:`.parseEMDStream`.
 
     See :ref:`parseEMD` for a detailed usage example. 
 
-    :arg emd: an EMD identifier or a file name. A 4-digit EMDataBank identifier can be provided
-    to download it via FTP.
+    :arg emd: an EMD identifier or a file name. A 4-digit 
+              EMDataBank identifier can be provided to download 
+              it via FTP.
     :type emd: str
 
-    :arg cutoff: density cutoff to read EMD map. The regions with lower density than given cutoff 
-    are discarded.
+    :arg cutoff: density cutoff to read EMD map. The regions with 
+                 lower density than given cutoff are discarded.
     :type cutoff: float
 
-    :arg n_nodes: A bead based network will be constructed over provided density map. n_nodes parameter
-    will show the number of beads that will fit to density map. 
+    :arg n_nodes: A bead based network will be constructed into the provided density map. 
+                  This parameter will set the number of beads to fit to density map. 
+                  Default is 0. Please change it to some number to run the TRN algorithm.
     :type n_nodes: int  
 
-    :arg num_iter: After reading density map, coordinates are predicted with topological domain reconstruction
-    method. This parameter is the total number of iterations of this algorithm: 
+    :arg num_iter: After reading density map, coordinates are predicted with the 
+                   topology representing network method. This parameter is the total 
+                   number of iterations of this algorithm.
     :type num_iter: int
 
     :arg map: Return the density map itself. Default is **False** in line with previous behaviour.
-        This value is reset to **True** if make_nodes is **False** as something must be returned.
+        This value is reset to **True** if n_nodes is 0 or less.
     :type map: bool
-
-    :arg make_nodes: Use the topology representing network algorithm to fit pseudoatom nodes to the map.
-        Default is **False** and sets map to **True**.
-    :type make_nodes: bool
     """
 
     title = kwargs.get('title', None)
@@ -72,49 +73,58 @@ def parseEMD(emd, **kwargs):
             elif os.path.isfile(emd + '.map.gz'):
                 filename = emd + '.map.gz'
             else:
-                filename = fetchPDB(emd, report=True, format='emd',compressed=False)
+                filename = fetchPDB(emd, report=True,
+                                    format='emd', compressed=False)
                 if filename is None:
                     raise IOError('EMD map file for {0} could not be downloaded.'
                                   .format(emd))
             emd = filename
-        else:   
+        else:
             raise IOError('EMD file {0} is not available in the directory {1}'
-                           .format(emd, os.getcwd()))
+                          .format(emd, os.getcwd()))
     if title is None:
         kwargs['title'], ext = os.path.splitext(os.path.split(emd)[1])
 
     emdStream = openFile(emd, 'rb')
-
-    if emd.endswith('.stk'):
-        result = parseSTKStream(emd, **kwargs)
-    else:
-        result = parseEMDStream(emdStream, **kwargs)
-
+    result = parseEMDStream(emdStream, **kwargs)
     emdStream.close()
 
     return result
 
-def _parseEMDLines(atomgroup, stream, cutoff=None, n_nodes=0, num_iter=20, map=False, make_nodes=False):
-    """ Returns an AtomGroup. see also :func:`.parseEMDStream()`.
 
-    :arg stream: stream from parser.
+def parseEMDStream(stream, **kwargs):
+    """Parse lines of data stream from an EMD/MRC2014 file and 
+    optionally return an :class:`.AtomGroup` containing TRN 
+    nodes based on it.
+
+    :arg stream: Any object with the method ``readlines``
+                (e.g. :class:`file`, buffer, stdin)
     """
+    cutoff = kwargs.get('cutoff', None)
+    if cutoff is not None:
+        cutoff = float(cutoff)
+
+    n_nodes = kwargs.get('n_nodes', 0)
+    num_iter = int(kwargs.get('num_iter', 20))
+    map = kwargs.get('map', False)
 
     if not isinstance(n_nodes, int):
         raise TypeError('n_nodes should be an integer')
-        
+
     if n_nodes > 0:
         make_nodes = True
     else:
+        make_nodes = False
         map = True
-        LOGGER.info('As n_nodes is less than or equal to 0, no nodes will be made and the raw map will be returned')
+        LOGGER.info('As n_nodes is less than or equal to 0, no nodes will be'
+                    ' made and the raw map will be returned')
 
     emd = EMDMAP(stream, cutoff)
 
     if make_nodes:
-
-        if not n_nodes > 0:
-            raise ValueError('n_nodes should be larger than 0')
+        title_suffix = kwargs.get('title_suffix', '')
+        atomgroup = AtomGroup(str(kwargs.get('title', 'Unknown')) + title_suffix)
+        atomgroup._n_atoms = n_nodes
 
         coordinates = np.zeros((n_nodes, 3), dtype=float)
         atomnames = np.zeros(n_nodes, dtype=ATOMIC_FIELDS['name'].dtype)
@@ -122,12 +132,12 @@ def _parseEMDLines(atomgroup, stream, cutoff=None, n_nodes=0, num_iter=20, map=F
         resnums = np.zeros(n_nodes, dtype=ATOMIC_FIELDS['resnum'].dtype)
         chainids = np.zeros(n_nodes, dtype=ATOMIC_FIELDS['chain'].dtype)
 
-        trn = TRNET(n_nodes = n_nodes)
+        trn = TRNET(n_nodes=n_nodes)
         trn.inputMap(emd, sample='density')
 
-        trn.run(tmax = num_iter)
+        trn.run(tmax=num_iter)
         for i in range(n_nodes):
-            coordinates[i,:] = trn.W[i,:]
+            coordinates[i, :] = trn.W[i, :]
             atomnames[i] = 'B'
             resnames[i] = 'CGB'
             resnums[i] = i+1
@@ -138,75 +148,15 @@ def _parseEMDLines(atomgroup, stream, cutoff=None, n_nodes=0, num_iter=20, map=F
         atomgroup.setResnames(resnames)
         atomgroup.setResnums(resnums)
         atomgroup.setChids(chainids)
- 
+
     if make_nodes:
         if map:
-            return emd, atomgroup
+            return atomgroup, emd
         else:
             return atomgroup
     else:
         return emd
 
-
-def parseSTKStream(stream, **kwargs):
-    LOGGER.warn('ProDy currently cannot parse .stk files correctly')
-    return None
-
-
-def parseEMDStream(stream, **kwargs):
-    """ Returns an :class:`.AtomGroup` containing EMD data parsed from a stream of EMD file.
-
-    :arg stream: Any object with the method ``readlines``
-        (e.g. :class:`file`, buffer, stdin)"""
-
-    cutoff = kwargs.get('cutoff', None)
-    if cutoff is not None:
-        cutoff = float(cutoff)
-
-    n_nodes = kwargs.get('n_nodes', 0)
-    num_iter = int(kwargs.get('num_iter', 20))
-    map = kwargs.get('map', False)
-    make_nodes = kwargs.get('make_nodes', False)
-
-    if n_nodes > 0:
-        make_nodes = True
-        n_nodes = int(n_nodes)
-
-    if map is False and make_nodes is False:
-        LOGGER.warn('At least one of map and make_nodes should be True. '
-                    'Setting map to False was an intentional change from the default '
-                    'behaviour so make_nodes has been set to True with n_nodes=1000.')
-        make_nodes = True
-        n_nodes = 1000
-
-    title_suffix = kwargs.get('title_suffix','')
-    atomgroup = AtomGroup(str(kwargs.get('title', 'Unknown')) + title_suffix)
-    atomgroup._n_atoms = n_nodes
-
-    if make_nodes:
-        LOGGER.info('Building coordinates from electron density map. This may take a while.')
-        LOGGER.timeit()
-
-        if map:
-            emd, atomgroup = _parseEMDLines(atomgroup, stream, cutoff=cutoff, n_nodes=n_nodes, \
-                                            num_iter=num_iter, map=map, make_nodes=make_nodes)
-        else:
-            atomgroup = _parseEMDLines(atomgroup, stream, cutoff=cutoff, n_nodes=n_nodes, \
-                                       num_iter=num_iter, map=map, make_nodes=make_nodes)
-
-        LOGGER.report('{0} pseudoatoms were fitted in %.2fs.'.format(
-            atomgroup.numAtoms(), atomgroup.numCoordsets()))
-    else: 
-        emd = _parseEMDLines(atomgroup, stream, cutoff=cutoff, n_nodes=n_nodes, \
-                             num_iter=num_iter, map=map, make_nodes=make_nodes)
-
-    if make_nodes:
-        if map:
-            return emd, atomgroup
-        else:
-            return atomgroup
-    else:
-        return emd
 
 def writeEMD(filename, emd):
     '''
@@ -220,46 +170,47 @@ def writeEMD(filename, emd):
     '''
 
     f = open(filename, "wb")
-    f.write(st.pack('<L',emd.NC))
-    f.write(st.pack('<L',emd.NR))
-    f.write(st.pack('<L',emd.NS))
-    f.write(st.pack('<L',emd.mode))
-    f.write(st.pack('<L',emd.ncstart))
-    f.write(st.pack('<L',emd.nrstart))
-    f.write(st.pack('<L',emd.nsstart))
-    f.write(st.pack('<L',emd.Nx))
-    f.write(st.pack('<L',emd.Ny))
-    f.write(st.pack('<L',emd.Nz))
-    f.write(st.pack('<f',emd.Lx))
-    f.write(st.pack('<f',emd.Ly))
-    f.write(st.pack('<f',emd.Lz))
-    f.write(st.pack('<f',emd.a))
-    f.write(st.pack('<f',emd.b))
-    f.write(st.pack('<f',emd.c))
-    f.write(st.pack('<L',emd.mapc))
-    f.write(st.pack('<L',emd.mapr))
-    f.write(st.pack('<L',emd.maps))
-    f.write(st.pack('<f',emd.dmin))
-    f.write(st.pack('<f',emd.dmax))
-    f.write(st.pack('<f',emd.dmean))
-    f.write(st.pack('<L',emd.ispg))
-    f.write(st.pack('<L',emd.nsymbt))
-    f.write(st.pack('<100s',emd.extra))
-    f.write(st.pack('<f',emd.x0))
-    f.write(st.pack('<f',emd.y0))
-    f.write(st.pack('<f',emd.z0))
-    f.write(st.pack('<4s',emd.wordMAP))
-    f.write(st.pack('<4s',emd.machst))
-    f.write(st.pack('<f',emd.rms))
-    f.write(st.pack('<L',emd.nlabels))
-    f.write(st.pack('<800s',emd.labels))
+    f.write(st.pack('<L', emd.NC))
+    f.write(st.pack('<L', emd.NR))
+    f.write(st.pack('<L', emd.NS))
+    f.write(st.pack('<L', emd.mode))
+    f.write(st.pack('<L', emd.ncstart))
+    f.write(st.pack('<L', emd.nrstart))
+    f.write(st.pack('<L', emd.nsstart))
+    f.write(st.pack('<L', emd.Nx))
+    f.write(st.pack('<L', emd.Ny))
+    f.write(st.pack('<L', emd.Nz))
+    f.write(st.pack('<f', emd.Lx))
+    f.write(st.pack('<f', emd.Ly))
+    f.write(st.pack('<f', emd.Lz))
+    f.write(st.pack('<f', emd.a))
+    f.write(st.pack('<f', emd.b))
+    f.write(st.pack('<f', emd.c))
+    f.write(st.pack('<L', emd.mapc))
+    f.write(st.pack('<L', emd.mapr))
+    f.write(st.pack('<L', emd.maps))
+    f.write(st.pack('<f', emd.dmin))
+    f.write(st.pack('<f', emd.dmax))
+    f.write(st.pack('<f', emd.dmean))
+    f.write(st.pack('<L', emd.ispg))
+    f.write(st.pack('<L', emd.nsymbt))
+    f.write(st.pack('<100s', emd.extra))
+    f.write(st.pack('<f', emd.x0))
+    f.write(st.pack('<f', emd.y0))
+    f.write(st.pack('<f', emd.z0))
+    f.write(st.pack('<4s', emd.wordMAP))
+    f.write(st.pack('<4s', emd.machst))
+    f.write(st.pack('<f', emd.rms))
+    f.write(st.pack('<L', emd.nlabels))
+    f.write(st.pack('<800s', emd.labels))
 
     for s in range(0, emd.NS):
         for r in range(0, emd.NR):
             for c in range(0, emd.NC):
-                f.write(st.pack('<f',emd.density[s,r,c]))
+                f.write(st.pack('<f', emd.density[s, r, c]))
 
     f.close()
+
 
 class EMDMAP(object):
     def __init__(self, stream, cutoff):
@@ -286,7 +237,7 @@ class EMDMAP(object):
         self.Lx = st.unpack('<f', stream.read(4))[0]
         self.Ly = st.unpack('<f', stream.read(4))[0]
         self.Lz = st.unpack('<f', stream.read(4))[0]
-    
+
         # Cell angles (Degrees) (3 words, 12 bytes, 53-64)
         self.a = st.unpack('<f', stream.read(4))[0]
         self.b = st.unpack('<f', stream.read(4))[0]
@@ -321,7 +272,7 @@ class EMDMAP(object):
         self.z0 = st.unpack('<f', stream.read(4))[0]
 
         # the character string 'MAP' to identify file type (1 word, 4 bytes, 209-212)
-        self.wordMAP = st.unpack('<4s', stream.read(4))[0] 
+        self.wordMAP = st.unpack('<4s', stream.read(4))[0]
 
         # machine stamp encoding byte ordering of data (1 word, 4 bytes, 213-216)
         self.machst = st.unpack('<4s', stream.read(4))[0]
@@ -347,7 +298,6 @@ class EMDMAP(object):
 
         self.sampled = False
 
-
     def numidx2matidx(self, numidx):
         """ Given index of the position, it will return the numbers of section, row and column. """
         # calculate section idx
@@ -365,7 +315,7 @@ class EMDMAP(object):
             self.sampled = True
         summ = self.cumsumdens[-1]
         r = np.random.rand() * summ
-        j = np.searchsorted(self.cumsumdens,r)
+        j = np.searchsorted(self.cumsumdens, r)
         return self.numidx2matidx(j)
 
     def drawsample_uniform(self):
@@ -382,7 +332,7 @@ class EMDMAP(object):
         res[self.mapr - 1] = self.NR
         res[self.maps - 1] = self.NS
         res = np.divide(np.array([self.Lx, self.Ly, self.Lz]), res)
-        
+
         # find coordinates in voxels relative to start
         ret = np.empty(3)
         ret[self.mapc - 1] = col + self.ncstart
@@ -393,14 +343,21 @@ class EMDMAP(object):
         ret = np.multiply(ret, res)
         return ret
 
+
 class TRNET(object):
+    """Class for building topology representing networks using 
+    EM density maps. It uses the algorithm described in [TM94]_.
+
+    .. [TM94] Martinetz T, Schulten K, Topology Representing Networks.
+       *Neural Networks* **1994** 7(3):507-552."""
+
     def __init__(self, n_nodes):
         self.N = n_nodes
         self.W = np.empty([n_nodes, 3])
         self.C = np.eye(n_nodes, n_nodes)
         # test
         self.V = np.array([])
-        
+
     def inputMap(self, emdmap, sample='density'):
         self.map = emdmap
         # initialize the positions of nodes
@@ -414,7 +371,7 @@ class TRNET(object):
             else:
                 p = (0, 0, 0)
             self.W[i, :] = self.map.coordinate(p[0], p[1], p[2])
-        
+
     def runOnce(self, t, l, ep, T, c=0):
         # draw a point from the map
         p = self.map.drawsample()
@@ -423,19 +380,19 @@ class TRNET(object):
             self.V = v
         else:
             self.V = np.vstack((self.V, v))
-        
+
         # calc the squared distances \\ws - v\\^2
         D = v - self.W
         sD = np.empty(self.N)
         for i in range(self.N):
             d = D[i, :]
-            sD[i] = np.dot(d,d)
-        
+            sD[i] = np.dot(d, d)
+
         # calc the closeness rank k's
         I = np.argsort(sD)
         K = np.empty(I.shape)
-        K[I] = range(len(I))       
-        
+        K[I] = range(len(I))
+
         # move the nodes
         if c == 0:
             K = K[:, np.newaxis]
@@ -445,31 +402,32 @@ class TRNET(object):
             idx = K < kc
             K = K[:, np.newaxis]
             self.W[idx, :] += ep * np.exp(-K[idx]/l) * D[idx, :]
-            
-        
-        if T>=0:
+
+        if T >= 0:
             # search for i0 and i1
             i0 = I[0]
             i1 = I[1]
-            
+
             # refresh connections
             for i in range(self.N):
                 if i == i1:
                     self.C[i0, i] = 1
                     self.C[i, i0] = 1
-                elif i!=i0 and self.C[i0, i] > 0:
+                elif i != i0 and self.C[i0, i] > 0:
                     self.C[i0, i] = self.C[i0, i] + 1
                     if self.C[i0, i] > T:
                         self.C[i0, i] = 0
                     self.C[i, i0] = self.C[i0, i]
-                
-    def run(self, tmax = 200, li = 0.2, lf = 0.01, ei = 0.3,
-            ef = 0.05, Ti = 0.1, Tf = 2, c = 0, calcC = False):
+
+    def run(self, tmax=200, li=0.2, lf=0.01, ei=0.3,
+            ef=0.05, Ti=0.1, Tf=2, c=0, calcC=False):
+        LOGGER.info('Building coordinates from electron density map. This may take a while.')
+        LOGGER.timeit('_prody_make_nodes')
         tmax = int(tmax * self.N)
         li = li * self.N
         if calcC:
             Ti = Ti * self.N
-            Tf = Tf * self.N        
+            Tf = Tf * self.N
         for t in range(1, tmax + 1):
             # calc the parameters
             tt = float(t) / tmax
@@ -479,29 +437,26 @@ class TRNET(object):
                 T = Ti * np.power(Tf / Ti, tt)
             else:
                 T = -1
-            # run once
             self.runOnce(t, l, ep, T, c)
-            
-            #if t % 1000 == 0:
-            #    print str(t) + " steps have been run"
-    
-    def run_n_pause(self, k0, k, tmax = 200, li = 0.2, lf = 0.01, ei = 0.3,
-            ef = 0.05, Ti = 0.1, Tf = 2):
+        LOGGER.report('{0} pseudoatoms were fitted in %.2fs.'.format(
+            self.N), '_prody_make_nodes')
+        return
+
+    def run_n_pause(self, k0, k, tmax=200, li=0.2, lf=0.01, ei=0.3,
+                    ef=0.05, Ti=0.1, Tf=2):
         tmax = int(tmax * self.N)
         li = li * self.N
         Ti = Ti * self.N
-        Tf = Tf * self.N        
+        Tf = Tf * self.N
         for t in range(k0, k + 1):
             # calc the parameters
             tt = float(t) / tmax
             l = li * np.power(lf / li, tt)
             ep = ei * np.power(ef / ei, tt)
-            T = Ti * np.power(Tf / Ti, tt)            
+            T = Ti * np.power(Tf / Ti, tt)
             # run once
             self.runOnce(t, l, ep, T)
-            
-            #if t % 1000 == 0:
-            #    print str(t) + " steps have been run"
-        
+        return
+
     def outputEdges(self):
         return self.C > 0

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -18,7 +18,7 @@ from prody import LOGGER, SETTINGS
 
 from .header import getHeaderDict, buildBiomolecules, assignSecstr, isHelix, isSheet
 from .localpdb import fetchPDB
-from .ciffile import parseCIF
+from .ciffile import parseMMCIF
 
 __all__ = ['parsePDBStream', 'parsePDB', 'parseChainsList', 'parsePQR',
            'writePDBStream', 'writePDB', 'writeChainsList', 'writePQR',
@@ -204,7 +204,7 @@ def _parsePDB(pdb, **kwargs):
         if filename is None:
             try:
                 LOGGER.info("Trying to use mmCIF file instead")
-                return parseCIF(pdb, **kwargs)
+                return parseMMCIF(pdb, **kwargs)
             except:
                 raise IOError('PDB file for {0} could not be downloaded.'
                               .format(pdb))

--- a/prody/utilities/catchall.py
+++ b/prody/utilities/catchall.py
@@ -487,9 +487,9 @@ def showMatrix(matrix, x_array=None, y_array=None, **kwargs):
     :arg interactive: turn on or off the interactive options
     :type interactive: bool
 
-    :arg xtickrotation: turn on or off rotation of the xticklabels
-                        default is False
-    :type xtickrotation: bool
+    :arg xtickrotation: how much to rotate the xticklabels in degrees
+                        default is 0
+    :type xtickrotation: float
     """
 
     from matplotlib import ticker
@@ -525,7 +525,7 @@ def showMatrix(matrix, x_array=None, y_array=None, **kwargs):
     xticklabels = kwargs.pop('xticklabels', ticklabels)
     yticklabels = kwargs.pop('yticklabels', ticklabels)
 
-    xtickrotation = kwargs.pop('xtickrotation', False)
+    xtickrotation = kwargs.pop('xtickrotation', 0.)
 
     show_colorbar = kwargs.pop('colorbar', True)
     cb_extend = kwargs.pop('cb_extend', 'neither')
@@ -710,8 +710,7 @@ def showMatrix(matrix, x_array=None, y_array=None, **kwargs):
         cursor = ImageCursor(ax3, im)
         connect('button_press_event', cursor.onClick)
 
-    if xtickrotation:
-        ax3.tick_params(axis='x', rotation=90)
+    ax3.tick_params(axis='x', rotation=xtickrotation)
 
     return im, lines, cb
 

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -21,7 +21,7 @@ __all__ = ['Everything', 'Cursor', 'ImageCursor', 'rangeString', 'alnum', 'impor
            'getDataPath', 'openData', 'chr2', 'toChararray', 'interpY', 'cmp', 'pystr',
            'getValue', 'indentElement', 'isPDB', 'isURL', 'isListLike', 'isSymmetric', 'makeSymmetric',
            'getDistance', 'fastin', 'createStringIO', 'div0', 'wmean', 'bin2dec', 'wrapModes', 
-           'fixArraySize', 'DTYPE']
+           'fixArraySize', 'DTYPE', '_solveEig']
 
 CURSORS = []
 
@@ -222,6 +222,39 @@ def importLA():
             raise ImportError('scipy.linalg or numpy.linalg is required for '
                               'NMA and structure alignment calculations')
     return linalg
+
+
+def _solveEig(M, n_modes, turbo=True):
+    """Simple eigensolver based on PCA eigensolver"""
+    dof = M.shape[0]
+
+    linalg = importLA()
+    if str(n_modes).lower() == 'all':
+        n_modes = None
+    if linalg.__package__.startswith('scipy'):
+        if n_modes is None:
+            eigvals = None
+            n_modes = dof
+        else:
+            n_modes = int(n_modes)
+            if n_modes >= dof:
+                eigvals = None
+                n_modes = dof
+            else:
+                eigvals = (dof - n_modes, dof - 1)
+        values, vectors = linalg.eigh(M, turbo=turbo,
+                                      eigvals=eigvals)
+    else:
+        LOGGER.info('Scipy is not found, all modes are calculated.')
+        values, vectors = linalg.eigh(M)
+
+    # Order by descending SV
+    revert = list(range(len(values)-1, -1, -1))
+    values = values[revert]
+    vectors = vectors[:, revert]
+
+    return values, vectors
+
 
 def createStringIO():
     if PY3K:

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -224,7 +224,7 @@ def importLA():
     return linalg
 
 
-def _solveEig(M, n_modes, turbo=True):
+def solveEig(M, n_modes, turbo=True):
     """Simple eigensolver based on PCA eigensolver"""
     dof = M.shape[0]
 

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -13,12 +13,15 @@ from Bio.Data import IUPACData
 
 from xml.etree.ElementTree import Element
 
+DTYPE = array(['a']).dtype.char  # 'S' for PY2K and 'U' for PY3K
+
 __all__ = ['Everything', 'Cursor', 'ImageCursor', 'rangeString', 'alnum', 'importLA', 'dictElement',
            'intorfloat', 'startswith', 'showFigure', 'countBytes', 'sqrtm',
            'saxsWater', 'count', 'addEnds', 'copy', 'dictElementLoop', 'index',
            'getDataPath', 'openData', 'chr2', 'toChararray', 'interpY', 'cmp', 'pystr',
            'getValue', 'indentElement', 'isPDB', 'isURL', 'isListLike', 'isSymmetric', 'makeSymmetric',
-           'getDistance', 'fastin', 'createStringIO', 'div0', 'wmean', 'bin2dec', 'wrapModes', 'fixArraySize']
+           'getDistance', 'fastin', 'createStringIO', 'div0', 'wmean', 'bin2dec', 'wrapModes', 
+           'fixArraySize', 'DTYPE']
 
 CURSORS = []
 


### PR DESCRIPTION
_solveEig is based on the PCA calcModes. We may want to use the GNM one instead but it was more complicated to move.

Example:
```
In [1]: from prody import *                                                                                        

In [2]: o1 = parsePDB('3o21_CD.pdb', subset='ca')                                                                  
@> 750 atoms and 1 coordinate set(s) were parsed in 0.01s.

In [3]: calcPrincAxes(o1)                                                                                          
Out[3]: 
array([[-0.59801737,  0.24073971,  0.76447343],
       [ 0.18045356,  0.96977582, -0.16422963],
       [ 0.78090444, -0.03973978,  0.62338512]])
```