### PR TITLE
bug fix on showSignatureOverlap

### DIFF
--- a/prody/dynamics/signature.py
+++ b/prody/dynamics/signature.py
@@ -1467,10 +1467,10 @@ def showSignatureOverlaps(mode_ensemble, **kwargs):
         overlap_triu = overlaps[:, :, r, c]
 
         if std:
-            stdV = overlap_triu.std(axis=-1).std(axis=-1)
+            stdV = overlap_triu.std(axis=-1)
             show = showMatrix(stdV)
         else:
-            meanV = overlap_triu.mean(axis=-1).mean(axis=-1)
+            meanV = overlap_triu.mean(axis=-1)
             show = showMatrix(meanV)
     
     return show


### PR DESCRIPTION
Otherwise

```
In [71]: plt.figure(); showSignatureOverlaps(mode_ens_new, diag=False);                                
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-71-c1ba3b154254> in <module>
----> 1 plt.figure(); showSignatureOverlaps(mode_ens_new, diag=False);

~/Documents/code/ProDy/prody/dynamics/signature.py in showSignatureOverlaps(mode_ensemble, **kwargs)
   1472         else:
   1473             meanV = overlap_triu.mean(axis=-1).mean(axis=-1)
-> 1474             show = showMatrix(meanV)
   1475 
   1476     return show

~/Documents/code/ProDy/prody/utilities/catchall.py in showMatrix(matrix, x_array, y_array, **kwargs)
    591 
    592     im = ax3.imshow(matrix, aspect=aspect, vmin=vmin, vmax=vmax, 
--> 593                     norm=norm, cmap=cmap, origin=origin, **kwargs)
    594 
    595     #ax3.set_xlim([-0.5, matrix.shape[0]+0.5])

/anaconda3/lib/python3.7/site-packages/matplotlib/__init__.py in inner(ax, data, *args, **kwargs)
   1597     def inner(ax, *args, data=None, **kwargs):
   1598         if data is None:
-> 1599             return func(ax, *map(sanitize_sequence, args), **kwargs)
   1600 
   1601         bound = new_sig.bind(ax, *args, **kwargs)

/anaconda3/lib/python3.7/site-packages/matplotlib/cbook/deprecation.py in wrapper(*args, **kwargs)
    367                 f"%(removal)s.  If any parameter follows {name!r}, they "
    368                 f"should be pass as keyword, not positionally.")
--> 369         return func(*args, **kwargs)
    370 
    371     return wrapper

/anaconda3/lib/python3.7/site-packages/matplotlib/cbook/deprecation.py in wrapper(*args, **kwargs)
    367                 f"%(removal)s.  If any parameter follows {name!r}, they "
    368                 f"should be pass as keyword, not positionally.")
--> 369         return func(*args, **kwargs)
    370 
    371     return wrapper

/anaconda3/lib/python3.7/site-packages/matplotlib/axes/_axes.py in imshow(self, X, cmap, norm, aspect, interpolation, alpha, vmin, vmax, origin, extent, shape, filternorm, filterrad, imlim, resample, url, **kwargs)
   5677                               resample=resample, **kwargs)
   5678 
-> 5679         im.set_data(X)
   5680         im.set_alpha(alpha)
   5681         if im.get_clip_path() is None:

/anaconda3/lib/python3.7/site-packages/matplotlib/image.py in set_data(self, A)
    688                 or self._A.ndim == 3 and self._A.shape[-1] in [3, 4]):
    689             raise TypeError("Invalid shape {} for image data"
--> 690                             .format(self._A.shape))
    691 
    692         if self._A.ndim == 3:

TypeError: Invalid shape (20,) for image data
```