### PR TITLE
Reorder imports to avoid deprecation warning

### DIFF
--- a/prody/atomic/select.py
+++ b/prody/atomic/select.py
@@ -442,11 +442,11 @@ all alphanumeric characters."""
 import sys
 from re import compile as re_compile
 try:
-   # for upto python 3.9
-   from collections import Iterable
-except ImportError:
-   # for python 3.10
+   # for python>=3.3
    from collections.abc import Iterable
+except ImportError:
+   # for python<3.3
+   from collections import Iterable
 
 import numpy as np
 from numpy import array, ndarray, ones, zeros, arange


### PR DESCRIPTION
In `atomic/select.py`, importing `Iterable` from `collections` instead of `collections.abc` causes a `DeprecationWarning` in modern versions of python.  This commit avoids the warning by first trying to import from `collections.abc` before falling back on `collections`.

It'd probably be fine to remove the `collections` import altogether, since `collections.abc` has been present since python 3.3.  But in the interest of being conservative, I just changed the order in which the imports are tried.