### PR TITLE
selection.select within fix

### DIFF
--- a/prody/atomic/select.py
+++ b/prody/atomic/select.py
@@ -1641,7 +1641,7 @@ class Select(object):
                 torf[which] = False
 
         else:
-            n_atoms = self._ag.numAtoms()
+            n_atoms = self._atoms.numAtoms()
             torf = ones(n_atoms, bool)
             torf[which] = False
             check = torf.nonzero()[0]


### PR DESCRIPTION
In some cases, using `within` or `exwithin` in a selection string to select from a selection caused an indexing problem e.g.

```
$ ipython
Python 3.8.3 (default, Jul  2 2020, 17:30:36) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ag = parsePDB('4nre', compressed=False)
@> PDB file is found in working directory (4nre.pdb).
@> 11230 atoms and 1 coordinate set(s) were parsed in 0.11s.
@> Secondary structures were assigned to 451 residues.

In [3]: pdb = ag.select('protein')

In [4]: pdb.select('exwithin 5 of resid 353')
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-4-a5d4256415bb> in <module>
----> 1 pdb.select('exwithin 5 of resid 353')

~\code\ProDy\prody\atomic\atomic.py in select(self, selstr, **kwargs)
    230         documentation for details and usage examples."""
    231
--> 232         return SELECT.select(self, selstr, **kwargs)
    233
    234     def getTitle(self):

~\code\ProDy\prody\atomic\select.py in select(self, atoms, selstr, **kwargs)
    883
    884         self._selstr = selstr
--> 885         indices = self.getIndices(atoms, selstr, **kwargs)
    886
    887         self._kwargs = None

~\code\ProDy\prody\atomic\select.py in getIndices(self, atoms, selstr, **kwargs)
    941                                      'string', [ss])
    942         else:
--> 943             torf = self.getBoolArray(atoms, selstr, **kwargs)
    944             return torf.nonzero()[0]
    945

~\code\ProDy\prody\atomic\select.py in getBoolArray(self, atoms, selstr, **kwargs)
    993         try:
    994             parser = self._getParser(selstr)
--> 995             tokens = parser(selstr, parseAll=True)
    996         except pp.ParseException as err:
    997             self._parsers.pop(self._parser, None)

~\code\ProDy\prody\atomic\select.py in _noParser(self, selstr, parseAll)
   1098
   1099         debug(selstr, 0, ['_noParser'])
-> 1100         return [self._default(selstr, 0, selstr.split())]
   1101
   1102     def _getZeros(self, subset=None):

~\code\ProDy\prody\atomic\select.py in _default(self, sel, loc, tokens)
   1116             torf, err = self._eval(sel, loc, tokens)
   1117         else:
-> 1118             torf, err = self._and2(sel, loc, tokens)
   1119         if err: raise err
   1120         return torf

~\code\ProDy\prody\atomic\select.py in _and2(self, sel, loc, tokens, subset)
   1473         if unary:
   1474             if torf is None:
-> 1475                 torf, err = self._unary(sel, loc, unary.pop(0))
   1476                 if err: return None, err
   1477

~\code\ProDy\prody\atomic\select.py in _unary(self, sel, loc, tokens)
   1555             return self._bondedto(sel, loc, tokens)
   1556         else:
-> 1557             return self._within(sel, loc, tokens)
   1558
   1559     def _not(self, sel, loc, tokens):

~\code\ProDy\prody\atomic\select.py in _within(self, sel, loc, tokens)
   1648             torf = zeros(n_atoms, bool)
   1649
-> 1650             cxyz = coords[check]
   1651             kdtree = KDTree(coords[which])
   1652             search = kdtree.search

IndexError: index 10647 is out of bounds for axis 0 with size 10647
```

The problem was that the indices were based on the underlying atomgroup so I fixed it by basing them on the atoms themselves instead.

This now works:
```
$ ipython
Python 3.8.3 (default, Jul  2 2020, 17:30:36) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ag = parsePDB('4nre', compressed=False)
@> PDB file is found in working directory (4nre.pdb).
@> 11230 atoms and 1 coordinate set(s) were parsed in 0.11s.
@> Secondary structures were assigned to 451 residues.

In [3]: pdb = ag.select('protein')

In [4]: pdb.select('exwithin 5 of resid 353')
Out[4]: <Selection: '(exwithin 5 of ...) and (protein)' from 4nre (170 atoms)>

In [5]: pdb.select('same residue as exwithin 5 of (resid 373)')
Out[5]: <Selection: '(same residue a...) and (protein)' from 4nre (317 atoms)>
```