### PR TITLE
fix to ciffile fix

### DIFF
--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -226,7 +226,7 @@ def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
             fieldCounter += 1
             fields[line.split('.')[1].strip()] = fieldCounter
 
-        if line.startswith('ATOM  ') or line.startswith('HETATM'):
+        if line.startswith('ATOM ') or line.startswith('HETATM'):
             if not foundAtomBlock:
                 foundAtomBlock = True
                 start = i


### PR DESCRIPTION
Fixes error introduced by #1366. Not all pdb entries have two spaces e.g. 3j77