### PR TITLE
pca vars shape fix

### DIFF
--- a/prody/dynamics/pca.py
+++ b/prody/dynamics/pca.py
@@ -208,7 +208,7 @@ class PCA(NMA):
         which = values > ZERO
         self._eigvals = values[which]
         self._array = vectors[:, which]
-        self._vars = values
+        self._vars = values[which]
         self._n_modes = len(self._eigvals)
         if self._n_modes > 1:
             LOGGER.debug('{0} modes were calculated in {1:.2f}s.'


### PR DESCRIPTION
Without this fix, PCA on an ensemble with fewer than 20 members leads to fewer than 20 modes but vars still has 20 values including those that are basically zero. This then causes a problem for calcSqFlucts.
```
In [4]: pca._eigvals.shape
Out[4]: (16,)

In [5]: pca._array.shape
Out[5]: (8502, 16)

In [6]: pca._vars.shape
Out[6]: (20,)

In [7]: calcSqFlucts(pca)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-7-00fa53df2b79> in <module>
----> 1 calcSqFlucts(pca)

~\code\ProDy\prody\dynamics\analysis.py in calcSqFlucts(modes)
    327     V, W, is3d, n_atoms = _getModeProperties(modes)
    328
--> 329     sq_flucts = np.dot(V * V, W).sum(axis=1)
    330
    331     if is3d:

<__array_function__ internals> in dot(*args, **kwargs)

ValueError: shapes (8502,16) and (20,20) not aligned: 16 (dim 1) != 20 (dim 0)
```

With the fix, there is no such problem:
```
@> Covariance is calculated using 17 coordinate sets.
@> Covariance matrix calculated in 0.978131s.
@> 16 modes were calculated in 37.80s.

In [2]: pca._eigvals.shape
Out[2]: (16,)

In [3]: pca._array.shape
Out[3]: (8502, 16)

In [4]: pca._eigvals.shape
Out[4]: (16,)

In [5]: calcSqFlucts(pca)
Out[5]:
array([5.38054297, 4.88110732, 4.15143756, ..., 2.01338465, 3.2190225 ,
       3.55681443])
```