### PR TITLE
ciffile fix

### DIFF
--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -226,7 +226,7 @@ def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
             fieldCounter += 1
             fields[line.split('.')[1].strip()] = fieldCounter
 
-        if line.startswith('ATOM') or line.startswith('HETATM'):
+        if line.startswith('ATOM  ') or line.startswith('HETATM'):
             if not foundAtomBlock:
                 foundAtomBlock = True
                 start = i


### PR DESCRIPTION
Addresses #1364 

The problem was that line 501 starts with ATOMS as part of a sentence and we hadn't accounted for lines like that.