### PR TITLE
current bug fix for negative resnum selections

### DIFF
--- a/prody/atomic/select.py
+++ b/prody/atomic/select.py
@@ -448,13 +448,8 @@ from numpy import array, ndarray, ones, zeros, arange
 from numpy import invert, unique, concatenate, all, any
 from numpy import logical_and, logical_or, floor, ceil, where
 
-try:
-    from . import pyparsing as pp
-    from .pyparsing import ParseException
-except ImportError:
-    import pyparsing as pp
-    from pyparsing import ParseException
-
+import pyparsing as pp
+from pyparsing import ParseException
 
 from prody import LOGGER, SETTINGS, PY2K
 
@@ -678,7 +673,7 @@ FUNCTIONS = {
 
 OPERATORS = {
     '+'  : np.add,
-    '-'  : np.subtract,
+    #'-'  : np.subtract,
     '*'  : np.multiply,
     '/'  : np.divide,
     '%'  : np.remainder,


### PR DESCRIPTION
This works as a fix for #1119 but at the expense of being able to do subtraction as part of selection strings. I don't think this is a big loss but others may disagree.