### PR TITLE
make it compatible with python 3.10

### DIFF
--- a/prody/atomic/select.py
+++ b/prody/atomic/select.py
@@ -441,7 +441,7 @@ all alphanumeric characters."""
 
 import sys
 from re import compile as re_compile
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 from numpy import array, ndarray, ones, zeros, arange

--- a/prody/atomic/select.py
+++ b/prody/atomic/select.py
@@ -441,7 +441,12 @@ all alphanumeric characters."""
 
 import sys
 from re import compile as re_compile
-from collections.abc import Iterable
+try:
+   # for upto python 3.9
+   from collections import Iterable
+except ImportError:
+   # for python 3.10
+   from collections.abc import Iterable
 
 import numpy as np
 from numpy import array, ndarray, ones, zeros, arange


### PR DESCRIPTION
In python 3.10, Iterable is now provided in collections.abc instead of collections