### PR TITLE
CHARMM-GUI fixes

### DIFF
--- a/prody/database/charmmgui.py
+++ b/prody/database/charmmgui.py
@@ -210,7 +210,9 @@ class CharmmGUIBrowser(object):
             try:
                 res = browser.is_text_present(text)
                 if res == True:
-                    break
+                    status, err = self.check_error(browser, **kwargs)
+                    if status == True or err != 'The CHARMM-GUI process is still running. Please reload this page again a few minutes later.':
+                        break
                 else:
                     LOGGER.sleep(int(sleep), 'for %s.' % text)
                     sleep = int(sleep * 1.5)
@@ -358,8 +360,8 @@ class CharmmGUIBrowser(object):
         browser.find_option_by_text('NaCl').first.click()
         browser.find_option_by_text('Monte-Carlo').first.click()
 
+        self.job_id = browser.find_by_name("jobid")[0].value
         if job_type == 'membrane.bilayer':
-            self.job_id = browser.find_by_name("jobid")[0].value
             self.next_step(browser, "Assemble Components", **kwargs)
         else:
             self.next_step(browser, "Setup Periodic Boundary Condition", **kwargs)

--- a/prody/database/charmmgui.py
+++ b/prody/database/charmmgui.py
@@ -290,10 +290,9 @@ class CharmmGUIBrowser(object):
         if browser_type is None:
             browser_type = self.browser_type
 
-        self.browser_type, self.browser = initializeBrowser(browser_type)
-        browser = self.browser
-
         url = "http://www.charmm-gui.org/input/%s" % job_type
+        self.browser_type, self.browser = initializeBrowser(browser_type, url=url)
+        browser = self.browser
         browser.visit(url)
 
         browser.attach_file('file', "%s/%s/%s" % (cwd, ndir, fname))

--- a/prody/database/quartataweb.py
+++ b/prody/database/quartataweb.py
@@ -730,7 +730,7 @@ def searchQuartataWeb(data_source=None, drug_group=None, input_type=None, query_
 searchQuartataWeb.__doc__ += "\n" + QuartataWebBrowser.__init__.__doc__
 
 
-def initializeBrowser(browser_type):
+def initializeBrowser(browser_type, url):
     try:
         from splinter import Browser
     except ImportError:
@@ -738,16 +738,17 @@ def initializeBrowser(browser_type):
                             'install splinter package to solve the problem.')
     else:
         from selenium.webdriver.common.service import WebDriverException
-        
+    
+    if url is None:
+        url = "http://quartata.csb.pitt.edu"
+
     if browser_type is None:
         try:
             browser = Browser('chrome')
-            url = "http://quartata.csb.pitt.edu"
             browser.visit(url)
         except WebDriverException:
             try:
                 browser = Browser('firefox')
-                url = "http://quartata.csb.pitt.edu"
                 browser.visit(url)
             except WebDriverException:
                 raise ValueError('No web driver found for Chrome or Firefox. '
@@ -762,7 +763,6 @@ def initializeBrowser(browser_type):
     else:
         try:
             browser = Browser(browser_type)
-            url = "http://quartata.csb.pitt.edu"
             browser.visit(url)
         except WebDriverException:
             raise ValueError('No web driver found for browser_type. '


### PR DESCRIPTION
1. Previously the browser was initialized (selected, tested, etc.) by going to quartataweb, which may surprise charmm-gui users.
2. Solved the problem of the solvation step taking too long by visiting the job retriever and reloading if the page has an error saying to do so. The `wait_for_text` function needed changing for this as unlike the membrane case, the page that comes is the one that we are waiting for so the error is exposed otherwise. 