### PR TITLE
fixed bug with resindices/termini from mmCIF files

### DIFF
--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -297,10 +297,16 @@ def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
         chainids[acount] = chID
         segnames[acount] = segID
         hetero[acount] = startswith == 'HETATM' # True or False
-        if chainids[acount] != chainids[acount-1]: termini[acount] = True
+
+        if chainids[acount] != chainids[acount-1]: 
+            termini[acount-1] = True
+
         altlocs[acount] = alt
         icodes[acount] = line.split()[fields['pdbx_PDB_ins_code']]
-        if icodes[acount] == '?': icodes[acount] = ''
+
+        if icodes[acount] == '?': 
+            icodes[acount] = ''
+
         serials[acount] = line.split()[fields['id']]
         elements[acount] = line.split()[fields['type_symbol']]
         bfactors[acount] = line.split()[fields['B_iso_or_equiv']]


### PR DESCRIPTION
Before this, it was incrementing the resindices and splitting the first residue of every chain/segment after the first atom because the termini were in the wrong place. 