### PR TITLE
Adaptive ANM extension for membrane proteins

### DIFF
--- a/prody/dynamics/adaptive.py
+++ b/prody/dynamics/adaptive.py
@@ -56,7 +56,10 @@ def checkInput(a, b, **kwargs):
     if np.isscalar(maskB):
         maskB = None
 
-    coordsA, _ = superpose(coordsA, coordsB, weights)
+    aligned = kwargs.get('aligned', False)
+    if not aligned:
+        coordsA, _ = superpose(coordsA, coordsB, weights)
+        
     rmsd = calcRMSD(coordsA, coordsB, weights)
     LOGGER.info('Initialized Adaptive ANM with RMSD {:4.3f}\n'.format(rmsd))
 

--- a/prody/dynamics/adaptive.py
+++ b/prody/dynamics/adaptive.py
@@ -59,7 +59,7 @@ def checkInput(a, b, **kwargs):
     aligned = kwargs.get('aligned', False)
     if not aligned:
         coordsA, _ = superpose(coordsA, coordsB, weights)
-        
+
     rmsd = calcRMSD(coordsA, coordsB, weights)
     LOGGER.info('Initialized Adaptive ANM with RMSD {:4.3f}\n'.format(rmsd))
 
@@ -105,8 +105,9 @@ def calcStep(initial, target, n_modes, ensemble, defvecs, rmsds, mask=None, call
     if n_modes > n_max_modes:
         n_modes = n_max_modes
 
+    model = kwargs.pop('model', 'anm')
     anm, _ = calcENM(coords_init, select=mask, mask=mask, 
-                     model='anm', trim='trim', n_modes=n_modes, 
+                     model=model, trim='trim', n_modes=n_modes, 
                      **kwargs)
 
     if mask is not None:

--- a/prody/dynamics/exanm.py
+++ b/prody/dynamics/exanm.py
@@ -9,6 +9,7 @@ from prody.utilities import importLA, checkCoords, copy
 from numpy import sqrt, zeros, array, ceil, dot
 
 from .anm import ANM
+from .nma import MaskedNMA
 from .gnm import checkENMParameters
 from .editing import _reduceModel
 
@@ -467,3 +468,58 @@ def buildLayerHessian(coords, layers, layer, cutoff=15., gamma=1.0, **kwargs):
                 superelement = np.outer(v, v)*g/dist2
                 Hss[I, I] += superelement
     return Hss, Hse
+
+
+class MaskedExANM(exANM, MaskedNMA):
+    def __init__(self, name='Unknown', mask=False, masked=True):
+        exANM.__init__(self, name)
+        MaskedNMA.__init__(self, name, mask, masked)
+
+    def calcModes(self, n_modes=20, zeros=False, turbo=True):
+        self._maskedarray = None
+        super(MaskedExANM, self).calcModes(n_modes, zeros, turbo)
+
+    def _reset(self):
+        super(MaskedExANM, self)._reset()
+        self._maskedarray = None
+
+    def setHessian(self, hessian):
+        """Set Hessian matrix.  A symmetric matrix is expected, i.e. not a
+        lower- or upper-triangular matrix."""
+
+        if not isinstance(hessian, np.ndarray):
+            raise TypeError('hessian must be a Numpy array')
+        elif hessian.ndim != 2 or hessian.shape[0] != hessian.shape[1]:
+            raise ValueError('hessian must be square matrix')
+        elif hessian.shape[0] % 3:
+            raise ValueError('hessian.shape must be (3*n_atoms,3*n_atoms)')
+        elif hessian.dtype != float:
+            try:
+                hessian = hessian.astype(float)
+            except:
+                raise ValueError('hessian.dtype must be float')
+        
+        mask = self.mask
+        if not self.masked:
+            if not np.isscalar(mask):
+                if self.is3d():
+                    mask = np.repeat(mask, 3)
+                try:
+                    hessian = hessian[mask, :][:, mask]
+                except IndexError:
+                    raise IndexError('size mismatch between Hessian (%d) and mask (%d).'
+                                     'Try set masked to False or reset mask'%(len(hessian), len(mask)))
+
+        super(MaskedExANM, self).setHessian(hessian)
+
+    def _getHessian(self):
+        """Returns the Hessian matrix."""
+
+        hessian = self._hessian
+
+        if hessian is None: return None
+
+        if not self._isOriginal():
+            hessian = self._extend(hessian, axis=None)
+
+        return hessian

--- a/prody/dynamics/functions.py
+++ b/prody/dynamics/functions.py
@@ -13,6 +13,7 @@ from prody.utilities import openFile, isExecutable, which, PLATFORM, addext
 from .nma import NMA, MaskedNMA
 from .anm import ANM, ANMBase, MaskedANM
 from .gnm import GNM, GNMBase, ZERO, MaskedGNM
+from .exanm import exANM, MaskedExANM
 from .rtb import RTB
 from .pca import PCA, EDA
 from .imanm import imANM
@@ -482,6 +483,11 @@ def calcENM(atoms, select=None, model='anm', trim='trim', gamma=1.0,
         gnm.buildKirchhoff(atoms, gamma=gamma, **kwargs)
         enm = gnm
         MaskedModel = MaskedGNM
+    elif model == 'exanm':
+        exanm = exANM(title)
+        exanm.buildHessian(atoms, gamma=gamma, **kwargs)
+        enm = exanm
+        MaskedModel = MaskedExANM
     else:
         raise TypeError('model should be either ANM or GNM instead of {0}'.format(model))
     


### PR DESCRIPTION
This allows us to use exANM in Adaptive ANM.

Test code:
```
from prody import *

n, o = parsePDB('3kg2-opm.pdb', '5ide', subset='ca')
n_am = alignChains(n, o, seqid=70, rmsd_reject=50, match_func=sameChid)[0]

n_am_mem = n_am.select('resnum 512 to 629 790 to 900')

o_mem = alignChains(o, n_am_mem.copy(), seqid=70,
                    overlap=0, rmsd_reject=50, match_func=sameChid)[0]

o_mem_alg, T = superpose(o_mem, n_am_mem,
                         weights=n_am_mem.getFlags("mapped"))

aa = calcAdaptiveANM(n_am, o, 20, n_max_modes=20,
                     model='exanm', aligned=True)
```

Result snippet:
```
@> Initialized Adaptive ANM with RMSD 25.107

@>
Starting cycle 1 with (Chain D from 3kg2-opm_ca -> Chain D from 5ide_ca) + (Chain C from 3kg2-opm_ca -> Chain C from 5ide_ca) + (Chain B from 3kg2-opm_ca -> Chain B from 5ide_ca) + (Chain A from 3kg2-opm_ca -> Chain A from 5ide_ca)
@> Membrane was built in  4s.
@> layers: [0 1]
@> max layer: 1
@> layer: 0
C:\Users\james\code\ProDy\prody\dynamics\exanm.py:441: RuntimeWarning: invalid value encountered in true_divide
  superelement = np.outer(v, v)*g/dist2
@> layer: 1
@> layer: 1 finished
@> layer: 0 finished
@> Hessian was built in 1305.42s.
@> 20 modes were calculated in 46.39s.
@> Using 2 modes with square cumulative overlap 0.005
@> Current RMSD is 23.519

@>
Continuing cycle 1 with structure 5ide_ca
@> Membrane was built in  4s.
@> layers: [0 1]
@> max layer: 1
@> layer: 0
@> layer: 1
@> layer: 1 finished
@> layer: 0 finished
@> Hessian was built in 1301.11s.
@> 20 modes were calculated in 46.43s.
@> Using 2 modes with square cumulative overlap 0.027
@> Current RMSD is 23.106

@>
Starting cycle 2 with (Chain D from 3kg2-opm_ca -> Chain D from 5ide_ca) + (Chain C from 3kg2-opm_ca -> Chain C from 5ide_ca) + (Chain B from 3kg2-opm_ca -> Chain B from 5ide_ca) + (Chain A from 3kg2-opm_ca -> Chain A from 5ide_ca)
@> Membrane was built in  4s.
@> layers: [0 1]
@> max layer: 1
@> layer: 0
@> layer: 1
@> layer: 1 finished
@> layer: 0 finished
@> Hessian was built in 1335.14s.
@> 20 modes were calculated in 49.76s.
@> Using 3 modes with square cumulative overlap 0.011
@> Current RMSD is 23.060

@>
Continuing cycle 2 with structure 5ide_ca
@> Membrane was built in  4s.
@> layers: [0 1]
@> max layer: 1
@> layer: 0
@> layer: 1
@> layer: 1 finished
@> layer: 0 finished
@> Hessian was built in 1336.58s.
@> 20 modes were calculated in 51.68s.
@> Using 2 modes with square cumulative overlap 0.017
@> Current RMSD is 22.991

@>
Starting cycle 3 with (Chain D from 3kg2-opm_ca -> Chain D from 5ide_ca) + (Chain C from 3kg2-opm_ca -> Chain C from 5ide_ca) + (Chain B from 3kg2-opm_ca -> Chain B from 5ide_ca) + (Chain A from 3kg2-opm_ca -> Chain A from 5ide_ca)
@> Membrane was built in  4s.
@> layers: [0 1]
@> max layer: 1
@> layer: 0
@> layer: 1
@> layer: 1 finished
@> layer: 0 finished
@> Hessian was built in 1326.30s.
@> 20 modes were calculated in 51.41s.
@> Using 5 modes with square cumulative overlap 0.409
@> Current RMSD is 21.229
```