### PR TITLE
parsePDB fix for local mmcif

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -228,13 +228,12 @@ def _parsePDB(pdb, **kwargs):
             title = title[3:]
         kwargs['title'] = title
 
-    stream = openFile(pdb, 'rt')
-    if chain != '':
-        kwargs['chain'] = chain
-    result = parsePDBStream(stream, **kwargs)
-    stream.close()
-
-    if result is not None:
+    if pdb.endswith('.pdb') or pdb.endswith('.pdb.gz'):
+        stream = openFile(pdb, 'rt')
+        if chain != '':
+            kwargs['chain'] = chain
+        result = parsePDBStream(stream, **kwargs)
+        stream.close()
         return result
     else:
         try:


### PR DESCRIPTION
Without the fix, I get the following error parsing 4ake.cif from a path:
```
Traceback (most recent call last):
  File "/home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages/prody/proteins/pdbfile.py", line 575, in _parsePDBLines
    coordinates[acount, 0] = line[30:38]
ValueError: could not convert string to float: '  ? -10.'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages/prody/proteins/pdbfile.py", line 124, in parsePDB
    return _parsePDB(pdb[0], **kwargs)
  File "/home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages/prody/proteins/pdbfile.py", line 234, in _parsePDB
    result = parsePDBStream(stream, **kwargs)
  File "/home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages/prody/proteins/pdbfile.py", line 325, in parsePDBStream
    _parsePDBLines(ag, lines, split, model, chain, subset, altloc, bonds=bonds)
  File "/home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages/prody/proteins/pdbfile.py", line 597, in _parsePDBLines
    raise PDBParseError('invalid or missing coordinate(s) at '
prody.proteins.pdbfile.PDBParseError: invalid or missing coordinate(s) at line 871
```