### PR TITLE
writeNMD bug fix

### DIFF
--- a/prody/dynamics/nmdfile.py
+++ b/prody/dynamics/nmdfile.py
@@ -375,7 +375,7 @@ def writeNMD(filename, modes, atoms):
     if not isinstance(modes, (NMA, ModeSet, Mode, Vector)):
         raise TypeError('modes must be NMA, ModeSet, Mode, or Vector, '
                         'not {0}'.format(type(modes)))
-    if modes.numAtoms() != atoms.numAtoms():
+    if modes._n_atoms != atoms.numAtoms():
         raise Exception('number of atoms do not match')
     out = openFile(addext(filename, '.nmd'), 'w')
 


### PR DESCRIPTION
Otherwise we get an error for maskedANM when using a selection:
```
$ ipython
Python 3.7.8 | packaged by conda-forge | (default, Jul 31 2020, 01:53:57) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.17.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *
   ...: import numpy as np
   ...: import matplotlib.pyplot as plt
   ...: plt.ion()
   ...: 
   ...: open_ca = parsePDB('3o21', subset='ca').select('chain C D')
   ...: closed_ca = parsePDB('3o21', subset='ca').select('chain A B')
   ...: 
   ...: ens = buildPDBEnsemble([open_ca, closed_ca])
   ...: open_ca.setCoords(ens.getCoordsets()[0])
   ...: 
   ...: closed_alg = closed_ca.select(ens.getSelstrs()[1])
   ...: idx = np.where(ens.getWeights()[1].flatten() == 1.)[0]
   ...: closed_alg.setCoords(ens.getCoordsets()[1][idx])
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 3o21 downloaded (C:\Users\james\...\3o21.pdb.gz)
@> PDB download via FTP completed (1 downloaded, 0 failed).
@> 1489 atoms and 1 coordinate set(s) were parsed in 0.03s.
@> Secondary structures were assigned to 960 residues.
@> PDB file is found in working directory (3o21.pdb.gz).
@> 1489 atoms and 1 coordinate set(s) were parsed in 0.03s.
@> Secondary structures were assigned to 960 residues.
@> Starting iterative superposition:
@> Step #1: RMSD difference = 2.1343e+00
@> Step #2: RMSD difference = 2.3505e-14
@> Iterative superposition completed in 0.00s.
@> Final superposition to calculate transformations.
@> Superposition completed in 0.00 seconds.
@> Ensemble (2 conformations) were built in 0.33s.

In [2]: anms = calcEnsembleENMs(ens, 'anm', match=False)
   ...: 
   ...: anm_open = anms[0].getModel()
   ...: anm_closed = anms[1].getModel()
@> 20 ANM modes were calculated for each of the 2 conformations in 1.65s.

In [3]: saveModel(anm_open, 'open_A3.anm.npz')
   ...: writeNMD('open_A3.anm.nmd', anm_open, open_ca)
   ...:
   ...: saveModel(anm_closed, 'closed_A3.anm.npz')
   ...: writeNMD('closed_A3.anm.nmd', anm_closed, closed_alg)
---------------------------------------------------------------------------
Exception                                 Traceback (most recent call last)
<ipython-input-3-d332e4f51920> in <module>
      3
      4 saveModel(anm_closed, 'closed_A3.anm.npz')
----> 5 writeNMD('closed_A3.anm.nmd', anm_closed, closed_alg)

c:\users\james\code\prody\prody\dynamics\nmdfile.py in writeNMD(filename, modes, atoms)
    377                         'not {0}'.format(type(modes)))
    378     if modes.numAtoms() != atoms.numAtoms():
--> 379         raise Exception('number of atoms do not match')
    380     out = openFile(addext(filename, '.nmd'), 'w')
    381

Exception: number of atoms do not match
```