### PR TITLE
Removed selstrs from PDBEnsemble

### DIFF
--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -60,11 +60,6 @@ def saveEnsemble(ensemble, filename=None, **kwargs):
         attr_dict['_atoms'] = np.array([atoms, None], 
                                         dtype=object)
 
-    selstrs = dict_['_selstrs']
-    if selstrs is not None:
-        attr_dict['_selstrs'] = np.array([selstrs, None], 
-                                          dtype=object)
-
     data = dict_['_data']
     if len(data):
         attr_dict['_data'] = np.array([data, None], 
@@ -156,8 +151,6 @@ def loadEnsemble(filename, **kwargs):
             ensemble._trans = attr_dict['_trans']
         if '_msa' in attr_dict.files:
             ensemble._msa = attr_dict['_msa'][0]
-        if '_selstrs' in attr_dict.files:
-            ensemble._selstrs = attr_dict['_selstrs'][0]
     else:
         if type_ == 'ClustENM':
             attrs = ['_ph', '_cutoff', '_gamma', '_n_modes', '_n_confs',

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -30,7 +30,6 @@ class PDBEnsemble(Ensemble):
     def __init__(self, title='Unknown'):
 
         self._labels = []
-        self._selstrs = []
         self._trans = None
         self._msa = None
         Ensemble.__init__(self, title)
@@ -267,8 +266,6 @@ class PDBEnsemble(Ensemble):
             else:
                 label = label or 'Unknown'
 
-        selstr = atoms.getSelstr() if hasattr(atoms, 'getSelstr') else 'all'
-
         # check coordinates
         try:
             checkCoords(coords, csets=True, natoms=n_atoms)
@@ -350,15 +347,6 @@ class PDBEnsemble(Ensemble):
 
         self._labels.extend(labels)
 
-        # update selstrs
-        if n_csets > 1 and not degeneracy:
-            if isinstance(selstr, str):
-                selstrs = ['{0}'.format(selstr) for i in range(n_csets)]
-        else:
-            selstrs = [selstr] if np.isscalar(selstr) else selstr
-
-        self._selstrs.extend(selstrs)
-
         # update sequences
         if seqs:
             msa = MSA(seqs, title=self.getTitle(), labels=labels)
@@ -434,11 +422,6 @@ class PDBEnsemble(Ensemble):
         """Returns identifiers of the conformations in the ensemble."""
 
         return list(self._labels)
-
-    def getSelstrs(self):
-        """Returns identifiers of the conformations in the ensemble."""
-
-        return list(self._selstrs)
 
     def getCoordsets(self, indices=None, selected=True):
         """Returns a copy of coordinate set(s) at given *indices* for selected


### PR DESCRIPTION
`PDBEnsemble._selstrs` is removed for several reasons:

- It causes a bug in `saveEnsemble` when saving `Ensemble` objects. This is a `PDBEnsemble` only attribute but it was saved as if it were an attribute in the base class. 
- It was implemented incompletely. This attribute was not addressed at all in editing operators such as `__add__` and `__getitem__`. Future additions of new attributes should be made carefully as there are many aspects (e.g. loading, saving, and editing) of the class to be considered before making the decision to add an attribute.
- It is not very useful. Atomic subsets can be created without a selection string, namely AtomMap, which is the subset class used for creating the `PDBEnsemble`. Even if there is a selection string, the users cannot use it unless they have the access to the original `AtomGroup` instance, in which case they should just save the atomic subset objects (by themselves, not by `PDBEnsemble`) as well. 

With that being said, we might consider adding a callback function in `buildPDBEnsemble` in the future so that users can have access to the AtomMap or other local objects for debugging purposes. But that requires some design decisions to be made and tutorial changes, so this will be a future project (#1266).