### PR TITLE
ens_setWeights_bug_fix

### DIFF
--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -381,16 +381,16 @@ class Ensemble(object):
 
         if weights is None:
             self._weights = None
-
-        if self._n_atoms == 0:
-            raise AttributeError('first set reference coordinates')
-        try:
-            self._weights = checkWeights(weights, self._n_atoms, None)
-        except ValueError:
-            weights = checkWeights(weights, self.numSelected(), None)
-            if not self._weights:
-                self._weights = ones((self._n_atoms, 1), dtype=float)
-            self._weights[self._indices, :] = weights    
+        else:
+            if self._n_atoms == 0:
+                raise AttributeError('first set reference coordinates')
+            try:
+                self._weights = checkWeights(weights, self._n_atoms, None)
+            except ValueError:
+                weights = checkWeights(weights, self.numSelected(), None)
+                if not self._weights:
+                    self._weights = ones((self._n_atoms, 1), dtype=float)
+                self._weights[self._indices, :] = weights    
 
     def addCoordset(self, coords, **kwargs):
         """Add coordinate set(s) to the ensemble.  


### PR DESCRIPTION
Fix for setting ensemble weights as None. Otherwise, we get this error:
```
----> 4 ensemble.setWeights(weights)
      5 ensemble.addCoordset(coordsA.copy())

~\code\ProDy\prody\ensemble\ensemble.py in setWeights(self, weights)
    386             raise AttributeError('first set reference coordinates')
    387         try:
--> 388             self._weights = checkWeights(weights, self._n_atoms, None)
    389         except ValueError:
    390             weights = checkWeights(weights, self.numSelected(), None)

~\code\ProDy\prody\utilities\checkers.py in checkWeights(weights, natoms, ncsets, dtype)
     71         ndim, shape, wtype = weights.ndim, weights.shape, weights.dtype
     72     except AttributeError:
---> 73         raise TypeError('weights must be a numpy.ndarray instance')
     74
     75     if ncsets:

TypeError: weights must be a numpy.ndarray instance
```

Probably, this bug slipped notice because people don't usually do that, but it can happen e.g. in adaptive ANM.