### PR TITLE
TEMPy converters

### DIFF
--- a/prody/atomic/atom.py
+++ b/prody/atomic/atom.py
@@ -240,6 +240,23 @@ class Atom(AtomPointer):
                 break
             yield Atom(ag, other, acsi)
 
+    def toTEMPyAtom(self):
+        """Returns a TEMPy BioPyAtom or Structure object as appropriate"""  
+        try:
+            from TEMPy.protein.prot_rep_biopy import Atom as TEMPyAtom
+        except ImportError:
+            raise ImportError('TEMPy is needed for this functionality')
+
+        return TEMPyAtom(
+            self.getName(), self.getCoords(),
+            'HETATM' if self.getFlag('hetatm') else 'ATOM',
+            self.getSerial(), self.getBeta(),
+            self.getAltloc(), self.getIcode(),
+            self.getCharge(), self.getElement(),
+            self.getOccupancy(), self.getResname(),
+            None, self.getACSIndex(), self.getChid(),
+            self.getResnum())
+
 
 for fname, field in ATOMIC_FIELDS.items():
 

--- a/prody/atomic/atomic.py
+++ b/prody/atomic/atomic.py
@@ -253,3 +253,24 @@ class Atomic(object):
             seq = get(res, 'X')
         
         return seq
+
+    def toTEMPyAtoms(self):
+        """Returns a BioPy.PDB Atom or Structure object as appropriate"""
+        try:
+            from TEMPy.protein.prot_rep_biopy import Atom as TEMPyAtom
+        except ImportError:
+            raise ImportError('TEMPy is needed for this functionality')
+
+        if hasattr(self, 'getResnums'):
+            return [atom.toTEMPyAtom() for atom in self]
+        else:
+            return [self.toTEMPyAtom()]
+
+    def toTEMPyStructure(self):
+        """Returns a BioPy.PDB Atom or Structure object as appropriate""" 
+        try:
+            from TEMPy.protein.prot_rep_biopy import BioPy_Structure
+        except ImportError:
+            raise ImportError('TEMPy is needed for this functionality')
+
+        return BioPy_Structure(self.toTEMPyAtoms())

--- a/prody/proteins/emdfile.py
+++ b/prody/proteins/emdfile.py
@@ -11,7 +11,7 @@ from prody.atomic import AtomGroup
 from prody.atomic import flags
 from prody.atomic import ATOMIC_FIELDS
 
-from prody.utilities import openFile
+from prody.utilities import openFile, isListLike
 from prody import LOGGER, SETTINGS
 
 from .localpdb import fetchPDB
@@ -246,7 +246,9 @@ class EMDMAP(object):
 
         if max_cutoff is not None and not isinstance(max_cutoff, Number):
             raise TypeError('max_cutoff should be a number or None')
-            
+        
+        self._filename = stream.name
+
         # Number of columns, rows, and sections (3 words, 12 bytes, 1-12)
         self.NC = st.unpack('<L', stream.read(4))[0]
         self.NR = st.unpack('<L', stream.read(4))[0]
@@ -384,7 +386,47 @@ class EMDMAP(object):
     def center(self):
         return int(self.NS / 2), int(self.NR / 2), int(self.NC / 2)
 
+    def getOrigin(self):
+        return self.x0, self.y0, self.z0
+
+    def setOrigin(self, x0, y0, z0):
+        self.x0, self.y0, self.z0 = x0, y0, z0
+
+    origin = property(getOrigin, setOrigin)
+
+    def getTitle(self):
+        return self._filename
+
+    def setTitle(self, title):
+        self._filename = title
+
+    filename = property(getTitle, setTitle)
+
+    def getApix(self):
+        return np.array((self.Lx / self.NS,
+                         self.Ly / self.NR,
+                         self.Lz / self.NC))
+
+    def setApix(self, apix):
+        if not isListLike(apix):
+            try:
+                apix = [apix, apix, apix]
+            except:
+                raise TypeError('apix must be a single value or list-like')
+
+        if len(apix) != 3:
+            raise ValueError('apix must be a single value or 3 values')
+        
+        self._apix = apix
+        self.Lx = apix[0] * self.NS
+        self.Ly = apix[1] * self.NR
+        self.Lz = apix[2] * self.NC
+
+    apix = property(getApix, setApix)
+
     def coordinate(self, sec, row, col):
+        """Given a position as *sec*, *row* and *col*, 
+        it will return its coordinate in Angstroms. """
         # calculate resolution
         res = np.empty(3)
         res[self.mapc - 1] = self.NC
@@ -401,6 +443,19 @@ class EMDMAP(object):
         # convert to Angstroms
         ret = np.multiply(ret, res)
         return ret
+
+    def toTEMPyMap(self):
+        """Convert to a TEMPy Map."""
+        try:
+            from TEMPy.maps.em_map import Map
+            from TEMPy.maps.map_parser import MapParser
+        except ImportError:
+            raise ImportError('TEMPy needs to be installed for this functionality')
+        
+        header = MapParser.readMRCHeader(self.filename)
+        newOrigin = np.array((self.ncstart, self.nrstart, self.nsstart)) * self.apix
+        return Map(self.density, newOrigin, self.apix, self.filename, header)
+
 
 
 class TRNET(object):


### PR DESCRIPTION
We now have converters from ProDy Atom, Atomic and EMDMAP classes to TEMPy Atom, BioPy_Structure and Map objects. This also included addition to EMDMAP of functions and attributes for filename, origin and apix.

This enables pipelines such as the following:
```
from TEMPy.protein.scoring_functions import ScoringFunctions
from TEMPy.protein.structure_blurrer import StructureBlurrer

from prody import *

ne_map = parseEMD('2680')
ne, ne_header = parsePDB('4uqj', header=True)

ne_map_tempy = ne_map.toTEMPyMap()

ne_BioPy_Structure = ne.toTEMPyStructure()
blurrer = StructureBlurrer()
ne_blurred = blurrer.gaussian_blur(ne_BioPy_Structure,
                                    ne_header['resolution'], 
                                    ne_map_tempy, 
                                    filename=ne.getTitle()+'.mrc')
ne_blurred.write_to_MRC_file(ne_blurred.filename)

sc = ScoringFunctions()
ccc = sc.CCC(ne_blurred, ne_map_tempy)
print('\n', ccc)

anm, atoms = calcANM(ne, n_modes=3)
aa_anm, aa_atoms = extendModel(anm, atoms, ne)

ens = sampleModes(aa_anm, aa_atoms, n_confs=5, rmsd=3)
blurred_confs = []
for i, coordset in enumerate(ens.getCoordsets()):
    conf = aa_atoms.copy()
    conf.setCoords(coordset)
    blurred_conf = blurrer.gaussian_blur(conf.toTEMPyStructure(),
                                         ne_header['resolution'],
                                         ne_map_tempy,
                                         filename='{0}_conf_{1}.mrc'.format(
                                             conf.getTitle(), i))
    ccc = sc.CCC(blurred_conf, ne_map_tempy)
    print('\n', ccc, '\n')
    blurred_conf.write_to_MRC_file(blurred_conf.filename)
    blurred_confs.append(blurred_conf)
```

This does the following:
1. Use ProDy to fetch the map and pdb files, 2680.map and 4uqj.pdb, respectively
2. Provide them to TEMPy to create a map from the pdb structure by Gaussian blurring
3. Compare it to the map by calculating the cross-correlation coefficient (CCC)
4. Generate new conformers by sampling along ANM modes and repeat steps 2 and 3 for them to see if they fit any better. They all fit worse in this case because it is a good starting model, but in some cases it might not be and may help with fitting.
 
The output is as follows:
```
@> As n_nodes is less than or equal to 0, no nodes will be made and the raw map will be returned
@> PDB file is found in working directory (4uqj.pdb.gz).
@> 21793 atoms and 1 coordinate set(s) were parsed in 0.22s.
@> Secondary structures were assigned to 1924 residues.

 0.7736800756540227

@> Hessian was built in 1.89s.
@> 3 modes were calculated in 46.31s.
@> Parameter: rmsd = 3.00 A
@> Parameter: n_confs = 5
@> Modes are scaled by 5.435640482373315.

 0.7727212007656724

 0.7694773129943487

 0.7701585397277612

 0.7568664348223535

 0.7456445408399182
```