### PR TITLE
parsePDB now sets charges

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -776,10 +776,10 @@ def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
                         siguij.resize((acount, 6), refcheck=False)
                         atomgroup.setAnistds(siguij / 10000)
                 else:
-                    charges.resize(acount, refcheck=False)
                     radii.resize(acount, refcheck=False)
-                    atomgroup.setCharges(charges)
                     atomgroup.setRadii(radii)
+                charges.resize(acount, refcheck=False)
+                atomgroup.setCharges(charges)
 
                 nmodel += 1
                 n_atoms = acount
@@ -881,10 +881,10 @@ def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
             atomgroup.setBetas(bfactors)
             atomgroup.setOccupancies(occupancies)
         else:
-            charges.resize(acount, refcheck=False)
             radii.resize(acount, refcheck=False)
-            atomgroup.setCharges(charges)
             atomgroup.setRadii(radii)
+        charges.resize(acount, refcheck=False)
+        atomgroup.setCharges(charges)
 
     if altloc and altloc_torf:
         _evalAltlocs(atomgroup, altloc, chainids, resnums, resnames, atomnames)


### PR DESCRIPTION
closes #461 

The file from #461 after formatting works as follows:

File C.pdb
```
COMPND free
AUTHOR GENERATED BY OPEN BABEL 2.3.2
HETATM    1  C   LIG     1       0.000   0.000   0.000  1.00  0.00           C1+
MASTER 0 0 0 0 0 0 0 0 1 0 1 0
END
```

Code test:
```
$ ipython
Python 3.8.3 (default, Jul  2 2020, 17:30:36) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: c = parsePDB('C.pdb')
@> 1 atoms and 1 coordinate set(s) were parsed in 0.00s.

In [3]: c.getCharges()
Out[3]: array([1.])
```

Any PDB file without charges returns zeros as expected:
```
$ ipython
Python 3.8.3 (default, Jul  2 2020, 17:30:36) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ag = parsePDB('3h5vA')
@> PDB file is found in working directory (3h5v.pdb.gz).
@> 3225 atoms and 1 coordinate set(s) were parsed in 0.07s.
@> Secondary structures were assigned to 237 residues.

In [3]: ag.getCharges()
Out[3]: array([0., 0., 0., ..., 0., 0., 0.])
```