### PR TITLE
cif header fix for 3p3w

### DIFF
--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -913,7 +913,7 @@ def mapChainOntoChain(mobile, target, **kwargs):
     :arg target: chain to which atoms will be mapped
     :type target: :class:`.Chain`
 
-    :keyword seqid: percent sequence identity, default is **90**. Note that This parameter is 
+    :keyword seqid: percent sequence identity, default is **90**. Note that this parameter is 
         only effective for sequence alignment
     :type seqid: float
 


### PR DESCRIPTION
Fixes the following error:
```
In [1]: from prody import *

In [2]: atoms = parseMMCIF("3p3w")
@> WARNING Could not find _pdbx_nonpoly_scheme in lines.
@> WARNING Could not find _pdbx_branch_scheme in lines.
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Input In [2], in <module>
----> 1 atoms = parseMMCIF("3p3w")

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:117, in parseMMCIF(pdb, **kwargs)
    115     kwargs['title'] = title
    116 cif = openFile(pdb, 'rt')
--> 117 result = parseMMCIFStream(cif, chain=chain, **kwargs)
    118 cif.close()
    119 return result

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:188, in parseMMCIFStream(stream, **kwargs)
    186     raise ValueError('empty PDB file or stream')
    187 if header or biomol or secondary:
--> 188     hd = getCIFHeaderDict(lines)
    190 _parseMMCIFLines(ag, lines, model, chain, subset, altloc)
    192 if ag.numAtoms() > 0:

File /mnt/c/Users/james/code/ProDy/prody/proteins/cifheader.py:162, in getCIFHeaderDict(stream, *keys)
    160 header = {}
    161 for key, func in _PDB_HEADER_MAP.items():  # PY3K: OK
--> 162     value = func(lines)
    163     if value is not None:
    164         header[key] = value

File /mnt/c/Users/james/code/ProDy/prody/proteins/cifheader.py:1055, in _getPolymers(lines)
   1052 star_dict6, _ = parseSTARLines(lines[:2] + lines[start6-1:stop6], shlex=True)
   1053 loop_dict6 = list(star_dict6.values())[0]
-> 1055 data6 = list(loop_dict6[0]["data"].values())
   1057 star_dict7, _ = parseSTARLines(lines[:2] + lines[stop6:stop7], shlex=True)
   1058 loop_dict7 = list(star_dict7.values())[0]

KeyError: 0
```

The problem is that there's another data block where it was expecting a loop:
```
[ '_entity_name_com.entity_id   1 \n',
 '_entity_name_com.name        \n',
 "'GluR-3, GluR-C, GluR-K3, Glutamate receptor ionotropic, AMPA 3, GluA3, AMPA-selective glutamate receptor 3' \n"]
```

I've also included an unrelated docs grammar fix in mapChainOntoChain