### PR TITLE
Minor fixes in starfile

### DIFF
--- a/prody/proteins/starfile.py
+++ b/prody/proteins/starfile.py
@@ -174,11 +174,11 @@ class StarDataBlock:
             if indices is not None:
                 self.loops = [StarLoop(self, key, idx)
                               for (key, idx) in indices
-                              if key is not 'data']
+                              if key != 'data']
             else:
                 self.loops = [StarLoop(self, key)
                               for key in keys
-                              if key is not 'data']
+                              if key != 'data']
 
             self.data = np.array(list(self._dict['data'].values()))
             self.fields = np.array(list(self._dict['fields'].values()))
@@ -197,11 +197,11 @@ class StarDataBlock:
             if indices is not None:
                 self.loops = [StarLoop(self, key, idx)
                               for (key, idx) in indices
-                              if key is not 'fields']
+                              if key != 'fields']
             else:
                 self.loops = [StarLoop(self, key)
                               for key in keys
-                              if key is not 'fields']
+                              if key != 'fields']
 
             self.data = np.array(list(self._dict['data'].values()))
             self.fields = np.array(list(self._dict['fields'].values()))


### PR DESCRIPTION
Comparing string literals with identity operator "is" is not a good practice and may cause unexpected bugs. The string class is in a sweet spot between value-type and object-type variables, and in Python, it is treated in a mixed fashion. Using "!=" here is the intended comparison.