### PR TITLE
mmcif altloc fix

### DIFF
--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -309,6 +309,9 @@ def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
         if alt not in which_altlocs:
             continue
 
+        if alt == '.':
+            alt = ''
+
         if model is not None:
             if int(models[acount]) < model:
                 continue


### PR DESCRIPTION
In mmCIF files, there can be no empty columns and `.` is used instead. For altlocs, this causes problems if we read them as `.` and write that back to PDB files:

```
$ ipython
Python 3.8.6 | packaged by conda-forge | (default, Nov 27 2020, 18:58:29) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.20.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ag = parseMMCIF('7bnm', subset='ca')
@> 3207 atoms and 1 coordinate set(s) were parsed in 0.15s.

In [3]: ag.getAltlocs()
Out[3]: array(['.', '.', '.', ..., '.', '.', '.'], dtype='<U1')

In [4]: writePDB('7bnm_ca_prody.pdb', ag)
Out[4]: '7bnm_ca_prody.pdb'

In [5]: ag2 = parsePDB('7bnm_ca_prody.pdb')
@> WARNING Atomic data could not be parsed, please check the input file.
@> WARNING Trying to parse mmCIF file instead
@> WARNING Trying to parse EMD file instead
@> As n_nodes is less than or equal to 0, no nodes will be made and the raw map will be returned
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
~\code\ProDy\prody\proteins\pdbfile.py in _parsePDB(pdb, **kwargs)
    241             LOGGER.warn("Trying to parse mmCIF file instead")
--> 242             return parseMMCIF(pdb, **kwargs)
    243         except:

~\code\ProDy\prody\proteins\ciffile.py in parseMMCIF(pdb, **kwargs)
    109     cif = openFile(pdb, 'rt')
--> 110     result = parseMMCIFStream(cif, chain=chain, **kwargs)
    111     cif.close()

~\code\ProDy\prody\proteins\ciffile.py in parseMMCIFStream(stream, **kwargs)
    179         else:
--> 180             ag = _parseMMCIFLines(ag, lines, model, chain, subset,
    181                                   altloc, header)

~\code\ProDy\prody\proteins\ciffile.py in _parseMMCIFLines(atomgroup, lines, model, chain, subset, altloc_torf, header)
    232                 start = i
--> 233             models.append(line.split()[fields['pdbx_PDB_model_num']])
    234             if len(models) == 1 or (models[asize] != models[asize-1]):

KeyError: 'pdbx_PDB_model_num'

During handling of the above exception, another exception occurred:

ValueError                                Traceback (most recent call last)
~\code\ProDy\prody\proteins\pdbfile.py in _parsePDB(pdb, **kwargs)
    245                 LOGGER.warn("Trying to parse EMD file instead")
--> 246                 return parseEMD(pdb, **kwargs)
    247             except:

~\code\ProDy\prody\proteins\emdfile.py in parseEMD(emd, **kwargs)
     93     emdStream = openFile(emd, 'rb')
---> 94     result = parseEMDStream(emdStream, **kwargs)
     95     emdStream.close()

~\code\ProDy\prody\proteins\emdfile.py in parseEMDStream(stream, **kwargs)
    137
--> 138     emd = EMDMAP(stream, min_cutoff, max_cutoff)
    139

~\code\ProDy\prody\proteins\emdfile.py in __init__(self, stream, min_cutoff, max_cutoff)
    323         # Data blocks (1024-end)
--> 324         self.density = np.empty([self.NS, self.NR, self.NC])
    325         for s in range(0, self.NS):

ValueError: array is too big; `arr.size * arr.dtype.itemsize` is larger than the maximum possible size.

During handling of the above exception, another exception occurred:

OSError                                   Traceback (most recent call last)
<ipython-input-5-3ac694fd10dd> in <module>
----> 1 ag2 = parsePDB('7bnm_ca_prody.pdb')

~\code\ProDy\prody\proteins\pdbfile.py in parsePDB(*pdb, **kwargs)
    122
    123     if n_pdb == 1:
--> 124         return _parsePDB(pdb[0], **kwargs)
    125     else:
    126         results = []

~\code\ProDy\prody\proteins\pdbfile.py in _parsePDB(pdb, **kwargs)
    246                 return parseEMD(pdb, **kwargs)
    247             except:
--> 248                 raise IOError('PDB file for {0} could not be downloaded.'
    249                               .format(pdb))
    250

OSError: PDB file for 7bnm_ca_prody.pdb could not be downloaded.
```
```
REMARK AtomGroup 7bnm_ca
ATOM      1  CA .GLN A  14     169.665 175.789 266.766  1.00226.92         A C  
ATOM      2  CA .CYS A  15     171.717 173.896 264.197  1.00233.77         A C  
ATOM      3  CA .VAL A  16     170.688 170.613 262.548  1.00234.74         A C
```

With the fix, everything is ok:
```
In [2]: ag = parseMMCIF('7bnm', subset='ca')
@> 3207 atoms and 1 coordinate set(s) were parsed in 0.16s.

In [3]: ag.getAltlocs()
Out[3]: array(['', '', '', ..., '', '', ''], dtype='<U1')

In [4]: writePDB('7bnm_ca_prody.pdb', ag)
Out[4]: '7bnm_ca_prody.pdb'

In [5]: ag2 = parsePDB('7bnm_ca_prody.pdb')
@> 3207 atoms and 1 coordinate set(s) were parsed in 0.03s.
```
```
REMARK AtomGroup 7bnm_ca
ATOM      1  CA  GLN A  14     169.665 175.789 266.766  1.00226.92         A C  
ATOM      2  CA  CYS A  15     171.717 173.896 264.197  1.00233.77         A C  
ATOM      3  CA  VAL A  16     170.688 170.613 262.548  1.00234.74         A C  
```

We can, of course, see another problem, which is that parseEMD (which get called by parsePDB if it fails with PDB files and subsequent calling of parseMMCIF) can't recognise that this should be a filename. 