### PR TITLE
Extend ClustENM kwargs for more functionality

### DIFF
--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -478,7 +478,8 @@ class ClustENM(Ensemble):
     def _buildANM(self, cg):
 
         anm = ANM()
-        anm.buildHessian(cg, cutoff=self._cutoff, gamma=self._gamma)
+        anm.buildHessian(cg, cutoff=self._cutoff, gamma=self._gamma,
+                         sparse=self._sparse, kdtree=self._kdtree)
 
         return anm
 
@@ -513,7 +514,7 @@ class ClustENM(Ensemble):
         if not self._checkANM(anm_cg):
             return None
 
-        anm_cg.calcModes(self._n_modes)
+        anm_cg.calcModes(self._n_modes, turbo=self._turbo)
 
         anm_ex = self._extendModel(anm_cg, cg, tmp)
         ens_ex = sampleModes(anm_ex, atoms=tmp,
@@ -980,6 +981,12 @@ class ClustENM(Ensemble):
         self._cutoff = cutoff
         self._n_modes = n_modes
         self._gamma = gamma
+        self._sparse = kwargs.get('sparse', False)
+        self._kdtree = kwargs.get('kdtree', False)
+        self._turbo = kwargs.get('turbo', False)
+        if kwargs.get('zeros', False):
+            LOGGER.warn('ClustENM cannot use zero modes so ignoring this kwarg')
+
         self._n_confs = n_confs
         self._rmsd = (0.,) + rmsd if isinstance(rmsd, tuple) else (0.,) + (rmsd,) * n_gens
         self._n_gens = n_gens

--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -988,11 +988,11 @@ class ClustENM(Ensemble):
         :type platform: str
 
         :arg parallel: If it is True (default is False), conformer generation will be parallelized.
-            This can also be set to a number for how many simulations are run in parallel.
+            This can also be set to a number for how many CPUs are used in parallel conformer generation.
             Setting 0 or True means run as many as there are CPUs on the machine.
         :type parallel: bool
 
-        :arg threads: Number of threads to use for an individual simulation
+        :arg threads: Number of threads to use for an individual simulation using the thread setting from OpenMM
             Default of 0 uses all CPUs on the machine.
         :type threads: int
         '''

--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -530,7 +530,12 @@ class ClustENM(Ensemble):
 
         if self._targeted:
             if self._parallel:
-                with Pool(cpu_count()) as p:
+                if isinstance(self._parallel, int):
+                    repeats = self._parallel
+                elif isinstance(self._parallel, bool):
+                    repeats = cpu_count()
+
+                with Pool(repeats) as p:
                     pot_conf = p.map(self._multi_targeted_sim,
                                      [(conf, coords) for coords in coordsets])
             else:
@@ -614,7 +619,12 @@ class ClustENM(Ensemble):
         sample_method = self._sample_v1 if self._v1 else self._sample
 
         if self._parallel:
-            with Pool(cpu_count()) as p:
+            if isinstance(self._parallel, int):
+                repeats = self._parallel
+            elif isinstance(self._parallel, bool):
+                repeats = cpu_count()
+
+            with Pool(repeats) as p:
                 tmp = p.map(sample_method, [conf for conf in confs])
         else:
             tmp = [sample_method(conf) for conf in confs]
@@ -978,6 +988,8 @@ class ClustENM(Ensemble):
         :type platform: str
 
         :arg parallel: If it is True (default is False), conformer generation will be parallelized.
+            This can also be set to a number for how many simulations are run in parallel.
+            Setting 0 or True means run as many as there are CPUs on the machine.
         :type parallel: bool
 
         :arg threads: Number of threads to use for an individual simulation
@@ -1002,7 +1014,18 @@ class ClustENM(Ensemble):
         self._rmsd = (0.,) + rmsd if isinstance(rmsd, tuple) else (0.,) + (rmsd,) * n_gens
         self._n_gens = n_gens
         self._platform = kwargs.pop('platform', None)
+
         self._parallel = kwargs.pop('parallel', False)
+        if not isinstance(self._parallel, (int, bool)):
+            raise TypeError('parallel should be an int or bool')
+
+        if self._parallel == 1:
+            # this is equivalent to not actually being parallel
+            self._parallel = False
+        elif self._parallel == 0:
+            # this is a deliberate choice and is documented
+            self._parallel = True
+
         self._threads = kwargs.pop('threads', 0)
         self._targeted = kwargs.pop('targeted', False)
         self._tmdk = kwargs.pop('tmdk', 15.)

--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -291,6 +291,12 @@ class ClustENM(Ensemble):
             properties = {'Precision': 'single'}
         elif self._platform in ['CUDA', 'OpenCL']:
             properties = {'Precision': 'single'}
+        elif self._platform == 'CPU':
+            if self._threads == 0:
+                cpus = cpu_count()
+            else:
+                cpus = self._threads
+            properties = {'Threads': str(cpus)}
 
         simulation = Simulation(modeller.topology, system, integrator,
                                 platform, properties)
@@ -968,10 +974,15 @@ class ClustENM(Ensemble):
         :arg platform: Architecture on which the OpenMM part runs, default is None.
             It can be chosen as 'CUDA', 'OpenCL' or 'CPU'.
             For efficiency, 'CUDA' or 'OpenCL' is recommended.
+            'CPU' is needed for setting threads per simulation.
         :type platform: str
 
         :arg parallel: If it is True (default is False), conformer generation will be parallelized.
         :type parallel: bool
+
+        :arg threads: Number of threads to use for an individual simulation
+            Default of 0 uses all CPUs on the machine.
+        :type threads: int
         '''
 
         if self._isBuilt():
@@ -992,6 +1003,7 @@ class ClustENM(Ensemble):
         self._n_gens = n_gens
         self._platform = kwargs.pop('platform', None)
         self._parallel = kwargs.pop('parallel', False)
+        self._threads = kwargs.pop('threads', 0)
         self._targeted = kwargs.pop('targeted', False)
         self._tmdk = kwargs.pop('tmdk', 15.)
 


### PR DESCRIPTION
Here are some suggested improvement for ClustENM that are helpful for Scipion. 

- Add more kwargs for ANM options to include sparse and kdtree for buildHessian and turbo for calcModes
- Add threads kwarg to control number of threads per simulation. This requires the CPU platform and that has been documented.
- Extend parallel kwarg to allow the user to set the number of parallel simulations to be run at a time. Setting just 1 simulation in parallel sets parallel to False and setting 0 sets it to True to use all CPUs as previously. Original True and False options are still accepted too. 