### PR TITLE
docs fix

### DIFF
--- a/prody/atomic/select.py
+++ b/prody/atomic/select.py
@@ -371,12 +371,12 @@ at least an atom within 4 A of any water molecule.
    p.select('same residue as exwithin 4 of water')
 
 Additionally, a selection may be expanded to the immediately bonded atoms using
-``bonded [n] to ...`` setting, e.f. ``bonded 1 to calpha`` will select atoms
+``bonded [n] to ...`` setting, e.g. ``bonded 1 to calpha`` will select atoms
 bonded to Cα atoms.  For this setting to work, bonds must be set by the user
 using the :meth:`.AtomGroup.setBonds` or :meth:`.AtomGroup.inferBonds` method.  
 It is also possible to select bonded atoms by excluding the originating atoms 
 using ``exbonded [n] to ...`` setting.  Number ``'[n]'`` indicates number of 
-bonds to consider from the originating selection and defaults to 1.
+bonds to consider from the originating selection.
 
 
 Selection macros


### PR DESCRIPTION
Fixed a minor typo and removed a bit that wasn't right. Selections using `bonded` need a number a can't default without. This could be improved at some later stage, but probably isn't necessary. 