### PR TITLE
Cif header

### DIFF
--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -409,8 +409,9 @@ def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
     anisou = None
     siguij = None
     try:
-        anisou_data = data = parseSTARSection(lines, "_atom_site_anisotrop")
-    except ValueError:
+        data = parseSTARSection(lines, "_atom_site_anisotrop")
+        x = data[0] # check if data has anything in it
+    except IndexError:
         LOGGER.warn("No anisotropic B factors found")
     else:
         anisou = np.zeros((acount, 6),

--- a/prody/proteins/starfile.py
+++ b/prody/proteins/starfile.py
@@ -1077,6 +1077,7 @@ def parseSTARSection(lines, key):
         else:
             data = [loop_dict["data"]]
     else:
-        raise ValueError("Could not find {0} in lines.".format(key))
+        LOGGER.warn("Could not find {0} in lines.".format(key))
+        return []
 
     return data


### PR DESCRIPTION
fixes #1530 

By using parseSTARSection, we can now handle chemicals as data blocks instead of loops. 

It can also now handle keys that aren't actually present such as carbohydrates and return and empty list. _parseMMCIFLines has been adjusted to cope with that.