### PR TITLE
Write pdb 2char chid

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -541,7 +541,7 @@ def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
         if startswith == 'ATOM' or startswith == 'HETATM':
             if isPDB:
                 atomname = line[12:16].strip()
-                resname = line[17:21].strip()
+                resname = line[17:20].strip()
             else:
                 atomname= fields[2]
                 resname = fields[3]
@@ -552,7 +552,7 @@ def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
                     continue
 
             if isPDB:
-                chid = line[21]
+                chid = line[20:22]
             else:
                 chid = fields[4]
 
@@ -1032,11 +1032,6 @@ def _evalAltlocs(atomgroup, altloc, chainids, resnums, resnames, atomnames):
                         'atomgroup {1}.'.format(repr(key), atomgroup.getTitle()))
             atomgroup.addCoordset(xyz, label='altloc ' + key)
 
-PDBLINE = ('{0:6s}{1:5d} {2:4s}{3:1s}'
-           '{4:4s}{5:1s}{6:4d}{7:1s}   '
-           '{8:8.3f}{9:8.3f}{10:8.3f}'
-           '{11:6.2f}{12:6.2f}      '
-           '{13:4s}{14:2s}\n')
 
 #HELIXLINE = ('HELIX  %3d %3s %-3s %1s %4d%1s %-3s %1s %4d%1s%2d'
 #             '                               %5d\n')
@@ -1050,51 +1045,51 @@ SHEETLINE = ('SHEET  {strand:3d} {sheetID:>3s}{numStrands:2d} '
              '{initResName:3s} {initChainID:1s}{initSeqNum:4d}{initICode:1s} '
              '{endResName:3s} {endChainID:1s}{endSeqNum:4d}{endICode:1s}{sense:2d} \n')
 
-PDBLINE_LT100K = ('%-6s%5d %-4s%1s%-4s%1s%4d%1s   '
+PDBLINE_LT100K = ('%-6s%5d %-4s%1s%-3s%2s%4d%1s   '
                   '%8.3f%8.3f%8.3f%6.2f%6.2f      '
                   '%4s%2s%2s\n')
 
 # Residue number
-PDBLINE_GE10K = ('%-6s%5d %-4s%1s%-4s%1s%4x%1s   '
+PDBLINE_GE10K = ('%-6s%5d %-4s%1s%-3s%2s%4x%1s   '
                  '%8.3f%8.3f%8.3f%6.2f%6.2f      '
                  '%4s%2s%2s\n')
 
 # Serial number
-PDBLINE_GE100K = ('%-6s%5x %-4s%1s%-4s%1s%4d%1s   '
+PDBLINE_GE100K = ('%-6s%5x %-4s%1s%-3s%2s%4d%1s   '
                   '%8.3f%8.3f%8.3f%6.2f%6.2f      '
                   '%4s%2s%2s\n')
 
 # Both
-PDBLINE_GE100K_GE10K = ('%-6s%5x %-4s%1s%-4s%1s%4x%1s   '
+PDBLINE_GE100K_GE10K = ('%-6s%5x %-4s%1s%-3s%2s%4x%1s   '
                         '%8.3f%8.3f%8.3f%6.2f%6.2f      '
                         '%4s%2s%2s\n')
 
 # All cases
-PDBLINE_H36 = ('%-6s%5s %-4s%1s%-4s%1s%4s%1s   '
+PDBLINE_H36 = ('%-6s%5s %-4s%1s%-3s%2s%4s%1s   '
                '%8.3f%8.3f%8.3f%6.2f%6.2f      '
                '%4s%2s%2s\n')
 
-ANISOULINE_LT100K = ('%-6s%5d %-4s%1s%-4s%1s%4d%1s '
+ANISOULINE_LT100K = ('%-6s%5d %-4s%1s%-3s%2s%4d%1s '
                      '%7d%7d%7d%7d%7d%7d  '
                      '%4s%2s%2s\n')
 
 # Residue number
-ANISOULINE_GE10K = ('%-6s%5d %-4s%1s%-4s%1s%4x%1s '
+ANISOULINE_GE10K = ('%-6s%5d %-4s%1s%-3s%2s%4x%1s '
                     '%7d%7d%7d%7d%7d%7d  '
                     '%4s%2s%2s\n')
 
 # Serial number
-ANISOULINE_GE100K = ('%-6s%5x %-4s%1s%-4s%1s%4d%1s '
+ANISOULINE_GE100K = ('%-6s%5x %-4s%1s%-3s%2s%4d%1s '
                      '%7d%7d%7d%7d%7d%7d  '
                      '%4s%2s%2s\n')
 
 # Both
-ANISOULINE_GE100K_GE10K = ('%-6s%5x %-4s%1s%-4s%1s%4x%1s '
+ANISOULINE_GE100K_GE10K = ('%-6s%5x %-4s%1s%-3s%2s%4x%1s '
                            '%7d%7d%7d%7d%7d%7d  '
                            '%4s%2s%2s\n')
 
 # All cases
-ANISOULINE_H36 = ('%-6s%5s %-4s%1s%-4s%1s%4s%1s '
+ANISOULINE_H36 = ('%-6s%5s %-4s%1s%-3s%2s%4s%1s '
                   '%7d%7d%7d%7d%7d%7d  '
                   '%4s%2s%2s\n')
 

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -552,7 +552,7 @@ def _parsePDBLines(atomgroup, lines, split, model, chain, subset,
                     continue
 
             if isPDB:
-                chid = line[20:22]
+                chid = line[20:22].strip()
             else:
                 chid = fields[4]
 


### PR DESCRIPTION
This repartitions resnames and chainids to be 3 and 2 characters rather than 4 and 1. Thus 2-char chainids don't overflow.

Otherwise, we get lines that are too long and can't be parsed:
```
Python 3.9.9 | packaged by conda-forge | (main, Dec 20 2021, 02:40:17) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.31.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ag = parseMMCIF('4v8r')
@> 128780 atoms and 1 coordinate set(s) were parsed in 2.15s.

In [3]: ag.getChids()
Out[3]: array(['AA', 'AA', 'AA', ..., 'Bz', 'Bz', 'Bz'], dtype='<U2')

In [4]: writePDB('4v8r', ag)
@> WARNING Indices are exceeding 99999 and hexadecimal format is being used for indices
Out[4]: '4v8r.pdb'

In [5]: ag2 = parsePDB('4v8r.pdb')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
/mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py in _parsePDBLines(atomgroup, lines, split, model, chain, subset, altloc_torf, format, bonds)
    574                     coordinates[acount, 0] = line[30:38]
--> 575                     coordinates[acount, 1] = line[38:46]
    576                     coordinates[acount, 2] = line[46:54]

ValueError: could not convert string to float: '8  15.29'

During handling of the above exception, another exception occurred:

PDBParseError                             Traceback (most recent call last)
<ipython-input-5-f4a604db14a0> in <module>
----> 1 ag2 = parsePDB('4v8r.pdb')

/mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py in parsePDB(*pdb, **kwargs)
    122 
    123     if n_pdb == 1:
--> 124         return _parsePDB(pdb[0], **kwargs)
    125     else:
    126         results = []

/mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py in _parsePDB(pdb, **kwargs)
    233         if chain != '':
    234             kwargs['chain'] = chain
--> 235         result = parsePDBStream(stream, **kwargs)
    236         stream.close()
    237         return result

/mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py in parsePDBStream(stream, **kwargs)
    322             hd, split = getHeaderDict(lines)
    323         bonds = [] if get_bonds else None
--> 324         _parsePDBLines(ag, lines, split, model, chain, subset, altloc, bonds=bonds)
    325         if bonds:
    326             try:

/mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py in _parsePDBLines(atomgroup, lines, split, model, chain, subset, altloc_torf, format, bonds)
    594                             i += 1
    595                 else:
--> 596                     raise PDBParseError('invalid or missing coordinate(s) at '
    597                                          'line {0}'.format(i+1))
    598             if onlycoords:

PDBParseError: invalid or missing coordinate(s) at line 2
```

Comparing an ATOM line from this file to the original one 4aol, we can see that many fields are shifted:
```
ATOM      1  N   PHE AA   5     131.128  15.297 139.774  1.00150.60         A N  
```
```
ATOM      1  N   PHE A   5     131.128  15.297 139.774  1.00150.60           N  
```

With the fix, we compress the 2-char chainid onto the resname and everything is fine again:
```
Python 3.9.9 | packaged by conda-forge | (main, Dec 20 2021, 02:40:17) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.31.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ag = parseMMCIF('4v8r')
@> 128780 atoms and 1 coordinate set(s) were parsed in 2.05s.

In [3]: ag.getResnames()
Out[3]: array(['PHE', 'PHE', 'PHE', ..., 'BEF', 'BEF', 'MG'], dtype='<U6')

In [4]: ag.getChids()
Out[4]: array(['AA', 'AA', 'AA', ..., 'Bz', 'Bz', 'Bz'], dtype='<U2')

In [5]: writePDB('4v8r_fix2', ag)
@> WARNING Indices are exceeding 99999 and hexadecimal format is being used for indices
Out[5]: '4v8r_fix2.pdb'

In [6]: ag2 = parsePDB('4v8r_fix2.pdb')
@> 128492 atoms and 1 coordinate set(s) were parsed in 1.62s.

In [7]: ag2.getResnames()
Out[7]: array(['PHE', 'PHE', 'PHE', ..., 'BEF', 'BEF', 'MG'], dtype='<U6')

In [8]: ag2.getChids()
Out[8]: array(['AA', 'AA', 'AA', ..., 'Bz', 'Bz', 'Bz'], dtype='<U2')
```

There are a different number of atoms parsed because the atoms with primes in their names were written wrong and couldn't be parsed (see #1469 where this is fixed). 

I also confirmed this works on regular PDB files with single character chain ids including 3h5v with ANISOU lines. Parsing by chain id also works fine:
```
In [1]: from prody import *

In [2]: akeA = parsePDB('4akeA', compressed=False, altloc='all')
@> PDB file is found in working directory (4ake.pdb).
@> 1728 atoms and 1 coordinate set(s) were parsed in 0.03s.
@> Secondary structures were assigned to 139 residues.

In [3]: akeA
Out[3]: <AtomGroup: 4akeA (1728 atoms)>

In [4]: ake = parsePDB('4ake', compressed=False, altloc='all')
@> PDB file is found in working directory (4ake.pdb).
@> 3459 atoms and 1 coordinate set(s) were parsed in 0.04s.
@> Secondary structures were assigned to 279 residues.

In [5]: ake.getChids()
Out[5]: array(['A', 'A', 'A', ..., 'B', 'B', 'B'], dtype='<U2')

In [6]: akeA.getChids()
Out[6]: array(['A', 'A', 'A', ..., 'A', 'A', 'A'], dtype='<U2')
```