### PR TITLE
improved inferBonds

### DIFF
--- a/prody/atomic/atomgroup.py
+++ b/prody/atomic/atomgroup.py
@@ -1129,16 +1129,20 @@ class AtomGroup(Atomic):
             return np.array([Bond(self, bond, acsi) for bond in self._bonds])
         return None
 
-    def inferBonds(self, max_bond=1.6, min_bond=0, set_bonds=False):
+    def inferBonds(self, max_bond=1.6, min_bond=0, set_bonds=True):
         """Returns bonds based on distances **max_bond** and **min_bond**."""
 
         bonds = []
-        for i, atom_i in enumerate(self[:-1]):
-            for _, atom_j in enumerate(self[i+1:]):
-                distance = getDistance(atom_i.getCoords(), atom_j.getCoords())
-                if distance > min_bond and distance < max_bond:
-                    bonds.append([atom_i._index, atom_j._index])
-        
+        for atom_i in self.iterAtoms():
+            sele = self.select('index > {0} and exwithin {1} of index {0}'
+                               .format(atom_i.getIndex(), max_bond))
+            if sele is not None:
+                for atom_j in sele.iterAtoms():
+                    distance = getDistance(atom_i.getCoords(),
+                                           atom_j.getCoords())
+                    if distance > min_bond:
+                        bonds.append([atom_i._index, atom_j._index])
+
         if set_bonds:
             self.setBonds(bonds)
 


### PR DESCRIPTION
I have now used selection for the upper cutoff instead of looping through all pairs of atoms to speed up the function. I also changed the default value of set_bonds to **True**.

Test code:
```
$ ipython
Python 3.7.8 | packaged by conda-forge | (default, Jul 31 2020, 01:53:57) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.17.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: import numpy as np

In [3]: import time

In [4]: p38 = parsePDB('1p38')
@> PDB file is found in working directory (1p38.pdb.gz).
@> 2962 atoms and 1 coordinate set(s) were parsed in 0.03s.
@> Secondary structures were assigned to 188 residues.

In [5]: times = []
   ...: for i in range(10):
   ...:     start = time.time();
   ...:     p38.inferBonds();
   ...:     end = time.time();
   ...:     times.append(end-start)
   ...:
   ...: print('mean time: {0}'.format(np.mean(times)))
```

New version:
```
mean time: 22.716177463531494
```

Old version:
```
mean time: 71.30652143955231
```