### PR TITLE
re-edited pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=1.10", "pyparsing", "biopython", "scipy"]
+requires = ["setuptools", "wheel", "numpy>=1.10", "pyparsing", "biopython<=1.76", "scipy"]


### PR DESCRIPTION
Actually is needed for Python 2.7 install to work. This is the error without it:
```
jkrieger@prody:/var/www/html/prody/ProDy-website-workdir/ProDy$ pip install -U . --user
/usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A 
future version of pip will drop support for Python 2.7.
Processing /var/www/html/prody/ProDy-website-workdir/ProDy
  Installing build dependencies ... error
  ERROR: Complete output from command /usr/bin/python /usr/local/lib/python2.7/dist-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-lg75Oz/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools wheel 'numpy>=1.10' pyparsing 
biopython scipy:
  ERROR: /usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
    warnings.warn(warning, RequestsDependencyWarning)
  DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. 
A future version of pip will drop support for Python 2.7.
  Collecting setuptools
    Using cached https://files.pythonhosted.org/packages/e1/b7/182161210a13158cd3ccc41ee19aadef54496b74f2817cc147006ec932b4/setuptools-44.1.1-py2.py3-none-any.whl
  Collecting wheel
    Using cached https://files.pythonhosted.org/packages/65/63/39d04c74222770ed1589c0eaba06c05891801219272420b40311cd60c880/wheel-0.36.2-py2.py3-none-any.whl  Collecting numpy>=1.10
    Using cached https://files.pythonhosted.org/packages/3a/5f/47e578b3ae79e2624e205445ab77a1848acdaa2929a00eeef6b16eaaeb20/numpy-1.16.6-cp27-cp27mu-manylinux1_x86_64.whl
  Collecting pyparsing
    Using cached https://files.pythonhosted.org/packages/8a/bb/488841f56197b13700afd5658fc279a2025a39e22449b7cf29864669b15d/pyparsing-2.4.7-py2.py3-none-any.whl
  Collecting biopython
    Using cached https://files.pythonhosted.org/packages/3d/2f/d9df24de05d651c5e686ee8fea3afe3985c03ef9ca02f4cc1e7ea10aa31e/biopython-1.77.tar.gz
      ERROR: Complete output from command python setup.py egg_info:
      ERROR: Biopython requires Python 3.6 or later. Python 2.7 detected.
      ----------------------------------------
  ERROR: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-cgIVDQ/biopython/
  WARNING: You are using pip version 19.1.1, however version 20.3.3 is available.
  You should consider upgrading via the 'pip install --upgrade pip' command.
  ----------------------------------------
ERROR: Command "/usr/bin/python /usr/local/lib/python2.7/dist-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-lg75Oz/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- setuptools wheel 'numpy>=1.10' pyparsing biopython scipy" failed with error code 1 in None
WARNING: You are using pip version 19.1.1, however version 20.3.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

With it, we get the following:
```
jkrieger@prody:/var/www/html/prody/ProDy-website-workdir/ProDy$ pip install -U . --user
/usr/local/lib/python2.7/dist-packages/pip/_vendor/requests/__init__.py:83: RequestsDependencyWarning: Old version of cryptography ([1, 2, 3]) may cause slowdown.
  warnings.warn(warning, RequestsDependencyWarning)
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A 
future version of pip will drop support for Python 2.7.
Processing /var/www/html/prody/ProDy-website-workdir/ProDy
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Requirement already satisfied, skipping upgrade: pyparsing in /usr/lib/python2.7/dist-packages (from ProDy==1.11) (2.0.3)
Requirement already satisfied, skipping upgrade: scipy in /usr/local/lib/python2.7/dist-packages (from ProDy==1.11) (1.2.1)
Requirement already satisfied, skipping upgrade: biopython<=1.76 in /home/jkrieger/.local/lib/python2.7/site-packages (from ProDy==1.11) (1.76)
Requirement already satisfied, skipping upgrade: numpy>=1.10 in /usr/local/lib/python2.7/dist-packages (from ProDy==1.11) (1.16.3)
Building wheels for collected packages: ProDy
  Building wheel for ProDy (PEP 517) ... done
  Stored in directory: /tmp/pip-ephem-wheel-cache-w2_A80/wheels/f3/43/59/8207d6508d40680cf76d2537d855a5bfd27a9e612cc613efe7
Successfully built ProDy
Installing collected packages: ProDy
  Found existing installation: ProDy 1.11
    Uninstalling ProDy-1.11:
      Successfully uninstalled ProDy-1.11
Successfully installed ProDy-1.11
WARNING: You are using pip version 19.1.1, however version 20.3.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

Surprisingly doesn't cause Python 3.7 to be forced to use bipython <= 1.76:
```
(py37) jkrieger@prody:/var/www/html/prody/ProDy-website-workdir/ProDy$ pip install -U . --user
Processing /var/www/html/prody/ProDy-website-workdir/ProDy
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Requirement already satisfied: biopython in /home/jkrieger/.local/lib/python3.7/site-packages (from ProDy==1.11) (1.78)
Requirement already satisfied: scipy in /home/jkrieger/.local/lib/python3.7/site-packages (from ProDy==1.11) (1.6.0)
Requirement already satisfied: numpy>=1.10 in /home/jkrieger/.local/lib/python3.7/site-packages (from ProDy==1.11) (1.19.4)
Requirement already satisfied: pyparsing in /home/jkrieger/.local/lib/python3.7/site-packages (from ProDy==1.11) (2.4.7)
Building wheels for collected packages: ProDy
  Building wheel for ProDy (PEP 517) ... done
  Created wheel for ProDy: filename=ProDy-1.11-cp37-cp37m-linux_x86_64.whl size=6606148 sha256=5966f9d2b921c6b824c26df9a2c27ffe9bbf648fb2e427afbc76c8f692204c04
  Stored in directory: /tmp/pip-ephem-wheel-cache-m70t7gcn/wheels/33/a4/c3/498b234cec3b0668ab0b659ce92ee49fc976fd1b94cc3ee575
Successfully built ProDy
Installing collected packages: ProDy
  Attempting uninstall: ProDy
    Found existing installation: ProDy 1.11
    Uninstalling ProDy-1.11:
      Successfully uninstalled ProDy-1.11
Successfully installed ProDy-1.11
```

There must be a difference between how Python 2.7 pip (19.1.1) and Python 3.7 pip (20.0.2) use this file.