### PR TITLE
Default to https

### DIFF
--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -80,7 +80,7 @@ def view3D(*alist, **kwargs):
         data_list = wrapModes(data_list)
         n_data = len(data_list)
 
-    view = kwargs.get('view',py3Dmol.view(width=width, height=height, js=kwargs.get('js','http://3dmol.csb.pitt.edu/build/3Dmol-min.js')))
+    view = kwargs.get('view',py3Dmol.view(width=width, height=height, js=kwargs.get('js','https://3dmol.csb.pitt.edu/build/3Dmol-min.js')))
 
     def _mapData(atoms, data):
         # construct map from residue to data property


### PR DESCRIPTION
Otherwise won't work when called from webpages (e.g. colab) that default
to https since you can't make an insecure connection from a secure
webpage.