### PR TITLE
Fix typo in 'calcAnisousFromModel()'

### DIFF
--- a/prody/dynamics/analysis.py
+++ b/prody/dynamics/analysis.py
@@ -677,7 +677,7 @@ def calcHitTime(model, method='standard'):
 
 
 def calcAnisousFromModel(model, ):
-    """Returns a 3Nx6 matrix containing anisotropic B factors (ANISOU lines)
+    """Returns a Nx6 matrix containing anisotropic B factors (ANISOU lines)
     from a covariance matrix calculated from **model**.
 
     :arg model: 3D model from which to calculate covariance matrix


### PR DESCRIPTION
The docstring of 'calcAnisousFromModel()' states that a 3Nx6 matrix is returned, but in reality a Nx6 matrix is returned, since there a 6 different `U` values for each atom.