### PR TITLE
added nonstd aas

### DIFF
--- a/prody/atomic/flags.py
+++ b/prody/atomic/flags.py
@@ -83,6 +83,8 @@ NONSTANDARD = {
     'PHD': set(['acyclic', 'acidic', 'surface', 'polar', 'large']),
     'XLE': set(['aliphatic', 'acyclic', 'buried', 'hydrophobic', 'large']),
     'XAA': set(),
+    'MEN': set(),
+    'CSB': set()
 }
 
 DEFAULTS = {


### PR DESCRIPTION
Addresses #1358 

Essentially this issue is a request for other non-standard amino acids to be included in protein subsets such as ca and bb.