### PR TITLE
Simple chain fix for non-protein residues

### DIFF
--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -336,7 +336,7 @@ class SimpleChain(object):
             aa = AAMAP.get(res.getResname(), 'X')
             if aa == '-':
                 aa = 'X'
-            if aa == 'X':
+            if aa == 'X' and res.getResname() != 'HOH':
                 LOGGER.warn("no one-letter mapping found for %s " % repr(res))
             if not res.getResname() in protein_resnames:
                 continue

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -338,6 +338,8 @@ class SimpleChain(object):
                 aa = 'X'
             if aa == 'X':
                 LOGGER.warn("no one-letter mapping found for %s " % repr(res))
+            if not res.getResname() in protein_resnames:
+                continue
             simpres = SimpleResidue(self, i, resid, aa, incod, res)
             if gaps:
                 diff = resid - temp - 1


### PR DESCRIPTION
Fixes #1483 

This was broken by #1410.

With the fix, we restore the creation of SimpleChain objects that only include protein residues as in ProDy 2.0 and earlier, but also keeps the warnings about other residues besides waters, which are too much.

We now recover the expected behaviour:
```
In [1]: from prody import *
   ...: 
   ...: ref_prot = prody.parsePDB("5RS7")
   ...: ref_prot = ref_prot.select("chain A")
   ...: prot = prody.parsePDB("5RVP")
   ...: res = "1SQ"
   ...: hv = prot.getHierView()
@> PDB file is found in working directory (5rs7.pdb.gz).
@> 5540 atoms and 1 coordinate set(s) were parsed in 0.06s.
@> Secondary structures were assigned to 232 residues.
@> PDB file is found in working directory (5rvp.pdb.gz).
@> 2870 atoms and 1 coordinate set(s) were parsed in 0.03s.
@> Secondary structures were assigned to 118 residues.

In [2]: prot = list(hv)[0]

In [3]: x = prody.matchChains(prot, ref_prot)
@> WARNING no one-letter mapping found for <Residue: 1SQ 201 from Chain A from 5RVP (19 atoms)> 
@> Checking AtomGroup 5RVP: 1 chains are identified
@> WARNING no one-letter mapping found for <Residue: W4Y 201 from Chain A from 5RS7 (32 atoms)> 
@> Checking AtomGroup 5RS7: 1 chains are identified
@> Trying to match chains based on residue numbers and names:
@>   Comparing Chain A from 5RVP (len=168) and Chain A from 5RS7 (len=167):
@>      Match: 167 residues match with 100% sequence identity and 99% overlap.

In [4]: x
Out[4]: 
[(<AtomMap: Chain A from 5RVP -> Chain A from 5RS7 from 5RVP (167 atoms)>,
  <AtomMap: Chain A from 5RS7 -> Chain A from 5RVP from 5RS7 (167 atoms)>,
  100.0,
  99.4047619047619)]
```