### PR TITLE
pdbens addcoordset fix

### DIFF
--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -289,6 +289,7 @@ class PDBEnsemble(Ensemble):
        
         if not n_atoms:
             self._n_atoms = n_nodes
+            n_atoms = self._n_atoms
 
         if n_nodes == n_select and self.isSelected():
             full_coords = np.repeat(self._coords[np.newaxis, :, :], n_csets, axis=0)

--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -292,7 +292,8 @@ class PDBEnsemble(Ensemble):
             n_atoms = self._n_atoms
 
         if n_nodes == n_select and self.isSelected():
-            full_coords = np.repeat(self._coords[np.newaxis, :, :], n_csets, axis=0)
+            full_coords = np.repeat(self._coords[np.newaxis, :, :],
+                                    n_csets, axis=0)
             full_coords[:, self._indices, :] = coords
             coords = full_coords
         


### PR DESCRIPTION
fixes #1351 

The problem was with handling the case where the ensemble starts off empty. It was setting self._n_atoms using n_nodes from the added coordset but leaving the n_atoms variable used below as 0.