### PR TITLE
Resnum fix

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -646,7 +646,7 @@ def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
                 if not dec:
                     resnum = resnum_str
                     try:
-                        isnumeric = np.alltrue([x.isdigit() for x in resnum_str])
+                        isnumeric = np.alltrue([x.isdigit() or x==' ' for x in resnum_str])
                         if not isnumeric and resnum_str == resnum_str.upper():
                             resnum = hybrid36ToDec(resnum_str, resnum=True)
                         else:


### PR DESCRIPTION
Without this fix, we have some very strange residue numbers getting parsed from PDB files:

```
In [1]: from prody import *

In [2]: ag2 = parsePDB('test2.pdb')
@> WARNING parsed 5 digit residue number including numeric insertion code
@> 29 atoms and 1 coordinate set(s) were parsed in 0.00s.

In [3]: ag2.getResnums()
Out[3]:
array([   1572,    1572,    1572,   15720,   15720,   15720,   15721,
         15721,   15721,   15722,   15722,   15722,   15723,   15723,
         15723,   15724,   15724,   15724,   15725,   15725,   15725,
       -504547, -504546, -504545, -504544, -504543, -504542, -504541,
       -504540])
```

The file test2.pdb is the following (taken from pdb1tw7_step3_charmm2namd.pdb from the test files):
```
REMARK AtomMap (Selection 'resnum 1572') + (Selection 'resname CLA')
ATOM      1  OH2 TIP3 1572      23.223 -10.675 -28.085  1.00  0.00      SOLV    
ATOM      2  H1  TIP3 1572      22.652  -9.965 -27.716  1.00  0.00      SOLV    
ATOM      3  H2  TIP3 1572      23.899 -10.156 -28.571  1.00  0.00      SOLV    
ATOM      4  OH2 TIP3 15720     19.784  37.457  35.979  1.00  0.00      SOLV    
ATOM      5  H1  TIP3 15720     20.242  36.810  35.405  1.00  0.00      SOLV    
ATOM      6  H2  TIP3 15720     20.500  37.696  36.603  1.00  0.00      SOLV    
ATOM      7  OH2 TIP3 15721     24.605  38.040  38.574  1.00  0.00      SOLV    
ATOM      8  H1  TIP3 15721     24.866  37.167  38.906  1.00  0.00      SOLV    
ATOM      9  H2  TIP3 15721     24.212  38.461  39.371  1.00  0.00      SOLV    
ATOM     10  OH2 TIP3 15722     35.913  39.161  37.626  1.00  0.00      SOLV    
ATOM     11  H1  TIP3 15722     36.682  39.730  37.424  1.00  0.00      SOLV    
ATOM     12  H2  TIP3 15722     35.263  39.870  37.761  1.00  0.00      SOLV    
ATOM     13  OH2 TIP3 15723     35.377  37.126  39.414  1.00  0.00      SOLV    
ATOM     14  H1  TIP3 15723     34.405  37.185  39.295  1.00  0.00      SOLV    
ATOM     15  H2  TIP3 15723     35.675  37.922  38.926  1.00  0.00      SOLV    
ATOM     16  OH2 TIP3 15724     36.629  35.650  37.332  1.00  0.00      SOLV    
ATOM     17  H1  TIP3 15724     37.083  36.437  36.988  1.00  0.00      SOLV    
ATOM     18  H2  TIP3 15724     36.255  35.998  38.170  1.00  0.00      SOLV    
ATOM     19  OH2 TIP3 15725     38.627  37.478  35.957  1.00  0.00      SOLV    
ATOM     20  H1  TIP3 15725     39.147  36.847  35.419  1.00  0.00      SOLV    
ATOM     21  H2  TIP3 15725     39.267  37.753  36.626  1.00  0.00      SOLV    
ATOM     22  CLA CLA     1      -0.841 -10.575 -10.880  1.00  0.00       CLA    
ATOM     23  CLA CLA     2      34.760   4.272  -4.869  1.00  0.00       CLA    
ATOM     24  CLA CLA     3     -26.665 -14.732  -6.426  1.00  0.00       CLA    
ATOM     25  CLA CLA     4     -15.135   0.917  37.921  1.00  0.00       CLA    
ATOM     26  CLA CLA     5      -7.405 -29.082  20.129  1.00  0.00       CLA    
ATOM     27  CLA CLA     6       4.797   4.433 -23.354  1.00  0.00       CLA    
ATOM     28  CLA CLA     7      25.571 -21.402   9.795  1.00  0.00       CLA    
ATOM     29  CLA CLA     8      35.393  10.994   6.120  1.00  0.00       CLA    
TER

```

I tracked down that the problem was with having small residue numbers after big ones not being seen as numbers and triggering h36 format. With the fix, we get the following correct behaviour:
```
In [3]: ag2.getResnums()
Out[3]:
array([ 1572,  1572,  1572, 15720, 15720, 15720, 15721, 15721, 15721,
       15722, 15722, 15722, 15723, 15723, 15723, 15724, 15724, 15724,
       15725, 15725, 15725,     1,     2,     3,     4,     5,     6,
           7,     8])
```