### PR TITLE
add cme nonstdaa

### DIFF
--- a/prody/atomic/flags.py
+++ b/prody/atomic/flags.py
@@ -76,6 +76,7 @@ NONSTANDARD = {
     'HSE': set(['cyclic', 'basic', 'surface', 'large', 'polar']),
     'HSP': set(['cyclic', 'acidic', 'surface', 'large', 'polar']),
     'MSE': set(['acyclic', 'neutral', 'buried', 'large']),
+    'CME': set(['acyclic', 'neutral', 'buried', 'large']),
     'SEC': set(['acyclic', 'neutral', 'buried', 'polar', 'medium']),
     'SEP': set(['acyclic', 'surface', 'acidic', 'large', 'polar']),
     'TPO': set(['acyclic', 'surface', 'acidic', 'large', 'polar']),


### PR DESCRIPTION
As noted in #1427, CME should be in the non-standard amino acids. 