### PR TITLE
moved IndexFormatter into ProDy before matplotlib removes it

### DIFF
--- a/prody/database/charmmgui.py
+++ b/prody/database/charmmgui.py
@@ -24,45 +24,43 @@ __all__ = ['CharmmGUIBrowser']
 
 
 class CharmmGUIBrowser(object):
-    """Class for running CHARMM-GUI in a browser"""
+    """Class for running CHARMM-GUI in a browser
 
+    :arg fname: filename for starting PDB file. A PDB ID can be provided and ProDy will fetch the PDB file first.
+    :type fname: str
+
+    :arg cwd: current working directory for CHARMM-GUI. Default is the current working directory where Python is running.
+    :type cwd: str
+
+    :arg ndir: relative path for next directory for accessing and saving files. Default is an empty string meaning use cwd.
+    :type ndir: str
+
+    :arg segids: segment IDs for selection in CHARMM-GUI. Default is to select all protein chains.
+    :type segids: list
+
+    :arg job_type: type of job for CHARMM-GUI. Currently `'solution'` and `'membrane.bilayer'` are supported.
+        Default is `'solution'`.
+    :type job_type: str
+
+    :arg job_id: job ID for retrieving previous runs. Default is empty string.
+    :type job_id: str
+
+    :arg timeout: number of seconds before timing out when waiting for each step.
+        Default is 12000, corresponding to 3 hours and 20 minutes, which seems high enough to not time out.
+    :type timeout: int
+
+    :arg saveas: tgz folder name for saving the CHARMM-GUI outputs
+    :type saveas: str
+
+    :arg browser_type: type of browser for running CHARMM-GUI. 
+        Default is to find one that has compatible drivers.
+    :type browser_type: str
+
+    :arg max_warn: maximum number of warnings before raising an error.
+        Default is 0.
+    :type max_warn: int 
+    """
     def __init__(self, fname, **kwargs):
-        """Initialization of a CharmmGUIBrowser object will open a browser and run through the system setup steps.
-
-        :arg fname: filename for starting PDB file. A PDB ID can be provided and ProDy will fetch the PDB file first.
-        :type fname: str
-
-        :arg cwd: current working directory for CHARMM-GUI. Default is the current working directory where Python is running.
-        :type cwd: str
-
-        :arg ndir: relative path for next directory for accessing and saving files. Default is an empty string meaning use cwd.
-        :type ndir: str
-
-        :arg segids: segment IDs for selection in CHARMM-GUI. Default is to select all protein chains.
-        :type segids: list
-
-        :arg job_type: type of job for CHARMM-GUI. Currently `'solution'` and `'membrane.bilayer'` are supported.
-            Default is `'solution'`.
-        :type job_type: str
-
-        :arg job_id: job ID for retrieving previous runs. Default is empty string.
-        :type job_id: str
-
-        :arg timeout: number of seconds before timing out when waiting for each step.
-            Default is 12000, corresponding to 3 hours and 20 minutes, which seems high enough to not time out.
-        :type timeout: int
-
-        :arg saveas: tgz folder name for saving the CHARMM-GUI outputs
-        :type saveas: str
-
-        :arg browser_type: type of browser for running CHARMM-GUI. 
-            Default is to find one that has compatible drivers.
-        :type browser_type: str
-
-        :arg max_warn: maximum number of warnings before raising an error.
-            Default is 0.
-        :type max_warn: int 
-        """
         if fname is None:
             raise ValueError('Please enter a starting PDB filename.')
         if not isinstance(fname, str):

--- a/prody/utilities/catchall.py
+++ b/prody/utilities/catchall.py
@@ -1,9 +1,6 @@
 """This module defines miscellaneous utility functions that is public to users."""
 
 import numpy as np
-from numpy import unique, linalg, diag, sqrt, dot
-
-from Bio.Phylo.BaseTree import Tree, Clade
 
 from prody import PY3K
 from .misctools import addEnds, interpY, index, isListLike
@@ -515,6 +512,7 @@ def showLines(*args, **kwargs):
 
     from matplotlib import cm, ticker
     from matplotlib.pyplot import figure, gca, xlim
+    from .drawtools import IndexFormatter
 
     ax = gca()
     lines = ax.plot(*args, **kwargs)
@@ -595,7 +593,7 @@ def showLines(*args, **kwargs):
         if callable(ticklabels):
             ax.get_xaxis().set_major_formatter(ticker.FuncFormatter(ticklabels))
         else:
-            ax.get_xaxis().set_major_formatter(ticker.IndexFormatter(ticklabels))
+            ax.get_xaxis().set_major_formatter(IndexFormatter(ticklabels))
     
     ax.xaxis.set_major_locator(ticker.AutoLocator())
     ax.xaxis.set_minor_locator(ticker.AutoMinorLocator())
@@ -631,7 +629,7 @@ def showMatrix(matrix, x_array=None, y_array=None, **kwargs):
     from matplotlib.collections import LineCollection
     from matplotlib.pyplot import gca, sca, sci, colorbar, subplot
 
-    from .drawtools import drawTree
+    from .drawtools import drawTree, IndexFormatter
 
     p = kwargs.pop('percentile', None)
     vmin = vmax = None
@@ -732,9 +730,9 @@ def showMatrix(matrix, x_array=None, y_array=None, **kwargs):
     #ax3.set_ylim([-0.5, matrix.shape[1]+0.5])
 
     if xticklabels is not None:
-        ax3.xaxis.set_major_formatter(ticker.IndexFormatter(xticklabels))
+        ax3.xaxis.set_major_formatter(IndexFormatter(xticklabels))
     if yticklabels is not None and ncol == 1:
-        ax3.yaxis.set_major_formatter(ticker.IndexFormatter(yticklabels))
+        ax3.yaxis.set_major_formatter(IndexFormatter(yticklabels))
 
     if allticks:
         ax3.xaxis.set_major_locator(ticker.IndexLocator(offset=0.5, base=1.))

--- a/prody/utilities/drawtools.py
+++ b/prody/utilities/drawtools.py
@@ -358,22 +358,20 @@ def drawTree(
     return x_posns, y_posns
 
 class IndexFormatter(ticker.Formatter):
-    """
+    """Function taken from Matplotlib version 3.3.1 as soon to be deprecated.
+
     Format the position x to the nearest i-th label where ``i = int(x + 0.5)``.
     Positions where ``i < 0`` or ``i > len(list)`` have no tick labels.
 
-    Parameters
-    ----------
-    labels : list
-        List of labels.
+    :arg labels: List of labels.
+    type labels: list
     """
     def __init__(self, labels):
         self.labels = labels
         self.n = len(labels)
 
     def __call__(self, x, pos=None):
-        """
-        Return the format for tick value *x* at position pos.
+        """Return the format for tick value *x* at position pos.
 
         The position is ignored and the value is rounded to the nearest
         integer, which is used to look up the label.

--- a/prody/utilities/drawtools.py
+++ b/prody/utilities/drawtools.py
@@ -6,8 +6,9 @@ import numpy as np
 
 from matplotlib.patches import FancyArrowPatch
 from mpl_toolkits.mplot3d import proj3d
+from matplotlib import ticker
 
-__all__ = ['Arrow3D', 'drawArrow3D', 'drawTree']
+__all__ = ['Arrow3D', 'drawArrow3D', 'drawTree', 'IndexFormatter']
 
 class Arrow3D(FancyArrowPatch):
     """This function is implemented by tacaswell on stackoverflow: 
@@ -355,3 +356,30 @@ def drawTree(
             getattr(plt, str(key))(*value[0], **dict(value[1]))
 
     return x_posns, y_posns
+
+class IndexFormatter(ticker.Formatter):
+    """
+    Format the position x to the nearest i-th label where ``i = int(x + 0.5)``.
+    Positions where ``i < 0`` or ``i > len(list)`` have no tick labels.
+
+    Parameters
+    ----------
+    labels : list
+        List of labels.
+    """
+    def __init__(self, labels):
+        self.labels = labels
+        self.n = len(labels)
+
+    def __call__(self, x, pos=None):
+        """
+        Return the format for tick value *x* at position pos.
+
+        The position is ignored and the value is rounded to the nearest
+        integer, which is used to look up the label.
+        """
+        i = int(x + 0.5)
+        if i < 0 or i >= self.n:
+            return ''
+        else:
+            return self.labels[i]


### PR DESCRIPTION
The IndexFormatter is needed by too many functions to lose it and matplotlib has had deprecation warnings for it for a while.