### PR TITLE
update align app usage for matching pair

### DIFF
--- a/prody/apps/prody_apps/prody_align.py
+++ b/prody/apps/prody_apps/prody_align.py
@@ -119,7 +119,7 @@ def addCommand(commands):
     subparser.set_defaults(usage_example=
     """Align models in a PDB structure or multiple PDB structures and save \
 aligned coordinate sets.  When multiple structures are aligned, ProDy will \
-match chains based on sequence alignment and use best match for aligning the \
+match chains based on sequence alignment and use best matching pair for aligning the \
 structures.
 
 Fetch PDB structure 2k39 and align models (reference model is the first model):


### PR DESCRIPTION
Maybe this is still too subtle, but it should be noted that the align app does something much less sophisticated than users might expect. It just aligns over the single pair of chains that ranks best from matchChains. 

We may also want to update or replace the matchAlign function it uses or provide some kind of option. This probably isn't necessary though. 