### PR TITLE
fixed trimAtomsUsingMSA

### DIFF
--- a/prody/sequence/analysis.py
+++ b/prody/sequence/analysis.py
@@ -1190,7 +1190,7 @@ def trimAtomsUsingMSA(atoms, msa, **kwargs):
 
     u, i = unique(idx_2, return_index=True)
 
-    resnums_str = ' '.join([str(x) for x in idx_1[i[1:]]])
+    resnums_str = ' '.join([str(x) for x in idx_1[i]])
     chain = kwargs.get('chain', 'A')
 
     return atoms.select('chain {0} and resnum {1}'.format(chain, resnums_str))


### PR DESCRIPTION
Previously, we were missing the first residue. Now it works:

```
$ ipython
Python 3.8.3 (default, Jul  2 2020, 17:30:36) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.16.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: pdb = parsePDB('3l4aA')
@> PDB file is found in working directory (3l4a.pdb.gz).
@> 1120 atoms and 1 coordinate set(s) were parsed in 0.02s.
@> Secondary structures were assigned to 94 residues.

In [3]: sel = pdb['A'].select('protein and name CA')

In [4]: msa = parseMSA('PF01395_full_refined.sth')
@> 2324 sequence(s) with 107 residues were parsed in 0.02s.

In [5]: sel = trimAtomsUsingMSA(sel, msa)
@> PDB file is found in working directory (3l4a.pdb.gz).
@> 1120 atoms and 1 coordinate set(s) were parsed in 0.01s.
@> Secondary structures were assigned to 94 residues.
@> UniProt idcode Q7PGA3_ANOGA for 3l4aA is found in MSA PF01395_full_refined.

In [6]: str(msa['Q7PGA3_ANOGA'])
Out[6]: 'NESVIESCSNAVQGAANDELKVHYRANEFPDDPVTHCFVRCIGLELNLYDDKYGVDLQANWENLGNSDDADEEFVAKHRACLEAKNLETIEDLCERAYSAFQCLRED'

In [7]: sel.getSequence()
Out[7]: 'NESVIESCSNAVQGAANDELKVHYRANEFPDDPVTHCFVRCIGLELNLYDDKYGVDLQANWENLGNSDDADEEFVAKHRACLEAKNLETIEDLCERAYSAFQCLRED'
```