### PR TITLE
added packmol chain renumbering

### DIFF
--- a/prody/atomic/atomgroup.py
+++ b/prody/atomic/atomgroup.py
@@ -1761,6 +1761,15 @@ for fname, field in ATOMIC_FIELDS.items():
                                      'of atoms')
 
                 if not np.isscalar(array):
+                    if var == 'chain':
+                        max_len = 0
+                        for val in array:
+                            if len(val) > max_len:
+                                max_len = len(val)
+
+                        if max_len > int(dtype[1:]):
+                            dtype = dtype[0] + str(max_len)
+
                     array = np.asarray(array, dtype)
                 else:
                     raise TypeError('array must be an ndarray or a list')

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -14,7 +14,7 @@ from prody.atomic import AtomGroup, Atom, Selection
 from prody.atomic import flags
 from prody.atomic import ATOMIC_FIELDS
 from prody.utilities import openFile, isListLike
-from prody.utilities.misctools import decToHybrid36
+from prody.utilities.misctools import decToHybrid36, packmolRenumChains
 from prody import LOGGER, SETTINGS
 
 from .header import getHeaderDict, buildBiomolecules, assignSecstr, isHelix, isSheet
@@ -243,6 +243,7 @@ def parsePDBStream(stream, **kwargs):
     chain = kwargs.get('chain')
     subset = kwargs.get('subset')
     altloc = kwargs.get('altloc', 'A')
+    packmol = kwargs.get('packmol', False)
 
     auto_bonds = SETTINGS.get('auto_bonds')
     get_bonds = kwargs.get('bonds', auto_bonds)
@@ -333,6 +334,9 @@ def parsePDBStream(stream, **kwargs):
             else:
                 LOGGER.info('Biomolecular transformations were applied to the '
                             'coordinate data.')
+
+    if packmol:
+        ag = packmolRenumChains(ag)
 
     if model != 0:
         if header:

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -698,3 +698,30 @@ def split(string, shlex=False):
             return shlex.split(string)
     else:
         return string.split()
+
+
+def packmolRenumChains(ag):
+    chainids = ag.getChids()
+    new_chainids = zeros(chainids.shape[0], dtype=DTYPE + '2')
+    chid_mem = []
+    chid_alt = 0
+
+    num_chars = int(chainids.dtype.str[2:])
+    for j, chid in enumerate(chainids):
+        if j == 0:
+            chid_mem.append(chid)
+        else:
+            if chid != chainids[j-1]:
+                chid_alt += 1
+
+                if chid_alt >= 10**num_chars:
+                    num_chars += 1
+                    new_chainids = array(new_chainids, dtype=new_chainids.dtype.str[:2]+str(num_chars))
+
+                if chid_alt > 1 and len(chid_mem) > 1 and chid == chid_mem[-2]:
+                    chid_mem.append(chid)
+
+        new_chainids[j] = "{}".format(chid_alt)
+
+    ag.setChids(new_chainids)
+    return ag


### PR DESCRIPTION
This is alternative fix to close #1192.

It is much cleaner than the previous ones because it has a function in utilities/misctools.py rather than repeated code and is also optional and only activated when the kwarg packmol is set to True. 

The result for the PDB file in #1192 is as follows:

```
Python 3.7.8 | packaged by conda-forge | (default, Jul 31 2020, 01:53:57) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.17.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ag = parsePDB('1IYT_multi.pdb')
@> 3180 atoms and 1 coordinate set(s) were parsed in 0.04s.

In [3]: list(ag.getHierView())
Out[3]: 
[<Chain: A from 1IYT_multi (42 residues, 1908 atoms)>,
 <Chain: B from 1IYT_multi (42 residues, 1272 atoms)>]

In [4]: ag = parsePDB('1IYT_multi.pdb', packmol=True)
@> 3180 atoms and 1 coordinate set(s) were parsed in 0.03s.

In [5]: list(ag.getHierView())
Out[5]: 
[<Chain: 0 from 1IYT_multi (42 residues, 636 atoms)>,
 <Chain: 1 from 1IYT_multi (42 residues, 636 atoms)>,
 <Chain: 2 from 1IYT_multi (42 residues, 636 atoms)>,
 <Chain: 3 from 1IYT_multi (42 residues, 636 atoms)>,
 <Chain: 4 from 1IYT_multi (42 residues, 636 atoms)>]
```
