### PR TITLE
fixed getChain to work without segname

### DIFF
--- a/prody/atomic/hierview.py
+++ b/prody/atomic/hierview.py
@@ -440,7 +440,18 @@ class HierView(object):
             index = self._dict[(segname or self._getSegname() or None,
                                 chid or None)]
         except KeyError:
-            pass
+            try:
+                index = None
+                for key in self._dict.keys():
+                    if isinstance(key, tuple) and len(key) == 2:
+                        if key[1] == 'BU':
+                            index = self._dict[key]
+                if index is None:
+                    raise ValueError('invalid chain ID')
+            except ValueError:
+                pass
+            else:
+                return self._getChain(index)
         else:
             return self._getChain(index)
 


### PR DESCRIPTION
Previously, the only way to index and get a Chain was to use a segment name in addition to a chain ID (see #1175):

```
Python 3.7.8 | packaged by conda-forge | (default, Jul 31 2020, 01:53:57) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.17.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ag = parseMMCIF('4v88')
@> 413613 atoms and 1 coordinate set(s) were parsed in 8.14s.

In [3]: ag.getHierView().getChain('BU')

In [4]: ag['FB','BU']
Out[4]: <Chain: BU from Segment FB from 4v88 (100 residues, 796 atoms)>

In [5]: ag[None,'BU']
```

Now, we can just supply the chain ID and it gives the same result:

```
Python 3.7.8 | packaged by conda-forge | (default, Jul 31 2020, 01:53:57) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.17.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ag = parseMMCIF('4v88')
@> 413613 atoms and 1 coordinate set(s) were parsed in 8.11s.

In [3]: ag.getHierView().getChain('BU')
Out[3]: <Chain: BU from Segment FB from 4v88 (100 residues, 796 atoms)>

In [4]: ag['FB','BU']
Out[4]: <Chain: BU from Segment FB from 4v88 (100 residues, 796 atoms)>

In [5]: ag[None,'BU']
Out[5]: <Chain: BU from Segment FB from 4v88 (100 residues, 796 atoms)>
```