### PR TITLE
fix fetchPfamMSA and searchPfam with request verify False

### DIFF
--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -58,6 +58,8 @@ def searchPfam(query, **kwargs):
     chain identifier.  UniProt ID of the specified chain, or the first
     protein chain will be used for searching the Pfam database."""
 
+    import requests
+
     if isfile(query):
         from prody.sequence import MSAFile
         try:
@@ -203,14 +205,19 @@ def searchPfam(query, **kwargs):
 
     LOGGER.debug('Retrieving Pfam search results: ' + url)
     xml = None
+    sleep = 2
     while LOGGER.timing('_pfam') < timeout:
         try:
-            xml = openURL(url, timeout=timeout).read()
+            # xml = openURL(url, timeout=timeout).read()
+            xml = requests.get(url, verify=False).content
         except Exception:
             pass
         else:
             if xml not in ['PEND','RUN']:
                 break
+        
+        sleep = 20 if int(sleep * 1.5) >= 20 else int(sleep * 1.5)
+        LOGGER.sleep(int(sleep), '. Trying to reconnect...')
 
     if not xml:
         raise IOError('Pfam search timed out or failed to parse results '

--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -23,7 +23,6 @@ else:
     import urllib
     import urllib2
 
-import requests
 
 __all__ = ['searchPfam', 'fetchPfamMSA', 'parsePfamPDBs']
 
@@ -329,6 +328,8 @@ def fetchPfamMSA(acc, alignment='full', compressed=False, **kwargs):
     :arg outname: out filename, default is input ``'acc_alignment.format'``
 
     :arg folder: output folder, default is ``'.'``"""
+    
+    import requests
 
     # url = prefix + 'family/acc?id=' + acc
     # handle = openURL(url, timeout=int(kwargs.get('timeout', 60)))


### PR DESCRIPTION
Fixes #1444 and #1472 

Without the fix, I get the following error:
```
Python 3.8.12 | packaged by conda-forge | (default, Oct 12 2021, 21:57:06) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.30.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: fasta_file = fetchPfamMSA('PF00186', timeout=1000)
---------------------------------------------------------------------------
SSLCertVerificationError                  Traceback (most recent call last)
~/anaconda3/envs/scipion3/lib/python3.8/urllib/request.py in do_open(self, http_class, req, **http_conn_args)
   1353             try:
-> 1354                 h.request(req.get_method(), req.selector, req.data, headers,
   1355                           encode_chunked=req.has_header('Transfer-encoding'))

~/anaconda3/envs/scipion3/lib/python3.8/http/client.py in request(self, method, url, body, headers, encode_chunked)
   1255         """Send a complete request to the server."""
-> 1256         self._send_request(method, url, body, headers, encode_chunked)
   1257 

~/anaconda3/envs/scipion3/lib/python3.8/http/client.py in _send_request(self, method, url, body, headers, encode_chunked)
   1301             body = _encode(body, 'body')
-> 1302         self.endheaders(body, encode_chunked=encode_chunked)
   1303 

~/anaconda3/envs/scipion3/lib/python3.8/http/client.py in endheaders(self, message_body, encode_chunked)
   1250             raise CannotSendHeader()
-> 1251         self._send_output(message_body, encode_chunked=encode_chunked)
   1252 

~/anaconda3/envs/scipion3/lib/python3.8/http/client.py in _send_output(self, message_body, encode_chunked)
   1010         del self._buffer[:]
-> 1011         self.send(msg)
   1012 

~/anaconda3/envs/scipion3/lib/python3.8/http/client.py in send(self, data)
    950             if self.auto_open:
--> 951                 self.connect()
    952             else:

~/anaconda3/envs/scipion3/lib/python3.8/http/client.py in connect(self)
   1424 
-> 1425             self.sock = self._context.wrap_socket(self.sock,
   1426                                                   server_hostname=server_hostname)

~/anaconda3/envs/scipion3/lib/python3.8/ssl.py in wrap_socket(self, sock, server_side, do_handshake_on_connect, suppress_ragged_eofs, server_hostname, session)
    499         # ctx._wrap_socket()
--> 500         return self.sslsocket_class._create(
    501             sock=sock,

~/anaconda3/envs/scipion3/lib/python3.8/ssl.py in _create(cls, sock, server_side, do_handshake_on_connect, suppress_ragged_eofs, server_hostname, context, session)
   1039                         raise ValueError("do_handshake_on_connect should not be specified for non-blocking sockets")
-> 1040                     self.do_handshake()
   1041             except (OSError, ValueError):

~/anaconda3/envs/scipion3/lib/python3.8/ssl.py in do_handshake(self, block)
   1308                 self.settimeout(None)
-> 1309             self._sslobj.do_handshake()
   1310         finally:

SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1131)

During handling of the above exception, another exception occurred:

URLError                                  Traceback (most recent call last)
/mnt/c/Users/james/code/ProDy/prody/utilities/pathtools.py in openURL(url, timeout, **kwargs)
    407     try:
--> 408         return urlopen(request, timeout=int(timeout))
    409     except URLError:

~/anaconda3/envs/scipion3/lib/python3.8/urllib/request.py in urlopen(url, data, timeout, cafile, capath, cadefault, context)
    221         opener = _opener
--> 222     return opener.open(url, data, timeout)
    223 

~/anaconda3/envs/scipion3/lib/python3.8/urllib/request.py in open(self, fullurl, data, timeout)
    524         sys.audit('urllib.Request', req.full_url, req.data, req.headers, req.get_method())
--> 525         response = self._open(req, data)
    526 

~/anaconda3/envs/scipion3/lib/python3.8/urllib/request.py in _open(self, req, data)
    541         protocol = req.type
--> 542         result = self._call_chain(self.handle_open, protocol, protocol +
    543                                   '_open', req)

~/anaconda3/envs/scipion3/lib/python3.8/urllib/request.py in _call_chain(self, chain, kind, meth_name, *args)
    501             func = getattr(handler, meth_name)
--> 502             result = func(*args)
    503             if result is not None:

~/anaconda3/envs/scipion3/lib/python3.8/urllib/request.py in https_open(self, req)
   1396         def https_open(self, req):
-> 1397             return self.do_open(http.client.HTTPSConnection, req,
   1398                 context=self._context, check_hostname=self._check_hostname)

~/anaconda3/envs/scipion3/lib/python3.8/urllib/request.py in do_open(self, http_class, req, **http_conn_args)
   1356             except OSError as err: # timeout error
-> 1357                 raise URLError(err)
   1358             r = h.getresponse()

URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1131)>

During handling of the above exception, another exception occurred:

OSError                                   Traceback (most recent call last)
<ipython-input-2-488741d1815c> in <module>
----> 1 fasta_file = fetchPfamMSA('PF00186', timeout=1000)

/mnt/c/Users/james/code/ProDy/prody/database/pfam.py in fetchPfamMSA(acc, alignment, compressed, **kwargs)
    330 
    331     url = prefix + 'family/acc?id=' + acc
--> 332     handle = openURL(url, timeout=int(kwargs.get('timeout', 60)))
    333     orig_acc = acc
    334     acc = handle.readline().strip()

/mnt/c/Users/james/code/ProDy/prody/utilities/pathtools.py in openURL(url, timeout, **kwargs)
    408         return urlopen(request, timeout=int(timeout))
    409     except URLError:
--> 410         raise IOError('{0} could not be opened for reading, invalid URL or '
    411                       'no internet connection'.format(repr(request)))
    412 

OSError: 'https://pfam.xfam.org/family/acc?id=PF00186' could not be opened for reading, invalid URL or no internet connection
```

With the fix, everything works:
```
In [2]: fasta_file = fetchPfamMSA('PF00186', timeout=1000)
/home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages/urllib3/connectionpool.py:1043: InsecureRequestWarning: Unverified HTTPS request is being made to host 'pfam.xfam.org'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
  warnings.warn(
@> Pfam MSA for PF00186 is written as PF00186_full.slx.
```

This fix uses `request.get(url, verify=False)` to get around the new need for SSL verification for pfam.