### PR TITLE
cleaned up unneeded/unused definitions

### DIFF
--- a/prody/atomic/atomic.py
+++ b/prody/atomic/atomic.py
@@ -13,8 +13,6 @@ from .fields import READONLY
 
 __all__ = ['Atomic', 'AAMAP']
 
-SELECT = None
-isSelectionMacro = None
 NOTALLNONE = set(['not', 'all', 'none', 'index', 'sequence', 'x', 'y', 'z'])
 
 MODMAP = {}

--- a/prody/atomic/select.py
+++ b/prody/atomic/select.py
@@ -449,7 +449,6 @@ from numpy import invert, unique, concatenate, all, any
 from numpy import logical_and, logical_or, floor, ceil, where
 
 import pyparsing as pp
-from pyparsing import ParseException
 
 from prody import LOGGER, SETTINGS, PY2K
 
@@ -720,7 +719,7 @@ def specialCharsParseAction(sel, loc, token):
     if ':' in token or 'to' in token:
         try:
             token = PP_NRANGE.parseString(token)[0]
-        except ParseException:
+        except pp.ParseException:
             pass
     return token
 

--- a/prody/atomic/selection.py
+++ b/prody/atomic/selection.py
@@ -6,8 +6,6 @@ from .subset import AtomSubset
 
 __all__ = ['Selection']
 
-SELECT = None
-
 ellipsis = lambda s: s[:15] + '...' + s[-15:] if len(s) > 33 else s
 
 


### PR DESCRIPTION
SELECT and isSelectionMacro are defined in atomic __init__.py and prody __init__.py

ParseException wasn't necessary to import separately.