### PR TITLE
pca app/nmwiz fix

### DIFF
--- a/prody/apps/prody_apps/prody_pca.py
+++ b/prody/apps/prody_apps/prody_pca.py
@@ -91,8 +91,9 @@ def prody_pca(coords, **kwargs):
         else:
             ensemble = dcd[:]
             if not kwargs.get('aligned'):
-                ensemble.iterpose()
+                ensemble.iterpose(quiet=True)
             pca.performSVD(ensemble)
+        nmodes = pca.numModes()
 
     else:
         pdb = prody.parsePDB(coords)

--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -590,6 +590,7 @@ class Ensemble(object):
         """Superpose conformations and update coordinates."""
 
         ref = kwargs.pop('ref', None)
+        quiet = kwargs.pop('quiet', False)
 
         indices = self._indices
         weights = self._weights
@@ -628,7 +629,8 @@ class Ensemble(object):
             tar_org = (tar - tar_com)
             mob_org = zeros(tar_org.shape, dtype=mobs.dtype)
 
-        LOGGER.progress('Superposing ', len(mobs), '_prody_ensemble')
+        if not quiet:
+            LOGGER.progress('Superposing ', len(mobs), '_prody_ensemble')
         for i, mob in enumerate(mobs):
             if idx:
                 mob = mob[indices]
@@ -651,10 +653,11 @@ class Ensemble(object):
             else:
                 add(dot(movs[i], rotation),
                     (tar_com - dot(mob_com, rotation)), movs[i])
-            LOGGER.update(i + 1, label='_prody_ensemble')
+            if not quiet:
+                LOGGER.update(i + 1, label='_prody_ensemble')
         LOGGER.finish()
 
-    def iterpose(self, rmsd=0.0001):
+    def iterpose(self, rmsd=0.0001, quiet=False):
         """Iteratively superpose the ensemble until convergence.  Initially,
         all conformations are aligned with the reference coordinates.  Then
         mean coordinates are calculated, and are set as the new reference
@@ -687,7 +690,7 @@ class Ensemble(object):
                 weightsum = length
 
         while rmsdif > rmsd:
-            self._superpose()
+            self._superpose(quiet=quiet)
             if weights is None:
                 newxyz = self._confs.sum(0) / length
             else:


### PR DESCRIPTION
Otherwise the NMWiz ProDy Interface throws errors during PCA:
1. The number of modes is more than we have.
2. The output of the LOGGER about superposition.