### PR TITLE
fix on parsing mmCIF from file

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -228,15 +228,14 @@ def _parsePDB(pdb, **kwargs):
             title = title[3:]
         kwargs['title'] = title
 
-    stream = openFile(pdb, 'rt')
-    if chain != '':
-        kwargs['chain'] = chain
-    result = parsePDBStream(stream, **kwargs)
-    stream.close()
-
-    if result is not None:
+    try:
+        stream = openFile(pdb, 'rt')
+        if chain != '':
+            kwargs['chain'] = chain
+        result = parsePDBStream(stream, **kwargs)
+        stream.close()
         return result
-    else:
+    except PDBParseError:
         try:
             LOGGER.warn("Trying to parse as mmCIF file instead")
             return parseMMCIF(pdb, **kwargs)


### PR DESCRIPTION
Without the fix, I get the following error:
```
$ ipython
Python 3.8.6 | packaged by conda-forge | (default, Nov 27 2020, 18:58:29) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.20.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ags = parsePDB(['3o21_CD.pdb', '../PBP_pdbs/mGluR/1ewt.cif'])
@> Retrieving ../PBP_pdbs/mGluR/1ewt.cif... [ 50%] 1s---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
~\code\ProDy\prody\proteins\pdbfile.py in _parsePDBLines(atomgroup, lines, split, model, chain, subset, altloc_torf, format, bonds)
    571                 if isPDB:
--> 572                     coordinates[acount, 0] = line[30:38]
    573                     coordinates[acount, 1] = line[38:46]

ValueError: could not convert string to float: '  ? 8.71'

During handling of the above exception, another exception occurred:

PDBParseError                             Traceback (most recent call last)
<ipython-input-2-fbbc59cb54ed> in <module>
----> 1 ags = parsePDB(['3o21_CD.pdb', '../PBP_pdbs/mGluR/1ewt.cif'])

~\code\ProDy\prody\proteins\pdbfile.py in parsePDB(*pdb, **kwargs)
    142             LOGGER.update(i, 'Retrieving {0}...'.format(p+c),
    143                           label='_prody_parsePDB')
--> 144             result = _parsePDB(p, **kwargs)
    145             if not isinstance(result, tuple):
    146                 if isinstance(result, dict):

~\code\ProDy\prody\proteins\pdbfile.py in _parsePDB(pdb, **kwargs)
    232     if chain != '':
    233         kwargs['chain'] = chain
--> 234     result = parsePDBStream(stream, **kwargs)
    235     stream.close()
    236

~\code\ProDy\prody\proteins\pdbfile.py in parsePDBStream(stream, **kwargs)
    323             hd, split = getHeaderDict(lines)
    324         bonds = [] if get_bonds else None
--> 325         _parsePDBLines(ag, lines, split, model, chain, subset, altloc, bonds=bonds)
    326         if bonds:
    327             try:

~\code\ProDy\prody\proteins\pdbfile.py in _parsePDBLines(atomgroup, lines, split, model, chain, subset, altloc_torf, format, bonds)
    592                             i += 1
    593                 else:
--> 594                     raise PDBParseError('invalid or missing coordinate(s) at '
    595                                          'line {0}'.format(i+1))
    596             if onlycoords:

PDBParseError: invalid or missing coordinate(s) at line 1379
```

With it, everything works:
```
$ ipython
Python 3.8.6 | packaged by conda-forge | (default, Nov 27 2020, 18:58:29) [MSC v.1916 64 bit (AMD64)]
Type 'copyright', 'credits' or 'license' for more information
IPython 7.20.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ags = parsePDB(['3o21_CD.pdb', '../PBP_pdbs/mGluR/1ewt.cif'])
@> Retrieving ../PBP_pdbs/mGluR/1ewt.cif... [ 50%] 1s@> WARNING Trying to parse as mmCIF file instead
@> 2 PDBs were parsed in 0.28s.

In [3]: ags
Out[3]: [<AtomGroup: 3o21_CD (6512 atoms)>, <AtomGroup: 1ewt (7282 atoms)>]
```