### PR TITLE
bug fixes for converting AtomMap to TEMPy

### DIFF
--- a/prody/atomic/atomic.py
+++ b/prody/atomic/atomic.py
@@ -262,7 +262,7 @@ class Atomic(object):
             raise ImportError('TEMPy is needed for this functionality')
 
         if hasattr(self, 'getResnums'):
-            return [atom.toTEMPyAtom() for atom in self]
+            return [atom.toTEMPyAtom() for atom in self if atom is not None]
         else:
             return [self.toTEMPyAtom()]
 

--- a/prody/proteins/emdfile.py
+++ b/prody/proteins/emdfile.py
@@ -3,7 +3,6 @@
 
 .. _EMD map files: http://emdatabank.org/mapformat.html"""
 
-from collections import defaultdict
 from numbers import Number
 import os.path
 
@@ -12,7 +11,7 @@ from prody.atomic import flags
 from prody.atomic import ATOMIC_FIELDS
 
 from prody.utilities import openFile, isListLike, copy
-from prody import LOGGER, SETTINGS
+from prody import LOGGER
 
 from .localpdb import fetchPDB
 
@@ -337,26 +336,26 @@ class EMDMAP(object):
 
     def thresholdMap(self, min_cutoff=None, max_cutoff=None):
         """Thresholds a map and returns a new map like the equivalent function in TEMPy"""
-        newMap1 = self.density.copy()
+        newDensity = self.density.copy()
 
-        if min_cutoff is not None:
-            if isinstance(min_cutoff, Number):
-                min_cutoff = float(min_cutoff)
+        if max_cutoff is not None:
+            if isinstance(max_cutoff, Number):
+                min_cutoff = float(max_cutoff)
             else:
-                raise TypeError('min_cutoff should be a number or None')
-        else:
-            newMap1 = newMap1 * (newMap1 < max_cutoff) 
+                raise TypeError('max_cutoff should be a number or None')
+
+            newDensity = newDensity * (newDensity < max_cutoff)
             
         if min_cutoff is not None:
             if isinstance(min_cutoff, Number):
                 min_cutoff = float(min_cutoff)
             else:
                 raise TypeError('min_cutoff should be a number or None')
-        else:
-            newMap1 = newMap1 * (newMap1 > min_cutoff)
+
+            newDensity = newDensity * (newDensity > min_cutoff)
 
         newMap = self.copyMap()
-        newMap.density = newMap1
+        newMap.density = newDensity
         return newMap
 
     def numidx2matidx(self, numidx):

--- a/prody/proteins/emdfile.py
+++ b/prody/proteins/emdfile.py
@@ -11,7 +11,7 @@ from prody.atomic import AtomGroup
 from prody.atomic import flags
 from prody.atomic import ATOMIC_FIELDS
 
-from prody.utilities import openFile, isListLike
+from prody.utilities import openFile, isListLike, copy
 from prody import LOGGER, SETTINGS
 
 from .localpdb import fetchPDB
@@ -355,7 +355,7 @@ class EMDMAP(object):
         else:
             newMap1 = newMap1 * (newMap1 > min_cutoff)
 
-        newMap = self.copy()
+        newMap = self.copyMap()
         newMap.density = newMap1
         return newMap
 
@@ -455,6 +455,12 @@ class EMDMAP(object):
         header = MapParser.readMRCHeader(self.filename)
         newOrigin = np.array((self.ncstart, self.nrstart, self.nsstart)) * self.apix
         return Map(self.density, newOrigin, self.apix, self.filename, header)
+
+    def copyMap(self):
+        """
+        Copy to a new object.
+        """
+        return copy(self)
 
 
 


### PR DESCRIPTION
AtomMap has None for dummies when iterating.

Therefore, we get the following error:
```
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-16-7a0390781457> in <module>
----> 1 c_BioPy_Structure = c_alg.toTEMPyStructure()

~\code\ProDy\prody\atomic\atomic.py in toTEMPyStructure(self)
    274             raise ImportError('TEMPy is needed for this functionality')
    275
--> 276         return BioPy_Structure(self.toTEMPyAtoms())

~\code\ProDy\prody\atomic\atomic.py in toTEMPyAtoms(self)
    263
    264         if hasattr(self, 'getResnums'):
--> 265             return [atom.toTEMPyAtom() for atom in self if atom is not None]
    266         else:
    267             return [self.toTEMPyAtom()]

~\code\ProDy\prody\atomic\atomic.py in <listcomp>(.0)
    263
    264         if hasattr(self, 'getResnums'):
--> 265             return [atom.toTEMPyAtom() for atom in self if atom is not None]
    266         else:
    267             return [self.toTEMPyAtom()]

AttributeError: 'NoneType' object has no attribute 'toTEMPyAtom'
```

Code giving it was the following:
```
o, c = parsePDB('1gruA', '1gr5A')
o = o.protein
c = c.protein

cmap = alignChains(c, o)[0]
c_alg, T = superpose(cmap, o)

c_BioPy_Structure = c_alg.toTEMPyStructure()
```

With the fix, we no longer get this error:
```
In [1]: from prody import *
   ...: 
   ...: o, c = parsePDB('1gruA', '1gr5A')
   ...: o = o.protein
   ...: c = c.protein
   ...: 
   ...: cmap = alignChains(c, o)[0]
   ...: c_alg, T = superpose(cmap, o, weights=cmap.getFlags("mapped"))
   ...: 
   ...: c_BioPy_Structure = c_alg.toTEMPyStructure()
@> 2 PDBs were parsed in 0.29s.
@> Trying to map atoms based on residue numbers and identities:
@>   Comparing Chain A from 1gr5A (len=517) with Chain A from 1gruA:
@>      Mapped: 516 residues match with 100% sequence identity and 98% overlap.
@> Finding the atommaps based on their coverages...
@> Identified that there exists 1 atommap(s) potentially.

In [2]: c_BioPy_Structure
Out[2]: 
No Of Atoms: 3710
First Atom: (ALA 2 A: 164.0313503184332, 175.68051608260606, 150.82603544034384)
Last Atom: (PRO 525 A: 163.89904926392495, 178.8354820112557, 161.5486421392784)
```