### PR TITLE
added theoretical ADPs calculation

### DIFF
--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -7,12 +7,11 @@ import time
 import numpy as np
 
 from prody import LOGGER
-from prody.proteins import parsePDB
-from prody.atomic import AtomGroup, Atomic
+from prody.atomic import Atomic
 from prody.ensemble import Ensemble, Conformation
 from prody.trajectory import TrajBase
 from prody.utilities import importLA, checkCoords, div0
-from numpy import sqrt, arange, log, polyfit, array, arccos, dot
+from numpy import sqrt, arange, log, polyfit, array
 
 from .nma import NMA
 from .modeset import ModeSet
@@ -23,7 +22,8 @@ __all__ = ['calcCollectivity', 'calcCovariance', 'calcCrossCorr',
            'calcFractVariance', 'calcSqFlucts', 'calcTempFactors',
            'calcProjection', 'calcCrossProjection',
            'calcSpecDimension', 'calcPairDeformationDist',
-           'calcDistFlucts', 'calcHinges', 'calcHitTime', 'calcHitTime']
+           'calcDistFlucts', 'calcHinges', 'calcHitTime', 'calcHitTime',
+           'calcAnisousFromModel']
            #'calcEntropyTransfer', 'calcOverallNetEntropyTransfer']
 
 def calcCollectivity(mode, masses=None, is3d=None):
@@ -660,3 +660,37 @@ def calcHitTime(model, method='standard'):
     LOGGER.debug('Hit and commute times are calculated in  {0:.2f}s.'
                  .format(time.time()-start)) 
     return H, C
+
+
+def calcAnisousFromModel(model, ):
+    """Returns a 3Nx6 matrix containing anisotropic B factors (ANISOU lines)
+    from a covariance matrix calculated from **model**.
+
+    :arg model: 3D model from which to calculate covariance matrix
+    :type model: :class:`.ANM`, :class:`.PCA`
+
+    .. ipython:: python
+
+       from prody import *
+       protein = parsePDB('1ejg')
+       anm, calphas = calcANM(protein)
+       adp_matrix = calcAnisousFromModel(anm)"""
+
+    if not isinstance(model, NMA) or not model.is3d():
+        raise TypeError('model must be of type ANM or PCA, not {0}'
+                        .format(type(model)))
+
+    cov = calcCovariance(model)
+    n_atoms = model.numAtoms()
+    
+    submatrices = [cov[i*3:(i+1)*3, i*3:(i+1)*3] for i in range(n_atoms)]
+
+    anisou = np.zeros((n_atoms, 6))
+    for index, submatrix in enumerate(submatrices):
+        anisou[index, 0] = submatrix[0, 0]
+        anisou[index, 1] = submatrix[1, 1]
+        anisou[index, 2] = submatrix[2, 2]
+        anisou[index, 3] = submatrix[0, 1]
+        anisou[index, 4] = submatrix[0, 2]
+        anisou[index, 5] = submatrix[1, 2]
+    return anisou


### PR DESCRIPTION
This allows the calculation of theoretical anisotropic displacement parameters (ANISOU lines in PDB files) from ANM or PCA covariance matrices. 

These are the entries in the ANISOU lines in PDB files (https://www.wwpdb.org/documentation/file-format-content/format33/sect9.html#ANISOU).

They are also described in Bahar et al.  Annu. Rev. Biophys. 2010: 
```In high-resolution crystallographic structures, the diffraction data are sufficiently detailed to refine six anisotropic displacement parameters (ADPs), instead of a single isotropic parameter, per atom. The ADPs for the ith atom are simply the six distinctive elements of the ith diagonal superelement (a 3 × 3 symmetric matrix) of C(3N). Three of these, 〈(Δxi)2〉, 〈(Δyi)2〉, and 〈(Δzi)2〉, provide information on the sizes of motions along different directions. The remaining three, 〈Δxi Δyi〉, 〈Δxi Δzi〉, and 〈Δyi Δzi〉, are cross-correlations between fluctuations along different axes.```

The new functionality is as follows:
```
from prody import *
import numpy as np
import matplotlib.pyplot as plt
plt.ion()

dimers = parsePDB('3h5v', biomol=True,
                  compressed=False)

tetramer = np.sum(dimers)

anm, ca = calcANM(tetramer)
expt_anisous = ca.getAnisous()

theo_anisous = calcAnisousFromModel(anm)

R172_anisous_t = sliceAtomicData(theo_anisous, ca, 'resnum 172', axis=0)
R172_anisous_e = sliceAtomicData(expt_anisous, ca, 'resnum 172', axis=0)

plt.figure()

plt.subplot(2,1,1)
showAtomicMatrix(R172_anisous_t, atoms=ca.select('resnum 172'))
plt.title('theoretical')

plt.subplot(2,1,2)
showAtomicMatrix(R172_anisous_e, atoms=ca.select('resnum 172'))
plt.title('experimental')

plt.savefig('anisou_test')
```

This returns the following figure, which looks approximately similar for theoretical and experimental. 
![anisou_test](https://user-images.githubusercontent.com/13259162/105398676-8da15e00-5c1a-11eb-9e74-41ee266ec7cf.png)

I also tidied up some unneeded imports as indicated by VS Code.