### PR TITLE
writePDB secstr

### DIFF
--- a/prody/proteins/header.py
+++ b/prody/proteins/header.py
@@ -470,8 +470,8 @@ def _getSheet(lines):
     for i, line in lines['SHEET ']:
         try:
             chid = line[21]
-            value = (int(line[38:40]), int(line[7:10]),
-                     line[11:14].strip())
+                     # sense           # strand num     # sheet id
+            value = (int(line[38:40]), int(line[7:10]), line[11:14].strip())
         except:
             continue
 


### PR DESCRIPTION
With this change, ProDy can now write secondary structure information into PDB files that ProDy can then read back. We are still missing the last part of the SHEET lines about hydrogen bonding between strands, but this can come later.

The output lines otherwise match the lines from the original PDB file and can be used for assigning secondary structures and using them in RTB. 