### PR TITLE
subset setFlags fix

### DIFF
--- a/prody/atomic/atom.py
+++ b/prody/atomic/atom.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 
-from . import flags
+from .flags import PLANTERS
 from .fields import ATOMIC_FIELDS, READONLY
 from .fields import wrapGetMethod, wrapSetMethod
 from .pointer import AtomPointer
@@ -182,7 +182,7 @@ class Atom(AtomPointer):
 
          :raise AttributeError: when *label* is not in use or read-only"""
 
-        if label in flags.PLANTERS:
+        if label in PLANTERS:
             raise AttributeError('flag {0} cannot be changed by user'
                                     .format(repr(label)))
         flags = self._ag._getFlags(label)

--- a/prody/atomic/subset.py
+++ b/prody/atomic/subset.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import numpy as np
 
-from . import flags
+from .flags import PLANTERS
 from .atom import Atom
 from .fields import ATOMIC_FIELDS, READONLY
 from .fields import wrapGetMethod, wrapSetMethod
@@ -159,7 +159,7 @@ class AtomSubset(AtomPointer):
 
          :raise AttributeError: when *label* is not in use or read-only"""
 
-        if label in flags.PLANTERS:
+        if label in PLANTERS:
             raise AttributeError('flag {0} cannot be changed by user'
                                     .format(repr(label)))
         flags = self._ag._getFlags(label)


### PR DESCRIPTION
Without this fix I get the following error:

```
In [8]: chain.setFlags('hetatm', True)
---------------------------------------------------------------------------
UnboundLocalError                         Traceback (most recent call last)
<ipython-input-8-a917de4e0178> in <module>
----> 1 chain.setFlags('hetatm', True)

~\code\ProDy\prody\atomic\subset.py in setFlags(self, label, value)
    160          :raise AttributeError: when *label* is not in use or read-only"""
    161
--> 162         if label in flags.PLANTERS:
    163             raise AttributeError('flag {0} cannot be changed by user'
    164                                     .format(repr(label)))

UnboundLocalError: local variable 'flags' referenced before assignment
```

With it, everything works as expected:
```
In [4]: chain.getFlags('hetatm')
Out[4]:
array([False, False, False, False, False, False, False, False, False,
       False, False, False, False, False, False, False, False, False])

In [5]: chain.setFlags('hetatm', True)

In [6]: chain.getFlags('hetatm')
Out[6]:
array([ True,  True,  True,  True,  True,  True,  True,  True,  True,
        True,  True,  True,  True,  True,  True,  True,  True,  True])
```