### PR TITLE
calcENM exanm fix

### DIFF
--- a/prody/dynamics/editing.py
+++ b/prody/dynamics/editing.py
@@ -213,7 +213,8 @@ def trimModelByMask(model, mask):
             gnm.setKirchhoff(matrix)
             return gnm
         elif isinstance(model, ANM):
-            anm = ANM(model.getTitle() + ' reduced')
+            model_type = type(model)
+            anm = model_type(model.getTitle() + ' reduced')
             
             n = len(matrix) // 3
             for i in range(n):
@@ -224,6 +225,9 @@ def trimModelByMask(model, mask):
                     S -= matrix[i*3:i*3+3, j*3:j*3+3]
                 matrix[i*3:i*3+3, i*3:i*3+3] = S
             anm.setHessian(matrix)
+            if hasattr(anm, 'getMembrane'):
+                anm._membrane = model.getMembrane()
+                anm._combined = model.getCombined()
             return anm
 
 def sliceMode(mode, atoms, select):


### PR DESCRIPTION
Otherwise, I get the following error because calcENM doesn't make an exANM object.
```
     60
     61     anm, ca = calcENM(n_opm.ca, n_modes=10, model='exanm', select='ca')
---> 62     n_mem = anm.getCombined()
     63
     64     n_mem_alg = applyTransformation(T, n_mem.copy())

AttributeError: 'ANM' object has no attribute 'getCombined'

In [2]: anm
Out[2]: <ANM: 3kg2-opm reduced (10 modes; 3116 nodes)>
```