### PR TITLE
AdaptiveANM fixes

### DIFF
--- a/prody/dynamics/adaptive.py
+++ b/prody/dynamics/adaptive.py
@@ -130,12 +130,12 @@ def calcStep(initial, target, n_modes, ensemble, defvecs, rmsds, mask=None, call
     c_sq = np.cumsum(np.power(normalised_overlaps, 2), axis=0)
 
     torf_Fmin = c_sq <= Fmin
-    if not np.any(torf_Fmin):
-        torf_Fmin[0] = True
-    
-    if not np.all(torf_Fmin):
+    if np.any(torf_Fmin) and not np.all(torf_Fmin):
         i = np.where(torf_Fmin)[0].max()
         torf_Fmin[i+1] = True
+
+    if not np.any(torf_Fmin):
+        torf_Fmin[0] = True
 
     selected_mode_indices = np.arange(anm.numModes())[torf_Fmin]
 

--- a/prody/dynamics/adaptive.py
+++ b/prody/dynamics/adaptive.py
@@ -130,12 +130,17 @@ def calcStep(initial, target, n_modes, ensemble, defvecs, rmsds, mask=None, call
     c_sq = np.cumsum(np.power(normalised_overlaps, 2), axis=0)
 
     torf_Fmin = c_sq <= Fmin
-    if np.any(torf_Fmin) and not np.all(torf_Fmin):
-        i = np.where(torf_Fmin)[0].max()
-        torf_Fmin[i+1] = True
 
-    if not np.any(torf_Fmin):
-        torf_Fmin[0] = True
+    if Fmin is None and resetFmin:
+        argmax_overlap = np.argmax(abs(normalised_overlaps))
+        torf_Fmin[argmax_overlap] = True
+    else:
+        if np.any(torf_Fmin) and not np.all(torf_Fmin):
+            i = np.where(torf_Fmin)[0].max()
+            torf_Fmin[i+1] = True
+
+        if not np.any(torf_Fmin):
+            torf_Fmin[0] = True
 
     selected_mode_indices = np.arange(anm.numModes())[torf_Fmin]
 

--- a/prody/dynamics/adaptive.py
+++ b/prody/dynamics/adaptive.py
@@ -129,12 +129,12 @@ def calcStep(initial, target, n_modes, ensemble, defvecs, rmsds, mask=None, call
     normalised_overlaps = overlaps / norm(d)
     c_sq = np.cumsum(np.power(normalised_overlaps, 2), axis=0)
 
-    torf_Fmin = c_sq <= Fmin
-
     if Fmin == 0 and resetFmin:
+        torf_Fmin = np.zeros(c_sq.shape, dtype=bool)
         argmax_overlap = np.argmax(abs(normalised_overlaps))
         torf_Fmin[argmax_overlap] = True
     else:
+        torf_Fmin = c_sq <= Fmin
         if np.any(torf_Fmin) and not np.all(torf_Fmin):
             i = np.where(torf_Fmin)[0].max()
             torf_Fmin[i+1] = True
@@ -380,6 +380,7 @@ def calcAlternatingAdaptiveANM(a, b, n_steps, **kwargs):
         LOGGER.info('\nStarting cycle {0} with {1}'.format(n + 1, getTitle(a, 'structure A')))
         n_modes = calcStep(coordsA, coordsB, n_modes, ensA, defvecs, rmsds, mask=maskA,
                            resetFmin=resetFmin, **kwargs)
+        resetFmin = False
 
         if n_modes == 0:
             LOGGER.report('Alternating Adaptive ANM converged in %.2fs.', '_prody_calcAdaptiveANM')
@@ -389,7 +390,6 @@ def calcAlternatingAdaptiveANM(a, b, n_steps, **kwargs):
         n_modes = calcStep(coordsB, coordsA, n_modes, ensB, defvecs, rmsds, mask=maskB,
                            resetFmin=resetFmin, **kwargs)
         n += 1
-        resetFmin = False
 
         if n_modes == 0:
             LOGGER.report('Alternating Adaptive ANM converged in %.2fs.', '_prody_calcAdaptiveANM')

--- a/prody/dynamics/adaptive.py
+++ b/prody/dynamics/adaptive.py
@@ -131,7 +131,7 @@ def calcStep(initial, target, n_modes, ensemble, defvecs, rmsds, mask=None, call
 
     torf_Fmin = c_sq <= Fmin
 
-    if Fmin is None and resetFmin:
+    if Fmin == 0 and resetFmin:
         argmax_overlap = np.argmax(abs(normalised_overlaps))
         torf_Fmin[argmax_overlap] = True
     else:
@@ -380,7 +380,6 @@ def calcAlternatingAdaptiveANM(a, b, n_steps, **kwargs):
         LOGGER.info('\nStarting cycle {0} with {1}'.format(n + 1, getTitle(a, 'structure A')))
         n_modes = calcStep(coordsA, coordsB, n_modes, ensA, defvecs, rmsds, mask=maskA,
                            resetFmin=resetFmin, **kwargs)
-        resetFmin = False
 
         if n_modes == 0:
             LOGGER.report('Alternating Adaptive ANM converged in %.2fs.', '_prody_calcAdaptiveANM')
@@ -390,6 +389,7 @@ def calcAlternatingAdaptiveANM(a, b, n_steps, **kwargs):
         n_modes = calcStep(coordsB, coordsA, n_modes, ensB, defvecs, rmsds, mask=maskB,
                            resetFmin=resetFmin, **kwargs)
         n += 1
+        resetFmin = False
 
         if n_modes == 0:
             LOGGER.report('Alternating Adaptive ANM converged in %.2fs.', '_prody_calcAdaptiveANM')

--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -247,9 +247,7 @@ class Ensemble(object):
             except AttributeError:
                 pass
             else:
-                if dummies:
-                    raise ValueError('atoms must not have any dummies')
-                else:
+                if not dummies:
                     indices = atoms._getIndices()
                     if any(indices != unique(indices)):
                         raise ValueError('atoms must be ordered by indices')


### PR DESCRIPTION
These are fixes to the logic and they make small changes in the results. The most notable change is that only 1 mode is used in early cycles rather than 2. Using 2 in the first cycle was what caused me to look into this more carefully in the first place.

We still get 15 cycles (giving an ensemble with 32 conformers including the start and end points) for the GroEL single subunit case like the tutorial. The RMSDs are also very similar.

Original:
```
Starting cycle 15 with 1gruA_ca
@> Hessian was built in 0.26s.
@> 518 modes were calculated in 0.35s.
@> Using 518 modes with square cumulative overlap 0.078
@> Current RMSD is 1.253

@>
Continuing cycle 15 with structure (Chain A from 1gr5A_ca -> Chain A from 1gruA_ca)
@> Hessian was built in 0.24s.
@> 518 modes were calculated in 0.33s.
@> Using 518 modes with square cumulative overlap 0.055
@> WARNING The RMSD decrease fell below 0.05
@> Current RMSD is 1.240

@> Alternating Adaptive ANM converged in 24.53s.
@> Atom weights from 'A' are used in 'A + B (15:-1:-1)'.
```

Modified:
```
Starting cycle 15 with 1gruA_ca
@> Hessian was built in 0.23s.
@> 518 modes were calculated in 0.35s.
@> Using 518 modes with square cumulative overlap 0.090
@> Current RMSD is 1.254

@>
Continuing cycle 15 with structure (Chain A from 1gr5A_ca -> Chain A from 1gruA_ca)
@> Hessian was built in 0.22s.
@> 518 modes were calculated in 0.32s.
@> Using 518 modes with square cumulative overlap 0.066
@> WARNING The RMSD decrease fell below 0.05
@> Current RMSD is 1.239

@> Alternating Adaptive ANM converged in 20.89s.
@> Atom weights from 'A' are used in 'A + B (15:-1:-1)'.
```

The number of modes in the one way case at the bottom of the tutorial are also very similar as are the RMSDs. Again, I note that the early cycles now use 1 mode not 2.

Original:
```
Starting cycle 20 with initial structure 1gruA_ca
@> Hessian was built in 0.22s.
@> 518 modes were calculated in 0.36s.
@> Using 518 modes with square cumulative overlap 0.354
@> Current RMSD is 1.749

[2, 2, 2, 2, 2, 2, 3, 3, 4, 7, 14, 20, 33, 40, 80, 160, 320, 518, 518, 518]
```

Modified:
```
Starting cycle 20 with initial structure 1gruA_ca
@> Hessian was built in 0.24s.
@> 518 modes were calculated in 0.37s.
@> Using 518 modes with square cumulative overlap 0.397
@> Current RMSD is 1.829

[1, 1, 1, 1, 1, 1, 2, 3, 3, 5, 10, 14, 20, 40, 76, 142, 160, 320, 518, 518]
```

There are some differences in the intermediate cycles but they are pretty minor.