### PR TITLE
uniprot PY3 fix

### DIFF
--- a/prody/database/uniprot.py
+++ b/prody/database/uniprot.py
@@ -151,7 +151,7 @@ def queryUniprot(id, expand=[], regex=True):
     record_file.close()
     data = XML(data)
 
-    data = dictElement(data.getchildren()[0], '{http://uniprot.org/uniprot}', number_multiples=True)
+    data = dictElement(data[0], '{http://uniprot.org/uniprot}', number_multiples=True)
 
     for key in data:
         value = data[key]


### PR DESCRIPTION
In Python 3 on Ubuntu 20.20 with Windows Subsystem for Linux 2, the previous code yields the following error, which the new code fixes.
```
In [1]: from prody import *
In [2]: uniprot_rec = searchUniprot('O97071')
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-4a7191ded3ba> in <module>
----> 1 uniprot_rec = searchUniprot('O97071') 
/mnt/c/Users/james/code/ProDy/prody/database/uniprot.py in searchUniprot(id)
    191     """
    192
--> 193     data = queryUniprot(id)
    194
    195     return UniprotRecord(data)
/mnt/c/Users/james/code/ProDy/prody/database/uniprot.py in queryUniprot(id, expand, regex) 
    152     data = XML(data)
    153
--> 154     data = dictElement(data.getchildren()[0], '{http://uniprot.org/uniprot}', number_multiples=True)
    155
    156     for key in data:
AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getchildren'
```

In Python 2 on WSL2 and Python 3 on MinGW, both codes work fine.