### PR TITLE
Iterable import fix for python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.9]
+        python-version: [2.7, 3.5, 3.9, 3.10]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.5, 3.9, 3.10]
+        python-version: [2.7, 3.5, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/prody/atomic/select.py
+++ b/prody/atomic/select.py
@@ -441,7 +441,11 @@ all alphanumeric characters."""
 
 import sys
 from re import compile as re_compile
-from collections import Iterable
+
+try:
+    from collections import Iterable
+except ImportError:
+    from collections.abc import Iterable
 
 import numpy as np
 from numpy import array, ndarray, ones, zeros, arange


### PR DESCRIPTION
This accounts for changes in python 3.10 as noted in https://github.com/conda-forge/prody-feedstock/pull/10