### PR TITLE
parsePDB extension to EMD files

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -20,6 +20,7 @@ from prody import LOGGER, SETTINGS
 from .header import getHeaderDict, buildBiomolecules, assignSecstr, isHelix, isSheet
 from .localpdb import fetchPDB
 from .ciffile import parseMMCIF
+from .emdfile import parseEMD
 
 __all__ = ['parsePDBStream', 'parsePDB', 'parseChainsList', 'parsePQR',
            'writePDBStream', 'writePDB', 'writeChainsList', 'writePQR',
@@ -208,11 +209,15 @@ def _parsePDB(pdb, **kwargs):
         filename = fetchPDB(pdb, **kwargs)
         if filename is None:
             try:
-                LOGGER.info("Trying to use mmCIF file instead")
+                LOGGER.info("Trying to parse mmCIF file instead")
                 return parseMMCIF(pdb, **kwargs)
             except:
-                raise IOError('PDB file for {0} could not be downloaded.'
-                              .format(pdb))
+                try:
+                    LOGGER.info("Trying to parse EMD file instead")
+                    return parseEMD(pdb, **kwargs)
+                except:                
+                    raise IOError('PDB file for {0} could not be downloaded.'
+                                .format(pdb))
         pdb = filename
     if title is None:
         title, ext = os.path.splitext(os.path.split(pdb)[1])


### PR DESCRIPTION
Can now do the following:
```
Python 3.8.3 (default, Jul  2 2020, 17:30:36) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: emds = parsePDB('2686', '2687')
@> Retrieving 2686... [  0%]@> WARNING 2686 download failed ('https://files.rcsb.org/download/2686.pdb.gz' could not be opened for reading, invalid URL or no internet connection).
@> Retrieving 2687... [ 50%] 7s@> WARNING 2687 download failed ('https://files.rcsb.org/download/2687.pdb.gz' could not be opened for reading, invalid URL or no internet connection).
@> 2 PDBs were parsed in 12.90s.

In [3]: emds
Out[3]: 
[<prody.proteins.emdfile.EMDMAP at 0x2260d9d2d90>,
 <prody.proteins.emdfile.EMDMAP at 0x2260da26970>]
```