### PR TITLE
_parsePDB fix for bad chains

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -238,12 +238,15 @@ def _parsePDB(pdb, **kwargs):
         return result
     else:
         try:
-            LOGGER.warn("Trying to parse mmCIF file instead")
+            LOGGER.warn("Trying to parse as mmCIF file instead")
             return parseMMCIF(pdb, **kwargs)
-        except:
+        except KeyError:
             try:
-                LOGGER.warn("Trying to parse EMD file instead")
+                LOGGER.warn("Trying to parse as EMD file instead")
                 return parseEMD(pdb, **kwargs)
+            except ValueError:
+                LOGGER.warn("Could not parse anything so returning None")
+                return None
             except:                
                 raise IOError('PDB file for {0} could not be downloaded.'
                               .format(pdb))


### PR DESCRIPTION
This fixes a problem inadvertently incorporated by #1402. It wasn't picked up then because the tests weren't working, but was now picked up in e.g. https://github.com/jamesmkrieger/ProDy/runs/4069323448?check_suite_focus=true

The problem is that _parsePDB raises an error instead of returning None in situations with wrong chain IDs so the one of the tests fails:
```
=================================== FAILURES ===================================
________________________ TestParsePDB.testChainArgument ________________________

pdb = '/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb'
kwargs = {'chain': '$', 'title': 'pdb2k39_truncated'}
title = 'pdb2k39_truncated', chain = '', ext = '.pdb'
stream = <_io.TextIOWrapper name='/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb' mode='rt' encoding='UTF-8'>
result = None

    def _parsePDB(pdb, **kwargs):
        title = kwargs.get('title', None)
        chain = ''
        if not os.path.isfile(pdb):
            pdb, chain = _getPDBid(pdb)
            if title is None:
                title = pdb
                kwargs['title'] = title
            filename = fetchPDB(pdb, **kwargs)
            if filename is None:
                try:
                    LOGGER.info("Trying to parse mmCIF file instead")
                    return parseMMCIF(pdb+chain, **kwargs)
                except:
                    try:
                        LOGGER.info("Trying to parse EMD file instead")
                        return parseEMD(pdb+chain, **kwargs)
                    except:
                        raise IOError('PDB file for {0} could not be downloaded.'
                                    .format(pdb))
            pdb = filename
        if title is None:
            title, ext = os.path.splitext(os.path.split(pdb)[1])
            if ext == '.gz':
                title, ext = os.path.splitext(title)
            if len(title) == 7 and title.startswith('pdb'):
                title = title[3:]
            kwargs['title'] = title
    
        stream = openFile(pdb, 'rt')
        if chain != '':
            kwargs['chain'] = chain
        result = parsePDBStream(stream, **kwargs)
        stream.close()
    
        if result is not None:
            return result
        else:
            try:
                LOGGER.warn("Trying to parse mmCIF file instead")
>               return parseMMCIF(pdb, **kwargs)

prody/proteins/pdbfile.py:242: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

pdb = '/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb'
kwargs = {'title': 'pdb2k39_truncated'}, chain = '$'
title = 'pdb2k39_truncated'
cif = <_io.TextIOWrapper name='/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb' mode='rt' encoding='UTF-8'>

    def parseMMCIF(pdb, **kwargs):
        """Returns an :class:`.AtomGroup` and/or a :class:`.StarDict` containing header data
        parsed from an mmCIF file. If not found, the mmCIF file will be downloaded
        from the PDB. It will be downloaded in uncompressed format regardless of
        the compressed keyword.
    
        This function extends :func:`.parseMMCIFStream`.
    
        :arg pdb: a PDB identifier or a filename
            If needed, mmCIF files are downloaded using :func:`.fetchPDB()` function.
        :type pdb: str
    
        :arg chain: comma separated string or list-like of chain IDs
        :type chain: str, tuple, list, :class:`~numpy.ndarray`
        """
        chain = kwargs.pop('chain', None)
        title = kwargs.get('title', None)
        if not os.path.isfile(pdb):
            if len(pdb) == 5 and pdb.isalnum():
                if chain is None:
                    chain = pdb[-1]
                    pdb = pdb[:4]
                else:
                    raise ValueError('Please provide chain as a keyword argument or part of the PDB ID, not both')
            else:
                chain = chain
    
            if len(pdb) == 4 and pdb.isalnum():
                if title is None:
                    title = pdb
                    kwargs['title'] = title
    
                if os.path.isfile(pdb + '.cif'):
                    filename = pdb + '.cif'
                elif os.path.isfile(pdb + '.cif.gz'):
                    filename = pdb + '.cif.gz'
                else:
                    filename = fetchPDB(pdb, report=True,
                                        format='cif', compressed=False)
                    if filename is None:
                        raise IOError('mmCIF file for {0} could not be downloaded.'
                                      .format(pdb))
                pdb = filename
            else:
                raise IOError('{0} is not a valid filename or a valid PDB '
                              'identifier.'.format(pdb))
        if title is None:
            title, ext = os.path.splitext(os.path.split(pdb)[1])
            if ext == '.gz':
                title, ext = os.path.splitext(title)
            if len(title) == 7 and title.startswith('pdb'):
                title = title[3:]
            kwargs['title'] = title
        cif = openFile(pdb, 'rt')
>       result = parseMMCIFStream(cif, chain=chain, **kwargs)

prody/proteins/ciffile.py:110: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

stream = <_io.TextIOWrapper name='/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb' mode='rt' encoding='UTF-8'>
kwargs = {'chain': '$', 'title': 'pdb2k39_truncated'}, model = None
subset = None, chain = '$', altloc = 'A', header = False, title_suffix = '_$'
ag = <AtomGroup: pdb2k39_truncated_$ (0 atoms; no coordinates)>

    def parseMMCIFStream(stream, **kwargs):
        """Returns an :class:`.AtomGroup` and/or a class:`.StarDict`
        containing header data parsed from a stream of CIF lines.
    
        :arg stream: Anything that implements the method ``readlines``
            (e.g. :class:`file`, buffer, stdin)
    
        """
    
        model = kwargs.get('model')
        subset = kwargs.get('subset')
        chain = kwargs.get('chain')
        altloc = kwargs.get('altloc', 'A')
        header = kwargs.get('header', False)
    
        if model is not None:
            if isinstance(model, int):
                if model < 0:
                    raise ValueError('model must be greater than 0')
            else:
                raise TypeError('model must be an integer, {0} is invalid'
                                .format(str(model)))
        title_suffix = ''
        if subset:
            try:
                subset = _PDBSubsets[subset.lower()]
            except AttributeError:
                raise TypeError('subset must be a string')
            except KeyError:
                raise ValueError('{0} is not a valid subset'
                                 .format(repr(subset)))
            title_suffix = '_' + subset
        if chain is not None:
            if not isinstance(chain, str):
                raise TypeError('chain must be a string')
            elif len(chain) == 0:
                raise ValueError('chain must not be an empty string')
            title_suffix = '_' + chain + title_suffix
    
        ag = None
        if 'ag' in kwargs:
            ag = kwargs['ag']
            if not isinstance(ag, AtomGroup):
                raise TypeError('ag must be an AtomGroup instance')
            n_csets = ag.numCoordsets()
        elif model != 0:
            ag = AtomGroup(str(kwargs.get('title', 'Unknown')) + title_suffix)
            n_csets = 0
    
        if model != 0:
            LOGGER.timeit()
            try:
                lines = stream.readlines()
            except AttributeError as err:
                try:
                    lines = stream.read().split('\n')
                except AttributeError:
                    raise err
            if not len(lines):
                raise ValueError('empty PDB file or stream')
    
            if header:
                ag, header = _parseMMCIFLines(ag, lines, model, chain, subset,
                                              altloc, header)
            else:
>               ag = _parseMMCIFLines(ag, lines, model, chain, subset,
                                      altloc, header)

prody/proteins/ciffile.py:180: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

atomgroup = <AtomGroup: pdb2k39_truncated_$ (0 atoms; no coordinates)>
lines = ['HEADER    SIGNALING PROTEIN                       25-APR-08   2K39              \n', 'TITLE     RECOGNITION DYNAMICS...                        \n', 'COMPND   3 CHAIN: A;                                                            \n', ...]
model = None, chain = '$', subset = None, altloc_torf = 'A', header = False

    def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
                         altloc_torf, header):
        """Returns an AtomGroup. See also :func:`.parsePDBStream()`.
    
        :arg lines: mmCIF lines
        """
    
        if subset is not None:
            if subset == 'ca':
                subset = set(('CA',))
            elif subset in 'bb':
                subset = flags.BACKBONE
            protein_resnames = flags.AMINOACIDS
    
        asize = 0
        i = 0
        models = []
        nModels = 0
        fields = OrderedDict()
        fieldCounter = -1
        foundAtomBlock = False
        doneAtomBlock = False
        start = 0
        stop = 0
        while not doneAtomBlock:
            line = lines[i]
            if line[:11] == '_atom_site.':
                fieldCounter += 1
                fields[line.split('.')[1].strip()] = fieldCounter
    
            if line.startswith('ATOM ') or line.startswith('HETATM'):
                if not foundAtomBlock:
                    foundAtomBlock = True
                    start = i
>               models.append(line.split()[fields['pdbx_PDB_model_num']])
E               KeyError: 'pdbx_PDB_model_num'

prody/proteins/ciffile.py:233: KeyError

During handling of the above exception, another exception occurred:

pdb = '/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb'
kwargs = {'chain': '$', 'title': 'pdb2k39_truncated'}
title = 'pdb2k39_truncated', chain = '', ext = '.pdb'
stream = <_io.TextIOWrapper name='/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb' mode='rt' encoding='UTF-8'>
result = None

    def _parsePDB(pdb, **kwargs):
        title = kwargs.get('title', None)
        chain = ''
        if not os.path.isfile(pdb):
            pdb, chain = _getPDBid(pdb)
            if title is None:
                title = pdb
                kwargs['title'] = title
            filename = fetchPDB(pdb, **kwargs)
            if filename is None:
                try:
                    LOGGER.info("Trying to parse mmCIF file instead")
                    return parseMMCIF(pdb+chain, **kwargs)
                except:
                    try:
                        LOGGER.info("Trying to parse EMD file instead")
                        return parseEMD(pdb+chain, **kwargs)
                    except:
                        raise IOError('PDB file for {0} could not be downloaded.'
                                    .format(pdb))
            pdb = filename
        if title is None:
            title, ext = os.path.splitext(os.path.split(pdb)[1])
            if ext == '.gz':
                title, ext = os.path.splitext(title)
            if len(title) == 7 and title.startswith('pdb'):
                title = title[3:]
            kwargs['title'] = title
    
        stream = openFile(pdb, 'rt')
        if chain != '':
            kwargs['chain'] = chain
        result = parsePDBStream(stream, **kwargs)
        stream.close()
    
        if result is not None:
            return result
        else:
            try:
                LOGGER.warn("Trying to parse mmCIF file instead")
                return parseMMCIF(pdb, **kwargs)
            except:
                try:
                    LOGGER.warn("Trying to parse EMD file instead")
>                   return parseEMD(pdb, **kwargs)

prody/proteins/pdbfile.py:246: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

emd = '/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb'
kwargs = {'chain': '$', 'title': 'pdb2k39_truncated'}
title = 'pdb2k39_truncated'
emdStream = <_io.BufferedReader name='/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb'>

    def parseEMD(emd, **kwargs):
        """Parses an EM density map in EMD/MRC2015 format and
        optionally returns an :class:`.AtomGroup` containing
        beads built in the density using the TRN algorithm [_TM94].
    
        This function extends :func:`.parseEMDStream`.
    
        See :ref:`cryoem_analysis` for a usage example.
    
        :arg emd: an EMD identifier or a file name. A 4-digit
                  EMDataBank identifier can be provided to download
                  it via FTP.
        :type emd: str
    
        :arg min_cutoff: minimum density cutoff to read EMD map. The regions with
                     lower density than this cutoff are discarded.
                     This corresponds to the previous cutoff and take values from it.
        :type min_cutoff: float
    
        :arg max_cutoff: maximum density cutoff to read EMD map. The regions with
                     higher density than this cutoff are discarded.
        :type max_cutoff: float
    
        :arg n_nodes: A bead based network will be constructed into the provided density map.
                      This parameter will set the number of beads to fit to density map.
                      Default is 0. Please change it to some number to run the TRN algorithm.
        :type n_nodes: int
    
        :arg num_iter: After reading density map, coordinates are predicted with the
                       topology representing network method. This parameter is the total
                       number of iterations of this algorithm.
        :type num_iter: int
    
        :arg map: Return the density map itself. Default is **False** in line with previous behaviour.
            This value is reset to **True** if n_nodes is 0 or less.
        :type map: bool
        """
    
        title = kwargs.get('title', None)
        if not os.path.isfile(emd):
            if emd.startswith('EMD-') and len(emd[4:]) in [4, 5]:
                emd = emd[4:]
    
            if len(emd) in [4, 5] and emd.isdigit():
                if title is None:
                    title = emd
                    kwargs['title'] = title
    
                if os.path.isfile(emd + '.map'):
                    filename = emd + '.map'
                elif os.path.isfile(emd + '.map.gz'):
                    filename = emd + '.map.gz'
                else:
                    filename = fetchPDB(emd, report=True,
                                        format='emd', compressed=False)
                    if filename is None:
                        raise IOError('EMD map file for {0} could not be downloaded.'
                                      .format(emd))
                emd = filename
            else:
                raise IOError('EMD file {0} is not available in the directory {1}'
                              .format(emd, os.getcwd()))
        if title is None:
            kwargs['title'], ext = os.path.splitext(os.path.split(emd)[1])
    
        emdStream = openFile(emd, 'rb')
>       result = parseEMDStream(emdStream, **kwargs)

prody/proteins/emdfile.py:94: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

stream = <_io.BufferedReader name='/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb'>
kwargs = {'chain': '$', 'title': 'pdb2k39_truncated'}, cutoff = None
min_cutoff = None, max_cutoff = None, n_nodes = 0, num_iter = 20, map = True
make_nodes = False

    def parseEMDStream(stream, **kwargs):
        """Parse lines of data stream from an EMD/MRC2014 file and
        optionally return an :class:`.AtomGroup` containing TRN
        nodes based on it.
    
        :arg stream: Any object with the method ``readlines``
                    (e.g. :class:`file`, buffer, stdin)
        """
        cutoff = kwargs.get('cutoff', None)
        min_cutoff = kwargs.get('min_cutoff', cutoff)
        if min_cutoff is not None:
            if isinstance(min_cutoff, Number):
                min_cutoff = float(min_cutoff)
            else:
                raise TypeError('min_cutoff should be a number or None')
    
        max_cutoff = kwargs.get('max_cutoff', None)
        if max_cutoff is not None:
            if isinstance(max_cutoff, Number):
                max_cutoff = float(max_cutoff)
            else:
                raise TypeError('max_cutoff should be a number or None')
    
        n_nodes = kwargs.get('n_nodes', 0)
        num_iter = int(kwargs.get('num_iter', 20))
        map = kwargs.get('map', False)
    
        if not isinstance(n_nodes, int):
            raise TypeError('n_nodes should be an integer')
    
        if n_nodes > 0:
            make_nodes = True
        else:
            make_nodes = False
            map = True
            LOGGER.info('As n_nodes is less than or equal to 0, no nodes will be'
                        ' made and the raw map will be returned')
    
>       emd = EMDMAP(stream, min_cutoff, max_cutoff)

prody/proteins/emdfile.py:138: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <prody.proteins.emdfile.EMDMAP object at 0x7f32e7b91040>
stream = <_io.BufferedReader name='/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb'>
min_cutoff = None, max_cutoff = None

    def __init__(self, stream, min_cutoff, max_cutoff):
        if min_cutoff is not None and not isinstance(min_cutoff, Number):
            raise TypeError('min_cutoff should be a number or None')
    
        if max_cutoff is not None and not isinstance(max_cutoff, Number):
            raise TypeError('max_cutoff should be a number or None')
    
        self._filename = stream.name
    
        # Number of columns, rows, and sections (3 words, 12 bytes, 1-12)
        self.NC = st.unpack('<L', stream.read(4))[0]
        self.NR = st.unpack('<L', stream.read(4))[0]
        self.NS = st.unpack('<L', stream.read(4))[0]
        self.Ntot = self.NC * self.NR * self.NS
    
        # Mode (1 word, 4 bytes, 13-16)
        self.mode = st.unpack('<L', stream.read(4))[0]
    
        # Number of first column, row, section (3 words, 12 bytes, 17-28)
        self.ncstart = st.unpack('<l', stream.read(4))[0]
        self.nrstart = st.unpack('<l', stream.read(4))[0]
        self.nsstart = st.unpack('<l', stream.read(4))[0]
    
        # Number of intervals along x, y, z (3 words, 12 bytes, 29-40)
        self.Nx = st.unpack('<L', stream.read(4))[0]
        self.Ny = st.unpack('<L', stream.read(4))[0]
        self.Nz = st.unpack('<L', stream.read(4))[0]
    
        # Cell dimensions (Angstroms) (3 words, 12 bytes, 41-52)
        self.Lx = st.unpack('<f', stream.read(4))[0]
        self.Ly = st.unpack('<f', stream.read(4))[0]
        self.Lz = st.unpack('<f', stream.read(4))[0]
    
        # Cell angles (Degrees) (3 words, 12 bytes, 53-64)
        self.a = st.unpack('<f', stream.read(4))[0]
        self.b = st.unpack('<f', stream.read(4))[0]
        self.c = st.unpack('<f', stream.read(4))[0]
    
        # Which axis corresponds to column, row, and sections (1, 2, 3 for x, y ,z)
        # (3 words, 12 bytes, 65-76)
        self.mapc = st.unpack('<L', stream.read(4))[0]
        self.mapr = st.unpack('<L', stream.read(4))[0]
        self.maps = st.unpack('<L', stream.read(4))[0]
    
        # Density values (min, max, mean) (3 words, 12 bytes, 77-88)
        self.dmin = st.unpack('<f', stream.read(4))[0]
        self.dmax = st.unpack('<f', stream.read(4))[0]
        self.dmean = st.unpack('<f', stream.read(4))[0]
    
        # Space group number (1 word, 4 bytes, 89-92)
        # For EM/ET, this encodes the type of data:
        # 0 for 2D images and image stacks, 1 for 3D volumes, 401 for volume stacks
        self.ispg = st.unpack('<L', stream.read(4))[0]
    
        # size of extended header (1 word, 4 bytes, 93-96)
        # contained symmetry records in original format definition
        self.nsymbt = st.unpack('<L', stream.read(4))[0]
    
        # we treat this all as extra stuff like MRC2014 format (25 word, 100 bytes, 97-196)
        self.extra = st.unpack('<100s', stream.read(100))[0]
    
        # origins for x, y, z (3 words, 12 bytes, 197-208)
        self.x0 = st.unpack('<f', stream.read(4))[0]
        self.y0 = st.unpack('<f', stream.read(4))[0]
        self.z0 = st.unpack('<f', stream.read(4))[0]
    
        # the character string 'MAP' to identify file type (1 word, 4 bytes, 209-212)
        self.wordMAP = st.unpack('<4s', stream.read(4))[0]
    
        # machine stamp encoding byte ordering of data (1 word, 4 bytes, 213-216)
        self.machst = st.unpack('<4s', stream.read(4))[0]
    
        # rms deviation of map from mean density (1 word, 4 bytes, 217-220)
        self.rms = st.unpack('<f', stream.read(4))[0]
    
        # number of labels being used (1 word, 4 bytes, 221-224)
        self.nlabels = st.unpack('<L', stream.read(4))[0]
    
        # 10 80-character text labels, which we leave concatenated (200 words, 800 bytes, 225-1024)
        self.labels = st.unpack('<800s', stream.read(800))[0]
    
        # Data blocks (1024-end)
>       self.density = np.empty([self.NS, self.NR, self.NC])
E       ValueError: array is too big; `arr.size * arr.dtype.itemsize` is larger than the maximum possible size.

prody/proteins/emdfile.py:324: ValueError

During handling of the above exception, another exception occurred:

self = <prody.tests.proteins.test_pdbfile.TestParsePDB testMethod=testChainArgument>

    def testChainArgument(self):
        """Test outcome of valid and invalid *chain* arguments."""
    
        path = pathDatafile(self.pdb['file'])
        self.assertRaises(TypeError, parsePDB, path, chain=['A'])
        self.assertRaises(ValueError, parsePDB, path, chain='')
>       self.assertIsNone(parsePDB(path, chain='$'))

prody/tests/proteins/test_pdbfile.py:92: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
prody/proteins/pdbfile.py:124: in parsePDB
    return _parsePDB(pdb[0], **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

pdb = '/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb'
kwargs = {'chain': '$', 'title': 'pdb2k39_truncated'}
title = 'pdb2k39_truncated', chain = '', ext = '.pdb'
stream = <_io.TextIOWrapper name='/home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb' mode='rt' encoding='UTF-8'>
result = None

    def _parsePDB(pdb, **kwargs):
        title = kwargs.get('title', None)
        chain = ''
        if not os.path.isfile(pdb):
            pdb, chain = _getPDBid(pdb)
            if title is None:
                title = pdb
                kwargs['title'] = title
            filename = fetchPDB(pdb, **kwargs)
            if filename is None:
                try:
                    LOGGER.info("Trying to parse mmCIF file instead")
                    return parseMMCIF(pdb+chain, **kwargs)
                except:
                    try:
                        LOGGER.info("Trying to parse EMD file instead")
                        return parseEMD(pdb+chain, **kwargs)
                    except:
                        raise IOError('PDB file for {0} could not be downloaded.'
                                    .format(pdb))
            pdb = filename
        if title is None:
            title, ext = os.path.splitext(os.path.split(pdb)[1])
            if ext == '.gz':
                title, ext = os.path.splitext(title)
            if len(title) == 7 and title.startswith('pdb'):
                title = title[3:]
            kwargs['title'] = title
    
        stream = openFile(pdb, 'rt')
        if chain != '':
            kwargs['chain'] = chain
        result = parsePDBStream(stream, **kwargs)
        stream.close()
    
        if result is not None:
            return result
        else:
            try:
                LOGGER.warn("Trying to parse mmCIF file instead")
                return parseMMCIF(pdb, **kwargs)
            except:
                try:
                    LOGGER.warn("Trying to parse EMD file instead")
                    return parseEMD(pdb, **kwargs)
                except:
>                   raise IOError('PDB file for {0} could not be downloaded.'
                                  .format(pdb))
E                   OSError: PDB file for /home/runner/work/ProDy/ProDy/prody/tests/datafiles/pdb2k39_truncated.pdb could not be downloaded.

prody/proteins/pdbfile.py:248: OSError
------------------------------ Captured log call -------------------------------
WARNING  .prody:logger.py:141 WARNING Atomic data could not be parsed, please check the input file.
WARNING  .prody:logger.py:141 WARNING Trying to parse mmCIF file instead
WARNING  .prody:logger.py:141 WARNING Trying to parse EMD file instead
INFO     .prody:logger.py:123 As n_nodes is less than or equal to 0, no nodes will be made and the raw map will be returned
```