### PR TITLE
calcColl mode arg types

### DIFF
--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -36,7 +36,8 @@ def calcCollectivity(mode, masses=None, is3d=None):
        spin relaxation. *J Chem Phys* **1995** 102:3396-3403.
 
     :arg mode: mode(s) or vector(s)
-    :type mode: :class:`.Mode`, :class:`.Vector`, :class:`.ModeSet`
+    :type mode: :class:`.Mode`, :class:`.Vector`, :class:`.ModeSet`,
+        :class:`.NMA`, :class:`~numpy.ndarray`
 
     :arg masses: atomic masses
     :type masses: :class:`numpy.ndarray`


### PR DESCRIPTION
It can of course take NMA objects. Also ndarrays