### PR TITLE
matchChains log fix

### DIFF
--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -622,26 +622,27 @@ def matchChains(atoms1, atoms2, **kwargs):
 
     matches = []
     unmatched = []
-    LOGGER.debug('Trying to match chains based on residue numbers and names:')
-    for simpch1 in chains1:
-        for simpch2 in chains2:
-            LOGGER.debug('  Comparing {0} (len={1}) and {2} (len={3}):'
-                         .format(simpch1.getTitle(), len(simpch1),
-                                 simpch2.getTitle(), len(simpch2)))
+    if not pwalign:
+        LOGGER.debug('Trying to match chains based on residue numbers and names:')
+        for simpch1 in chains1:
+            for simpch2 in chains2:
+                LOGGER.debug('  Comparing {0} (len={1}) and {2} (len={3}):'
+                            .format(simpch1.getTitle(), len(simpch1),
+                                    simpch2.getTitle(), len(simpch2)))
 
-            match1, match2, nmatches = getTrivialMatch(simpch1, simpch2)
-            _seqid = nmatches * 100 / min(len(simpch1), len(simpch2))
-            _cover = len(match2) * 100 / max(len(simpch1), len(simpch2))
+                match1, match2, nmatches = getTrivialMatch(simpch1, simpch2)
+                _seqid = nmatches * 100 / min(len(simpch1), len(simpch2))
+                _cover = len(match2) * 100 / max(len(simpch1), len(simpch2))
 
-            if _seqid >= seqid and _cover >= coverage:
-                LOGGER.debug('\tMatch: {0} residues match with {1:.0f}% '
-                             'sequence identity and {2:.0f}% overlap.'
-                             .format(len(match1), _seqid, _cover))
-                matches.append((match1, match2, _seqid, _cover, simpch1, simpch2))
-            else:
-                LOGGER.debug('\tFailed to match chains (seqid={0:.0f}%, '
-                             'overlap={1:.0f}%).'.format(_seqid, _cover))
-                unmatched.append((simpch1, simpch2))
+                if _seqid >= seqid and _cover >= coverage:
+                    LOGGER.debug('\tMatch: {0} residues match with {1:.0f}% '
+                                'sequence identity and {2:.0f}% overlap.'
+                                .format(len(match1), _seqid, _cover))
+                    matches.append((match1, match2, _seqid, _cover, simpch1, simpch2))
+                else:
+                    LOGGER.debug('\tFailed to match chains (seqid={0:.0f}%, '
+                                'overlap={1:.0f}%).'.format(_seqid, _cover))
+                    unmatched.append((simpch1, simpch2))
 
     if pwalign or (not matches and (pwalign is None or pwalign)):
         if pairwise2:

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -645,26 +645,27 @@ def matchChains(atoms1, atoms2, **kwargs):
 
     if pwalign or (not matches and (pwalign is None or pwalign)):
         if pairwise2:
-            LOGGER.debug('Trying to match chains based on {0} sequence '
-                         'alignment:'.format(ALIGNMENT_METHOD))
-            for simpch1, simpch2 in unmatched:
-                LOGGER.debug(' Comparing {0} (len={1}) and {2} '
-                             '(len={3}):'
-                             .format(simpch1.getTitle(), len(simpch1),
-                                     simpch2.getTitle(), len(simpch2)))
-                match1, match2, nmatches = getAlignedMatch(simpch1, simpch2)
-                _seqid = nmatches * 100 / min(len(simpch1), len(simpch2))
-                _cover = len(match2) * 100 / max(len(simpch1), len(simpch2))
-                if _seqid >= seqid and _cover >= coverage:
-                    LOGGER.debug('\tMatch: {0} residues match with {1:.0f}% '
-                                 'sequence identity and {2:.0f}% overlap.'
-                                 .format(len(match1), _seqid, _cover))
-                    matches.append((match1, match2, _seqid, _cover,
-                                    simpch1, simpch2))
-                else:
-                    LOGGER.debug('\tFailed to match chains (seqid={0:.0f}%, '
-                                 'overlap={1:.0f}%).'
-                                 .format(_seqid, _cover))
+            if unmatched:
+                LOGGER.debug('Trying to match chains based on {0} sequence '
+                            'alignment:'.format(ALIGNMENT_METHOD))
+                for simpch1, simpch2 in unmatched:
+                    LOGGER.debug(' Comparing {0} (len={1}) and {2} '
+                                '(len={3}):'
+                                .format(simpch1.getTitle(), len(simpch1),
+                                        simpch2.getTitle(), len(simpch2)))
+                    match1, match2, nmatches = getAlignedMatch(simpch1, simpch2)
+                    _seqid = nmatches * 100 / min(len(simpch1), len(simpch2))
+                    _cover = len(match2) * 100 / max(len(simpch1), len(simpch2))
+                    if _seqid >= seqid and _cover >= coverage:
+                        LOGGER.debug('\tMatch: {0} residues match with {1:.0f}% '
+                                    'sequence identity and {2:.0f}% overlap.'
+                                    .format(len(match1), _seqid, _cover))
+                        matches.append((match1, match2, _seqid, _cover,
+                                        simpch1, simpch2))
+                    else:
+                        LOGGER.debug('\tFailed to match chains (seqid={0:.0f}%, '
+                                    'overlap={1:.0f}%).'
+                                    .format(_seqid, _cover))
         else:
             LOGGER.warning('Pairwise alignment could not be performed.')
     if not matches:

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -622,7 +622,11 @@ def matchChains(atoms1, atoms2, **kwargs):
 
     matches = []
     unmatched = []
-    if not pwalign:
+    if pwalign:
+        for simpch1 in chains1:
+            for simpch2 in chains2:
+                unmatched.append((simpch1, simpch2))
+    else:
         LOGGER.debug('Trying to match chains based on residue numbers and names:')
         for simpch1 in chains1:
             for simpch2 in chains2:


### PR DESCRIPTION
As noted in #1464, matchChains has a last line of logging that doesn't make sense if the trival match works:
```
Python 3.8.12 | packaged by conda-forge | (default, Oct 12 2021, 21:57:06) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.30.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import prody

In [2]: p1 = prody.parsePDB('Runs/000002_ProtImportPdb/extra/4ake.cif')
@> WARNING Trying to parse as mmCIF file instead
@> 3459 atoms and 1 coordinate set(s) were parsed in 0.06s.

In [3]: p2 = prody.parsePDB('Runs/000039_ProtImportPdb/extra/1ake.cif')
@> WARNING Trying to parse as mmCIF file instead
@> 3804 atoms and 1 coordinate set(s) were parsed in 0.09s.

In [4]: cutoff = 90

In [5]: m = prody.matchChains(p1.protein, p2.protein, subset="all", overlap=cutoff, seqid=cutoff, pwalign=True)
@> Checking AtomGroup 4ake: 2 chains are identified
@> Checking AtomGroup 1ake: 2 chains are identified
@> Trying to match chains based on residue numbers and names:
@>   Comparing Chain A from 4ake (len=214) and Chain A from 1ake (len=214):
@>      Match: 214 residues match with 100% sequence identity and 100% overlap.
@>   Comparing Chain A from 4ake (len=214) and Chain B from 1ake (len=214):
@>      Match: 214 residues match with 100% sequence identity and 100% overlap.
@>   Comparing Chain B from 4ake (len=214) and Chain A from 1ake (len=214):
@>      Match: 214 residues match with 100% sequence identity and 100% overlap.
@>   Comparing Chain B from 4ake (len=214) and Chain B from 1ake (len=214):
@>      Match: 214 residues match with 100% sequence identity and 100% overlap.
@> Trying to match chains based on local sequence alignment:

In [6]: 
```

With this fix, it doesn't:
```
In [5]: m = prody.matchChains(p1.protein, p2.protein, subset="all", overlap=cutoff, seqid=cutoff, pwalign=True)
@> Checking AtomGroup 4ake: 2 chains are identified
@> Checking AtomGroup 1ake: 2 chains are identified
@> Trying to match chains based on residue numbers and names:
@>   Comparing Chain A from 4ake (len=214) and Chain A from 1ake (len=214):
@>      Match: 214 residues match with 100% sequence identity and 100% overlap.
@>   Comparing Chain A from 4ake (len=214) and Chain B from 1ake (len=214):
@>      Match: 214 residues match with 100% sequence identity and 100% overlap.
@>   Comparing Chain B from 4ake (len=214) and Chain A from 1ake (len=214):
@>      Match: 214 residues match with 100% sequence identity and 100% overlap.
@>   Comparing Chain B from 4ake (len=214) and Chain B from 1ake (len=214):
@>      Match: 214 residues match with 100% sequence identity and 100% overlap.

In [6]: 
```