### PR TITLE
added fetchPDBs

### DIFF
--- a/prody/proteins/localpdb.py
+++ b/prody/proteins/localpdb.py
@@ -15,7 +15,8 @@ from .wwpdb import checkIdentifiers, fetchPDBviaFTP, fetchPDBviaHTTP
 
 __all__ = ['pathPDBFolder', 'pathPDBMirror',
            'fetchPDB', 'fetchPDBfromMirror',
-           'iterPDBFilenames', 'findPDBFiles']
+           'iterPDBFilenames', 'findPDBFiles',
+           'fetchPDBs']
 
 def pathPDBFolder(folder=None, divided=False):
     """Returns or specify local PDB folder for storing PDB files downloaded from
@@ -367,6 +368,25 @@ def fetchPDB(*pdb, **kwargs):
 
     return filenames[0] if len(identifiers) == 1 else filenames
 
+def fetchPDBs(pdb, **kwargs):
+    """"Wrapper function to fetch multiple files from the PDB. 
+    If no format is given, it tries PDB then mmCIF then EMD."""
+
+    format = kwargs.pop('format', None)
+    
+    if format is not None:
+        filename = fetchPDB(pdb, format=format, **kwargs)
+
+    else:
+        filename = fetchPDB(pdb, **kwargs)
+
+        if filename is None:
+            filename = fetchPDB("4u6f", format='cif', **kwargs)
+
+        if filename is None:
+            filename = fetchPDB(pdb, format='emd', **kwargs)
+
+    return filename
 
 def iterPDBFilenames(path=None, sort=False, unique=True, **kwargs):
     """Yield PDB filenames in *path* specified by the user or in local PDB


### PR DESCRIPTION
This function addresses the need expressed in #1323 

It provides a new function to fetch files from the PDB regardless of format. The test case is as follows:
```
from prody import fetchPDBs

pdbs = ["3h5v", "4u6f", "2680"]
fnames = []
for pdb in pdbs:
    filename = fetchPDBs(pdb)
    fnames.append(filename)

print(fnames)

@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 3h5v downloaded (C:\Users\james\...\3h5v.pdb.gz)
@> PDB download via FTP completed (1 downloaded, 0 failed).
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> pdb4u6f.ent.gz download failed. 4u6f does not exist on ftp.wwpdb.org.
@> PDB download via FTP completed (0 downloaded, 1 failed).
@> Downloading PDB files via FTP failed, trying HTTP.
@> WARNING 4u6f download failed ('https://files.rcsb.org/download/4U6F.pdb.gz' could not be opened for reading, invalid URL or no internet connection).
@> PDB download via HTTP completed (0 downloaded, 1 failed).
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 4u6f downloaded (C:\Users\james\...\4u6f.cif.gz)
@> PDB download via FTP completed (1 downloaded, 0 failed).
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> pdb2680.ent.gz download failed. 2680 does not exist on ftp.wwpdb.org.
@> PDB download via FTP completed (0 downloaded, 1 failed).
@> Downloading PDB files via FTP failed, trying HTTP.
@> WARNING 2680 download failed ('https://files.rcsb.org/download/2680.pdb.gz' could not be opened for reading, invalid URL or no internet connection).
@> PDB download via HTTP completed (0 downloaded, 1 failed).
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 4u6f downloaded (C:\Users\james\...\4u6f.cif.gz)
@> PDB download via FTP completed (1 downloaded, 0 failed).
['C:\\Users\\james\\OneDrive\\Desktop\\Topf-lab\\James\\tests\\3h5v.pdb.gz', 'C:\\Users\\james\\OneDrive\\Desktop\\Topf-lab\\James\\tests\\4u6f.cif.gz', 'C:\\Users\\james\\OneDrive\\Desktop\\Topf-lab\\James\\tests\\4u6f.cif.gz']
```