### PR TITLE
parseMMCIF fix for atomnames with prime

### DIFF
--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -290,8 +290,8 @@ def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
         startswith = line.split()[fields['group_PDB']]
 
         atomname = line.split()[fields['auth_atom_id']]
-        if atomname.find('"') != -1:
-            atomname = atomname[1:4]
+        if atomname.startswith('"') and atomname.endswith('"'):
+            atomname = atomname[1:-1]
         resname = line.split()[fields['auth_comp_id']]
 
         if subset is not None:

--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -290,6 +290,8 @@ def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
         startswith = line.split()[fields['group_PDB']]
 
         atomname = line.split()[fields['auth_atom_id']]
+        if atomname.find('"') != -1:
+            atomname = atomname[1:4]
         resname = line.split()[fields['auth_comp_id']]
 
         if subset is not None:


### PR DESCRIPTION
Without this, the double quotes around atom names with primes in mmCIF files are included in the atom names:
```
Python 3.9.9 | packaged by conda-forge | (main, Dec 20 2021, 02:40:17) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.31.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ag = parseMMCIF('4v8r')
@> 128780 atoms and 1 coordinate set(s) were parsed in 2.50s.

In [3]: ag['VD'].getNames()
Out[3]: 
array(['PB', 'O1B', 'O2B', 'O3B', 'PA', 'O1A', 'O2A', 'O3A', '"O5\'"',
       '"C5\'"', '"C4\'"', '"O4\'"', '"C3\'"', '"O3\'"', '"C2\'"',
       '"O2\'"', '"C1\'"', 'N9', 'C8', 'N7', 'C5', 'C6', 'N6', 'N1', 'C2',
       'N3', 'C4'], dtype='<U6')
```

These then get transferred when writing to PDB and make the lines longer:
```
HETATM1f6f4  O3A ADP Bz4601     180.693 -58.120 -21.066  1.00148.50        VD O  
HETATM1f6f5 "O5'" ADP Bz4601     182.720 -58.776 -22.315  1.00146.40        VD O 
```

With the fix, this no longer happens:
```
In [3]: ag['VD'].getNames()
Out[3]: 
array(['PB', 'O1B', 'O2B', 'O3B', 'PA', 'O1A', 'O2A', 'O3A', "O5'", "C5'",
       "C4'", "O4'", "C3'", "O3'", "C2'", "O2'", "C1'", 'N9', 'C8', 'N7',
       'C5', 'C6', 'N6', 'N1', 'C2', 'N3', 'C4'], dtype='<U6')

In [4]: writePDB('4v8r_fix1', ag)
@> WARNING Indices are exceeding 99999 and hexadecimal format is being used for indices
Out[4]: '4v8r_fix1.pdb'
```

```
HETATM1f6f4  O3A ADP Bz4601     180.693 -58.120 -21.066  1.00148.50        VD O  
HETATM1f6f5  O5' ADP Bz4601     182.720 -58.776 -22.315  1.00146.40        VD O  
```

This is in line with the original PDB file 4aol, which contained part of the structure:
```
HETATM63902  O3A ADP A1551     102.408  -0.305 160.824  1.00 92.70           O  
HETATM63903  O5' ADP A1551     102.826  -1.114 163.128  1.00141.40           O 
```

```
In [5]: aol = parsePDB('4aol', compressed=False)
@> PDB file is found in working directory (4aol.pdb).
@> 64390 atoms and 1 coordinate set(s) were parsed in 0.78s.
@> Secondary structures were assigned to 5486 residues.

In [6]: list(aol.hetatm.getHierView())[0].getNames()
Out[6]: 
array(['PB', 'O1B', 'O2B', 'O3B', 'PA', 'O1A', 'O2A', 'O3A', "O5'", "C5'",
       "C4'", "O4'", "C3'", "O3'", "C2'", "O2'", "C1'", 'N9', 'C8', 'N7',
       'C5', 'C6', 'N6', 'N1', 'C2', 'N3', 'C4', 'BE', 'F1', 'F2', 'F3',
       'MG'], dtype='<U6')
```