### PR TITLE
scanPockets fix for one pocket

### DIFF
--- a/prody/dynamics/essa.py
+++ b/prody/dynamics/essa.py
@@ -38,7 +38,7 @@ from prody.proteins import parsePDB, writePDB
 from .editing import reduceModel
 from .plotting import showAtomicLines
 from .signature import ModeEnsemble, saveModeEnsemble
-from prody.utilities import which
+from prody.utilities import which, isListLike
 from . import matchModes
 
 __all__ = ['ESSA']
@@ -496,6 +496,8 @@ class ESSA:
             fea, sco = list(zip(*tmp1))
             ps.append(sco)
         pdbs = parsePDB(l)
+        if not isListLike(pdbs):
+            pdbs = [pdbs]
         chdir('../..')
 
         # ----- # ----- #


### PR DESCRIPTION
Fixes #1381 

If there is only one pocket pdb file then parsePDB returns an AtomGroup not a list of AtomGroups, so we check for that and put the single AtomGroup in a list if that is the case. 