### PR TITLE
fixes related to failing tests

### DIFF
--- a/prody/apps/prody_apps/prody_pca.py
+++ b/prody/apps/prody_apps/prody_pca.py
@@ -60,7 +60,7 @@ def prody_pca(coords, **kwargs):
             if splitext(pdb)[1].lower() == '.psf':
                 pdb = prody.parsePSF(pdb)
             else:
-                pdb = prody.parsePDB(pdb, altlocs=altlocs)
+                pdb = prody.parsePDB(pdb, altloc=altloc)
         dcd = prody.DCDFile(coords)
         if prefix == '_pca' or prefix == '_eda':
             prefix = dcd.getTitle() + prefix

--- a/prody/tests/atomic/test_atomic.py
+++ b/prody/tests/atomic/test_atomic.py
@@ -88,6 +88,8 @@ class TestPickling(unittest.TestCase):
         s1 = atoms1.__getstate__()
         s2 = atoms2.__getstate__()
         for key in s1:
+            if key == '_hv':
+                continue # new objects are created by __getstate__
             assert_equal(s1[key], s2[key])
         self.assertEqual(atoms1, atoms2)
 


### PR DESCRIPTION
Two things to fix:

- [x] pca app handled altlocs wrong by having an extra s that is now removed.
- [x] the atomic pickling test failed because there wasn't a HierView to pickle and instead new instances were created by __get_state__ calling getHierView independently for each atomic object, which were therefore not equal

Without the fixes, these are the problems:
```
======================================================================
ERROR: testPCACommandDCD (prody.tests.apps.test_prody_pca.TestPCACommand)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/c/Users/james/code/ProDy/prody/tests/apps/test_prody_pca.py", line 55, in testPCACommandDCD
    namespace.func(namespace)
  File "/mnt/c/Users/james/code/ProDy/prody/apps/prody_apps/prody_pca.py", line 345, in <lambda>
    subparser.set_defaults(func=lambda ns: prody_pca(ns.dcd, **ns.__dict__))
  File "/mnt/c/Users/james/code/ProDy/prody/apps/prody_apps/prody_pca.py", line 63, in prody_pca
    pdb = prody.parsePDB(pdb, altlocs=altlocs)
NameError: name 'altlocs' is not defined

======================================================================
FAIL: testAtomGroup (prody.tests.atomic.test_atomic.TestPickling)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/mnt/c/Users/james/code/ProDy/prody/tests/atomic/test_atomic.py", line 91, in testAtomGroup
    assert_equal(s1[key], s2[key])
  File "/home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages/numpy/testing/_private/utils.py", line 428, in assert_equal
    raise AssertionError(msg)
AssertionError: 
Items are not equal:
 ACTUAL: <HierView: AtomGroup pdb2k39_truncated_ca (1 chains, 10 residues)>
 DESIRED: <HierView: AtomGroup pdb2k39_truncated_ca (1 chains, 10 residues)>
-------------------- >> begin captured logging << --------------------
.prody: DEBUG: 10 atoms and 3 coordinate set(s) were parsed in 0.01s.
.prody: INFO: Secondary structures were assigned to 6 residues.
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 908 tests in 243.739s

FAILED (errors=1, failures=1)
```

So far, I've fixed the first.