### PR TITLE
mmCIF parsing fixes for old 3h5v

### DIFF
--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -422,8 +422,8 @@ def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
                           dtype=ATOMIC_FIELDS['anisou'].dtype)
         
         if "_atom_site_anisotrop.U[1][1]_esd" in data[0].keys():
-            siguij = np.zeros((alength, 6),
-                dtype=ATOMIC_FIELDS['siguij'].dtype)
+            siguij = np.zeros((acount, 6),
+                              dtype=ATOMIC_FIELDS['siguij'].dtype)
 
         for entry in data:
             try:

--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -440,15 +440,20 @@ def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
             anisou[index, 5] = entry['_atom_site_anisotrop.U[2][3]'] 
 
             if siguij is not None:
-                siguij[index, 0] = entry['_atom_site_anisotrop.U[1][1]_esd']
-                siguij[index, 1] = entry['_atom_site_anisotrop.U[2][2]_esd']
-                siguij[index, 2] = entry['_atom_site_anisotrop.U[3][3]_esd']
-                siguij[index, 3] = entry['_atom_site_anisotrop.U[1][2]_esd']
-                siguij[index, 4] = entry['_atom_site_anisotrop.U[1][3]_esd']
-                siguij[index, 5] = entry['_atom_site_anisotrop.U[2][3]_esd']
+                try:
+                    siguij[index, 0] = entry['_atom_site_anisotrop.U[1][1]_esd']
+                    siguij[index, 1] = entry['_atom_site_anisotrop.U[2][2]_esd']
+                    siguij[index, 2] = entry['_atom_site_anisotrop.U[3][3]_esd']
+                    siguij[index, 3] = entry['_atom_site_anisotrop.U[1][2]_esd']
+                    siguij[index, 4] = entry['_atom_site_anisotrop.U[1][3]_esd']
+                    siguij[index, 5] = entry['_atom_site_anisotrop.U[2][3]_esd']
+                except:
+                    pass
 
         atomgroup.setAnisous(anisou) # no division needed anymore
-        atomgroup.setAnistds(siguij) # no division needed anymore
+
+        if not np.any(siguij):
+            atomgroup.setAnistds(siguij)  # no division needed anymore
 
     for n in range(1, nModels):
         atomgroup.addCoordset(coordinates[n*modelSize:(n+1)*modelSize])

--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -1285,14 +1285,17 @@ _PDB_HEADER_MAP = {
     'resolution': _getResolution,
     'biomoltrans': _getBiomoltrans,
     'version': _getVersion,
-    'deposition_date': lambda lines: [line.split()[1] for line in lines
-                                      if line.find("initial_deposition_date") != -1][0],
-    'classification': lambda lines: [line.split()[1] for line in lines
-                                     if line.find("_struct_keywords.pdbx_keywords") != -1][0],
-    'identifier': lambda lines: lines[0].split("_")[1].strip(),
+    'deposition_date': lambda lines: [line.split()[1]
+                                      if line.find("initial_deposition_date") != -1 else None
+                                      for line in lines][0],
+    'classification': lambda lines: [line.split()[1]
+                                     if line.find("_struct_keywords.pdbx_keywords") != -1 else None
+                                     for line in lines][0],
+    'identifier': lambda lines: lines[0].split("_")[1].strip() if len(lines[0].split("_")) else '',
     'title': _getTitle,
-    'experiment': lambda lines: [line.split()[1] for line in lines
-                                 if line.find("_exptl.method") != -1][0],
+    'experiment': lambda lines: [line.split()[1]
+                                 if line.find("_exptl.method") != -1 else None
+                                 for line in lines][0],
     'authors': _getAuthors,
     'split': _getSplit,
     'model_type': _getModelType,

--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -801,7 +801,9 @@ def _getPolymers(lines):
     # DBREF block 2
     items3 = parseSTARSection(lines, "_struct_ref_seq")
 
-    for item in items3:
+    for i, item in enumerate(items3):
+        i += 1
+
         ch = item["_struct_ref_seq.pdbx_strand_id"]
         poly = polymers[ch] 
         

--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -816,18 +816,30 @@ def _getPolymers(lines):
                     if initICode == '?':
                         initICode = ' '
                 except:
-                    LOGGER.warn('DBREF for chain {2}: failed to parse '
-                                'initial sequence number of the PDB sequence '
-                                '({0}:{1})'.format(pdbid, i, ch))
+                    try:
+                        first = int(item["_struct_ref_seq.pdbx_auth_seq_align_beg"])
+                        initICode = item["_struct_ref_seq.pdbx_seq_align_beg_ins_code"]
+                        if initICode == '?':
+                            initICode = ' '
+                    except:
+                        LOGGER.warn('DBREF for chain {2}: failed to parse '
+                                    'initial sequence number of the PDB sequence '
+                                    '({0}:{1})'.format(pdbid, i, ch))
                 try:
                     last = int(item["_struct_ref_seq.pdbx_auth_seq_align_end"])
-                    endICode = item["_struct_ref_seq.pdbx_db_align_beg_ins_code"]
+                    endICode = item["_struct_ref_seq.pdbx_db_align_end_ins_code"]
                     if endICode == '?':
-                        endICode = ' '            
+                        endICode = ' '
                 except:
-                    LOGGER.warn('DBREF for chain {2}: failed to parse '
-                                'ending sequence number of the PDB sequence '
-                                '({0}:{1})'.format(pdbid, i, ch))            
+                    try:
+                        last = int(item["_struct_ref_seq.pdbx_auth_seq_align_end"])
+                        endICode = item["_struct_ref_seq.pdbx_seq_align_end_ins_code"]
+                        if endICode == '?':
+                            endICode = ' '
+                    except:
+                        LOGGER.warn('DBREF for chain {2}: failed to parse '
+                                    'ending sequence number of the PDB sequence '
+                                    '({0}:{1})'.format(pdbid, i, ch))
                 try:
                     first2 = int(item["_struct_ref_seq.db_align_beg"])
                     dbref.first = (first, initICode, first2)

--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -859,7 +859,11 @@ def _getPolymers(lines):
                                 .format(pdbid, i, ch, dbabbr))
                     dbref.database = 'PDB'
             
-            resnum.append((dbref.first[0], dbref.last[0]))
+            try:
+                resnum.append((dbref.first[0], dbref.last[0]))
+            except:
+                pass # we've already warned about this
+
         resnum.sort()
         last = -10000
         for first, temp in resnum:


### PR DESCRIPTION
I have been trying to parse an old version of 3h5v.cif and it is causing a number of problems:

1. The first ones are problems with the siguij field being filled with "?" entries (default empty values):

a. We are not using alength for mmCIF parsing and it should be acount instead. This was just missed when adapting parsePDB and not noticed because we weren't parsing siguij data.
```
In [1]: base_path = "/mnt/c/Users/james/OneDrive/Documents/MC_fellowship/2_iGluR/"

In [2]: file_path = (
   ...:     base_path + "2_1_type/2_1_0_data/2_1_0_1_databases/1_pdb/PBP_pdbs/iGluR/ampar/ntd/"
   ...: )

In [3]: filename = file_path + "3h5v.cif"

In [4]: from prody import *
   ...:
   ...: ag = parsePDB(filename, secondary=False)
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
Input In [4], in <module>
      1 from prody import *
----> 3 ag = parsePDB(filename, secondary=False)

File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:124, in parsePDB(*pdb, **kwargs)
    121         n_pdb = len(pdb)
    123 if n_pdb == 1:
--> 124     return _parsePDB(pdb[0], **kwargs)
    125 else:
    126     results = []

File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:241, in _parsePDB(pdb, **kwargs)
    239 try:
    240     LOGGER.warn("Trying to parse as mmCIF file instead")
--> 241     return parseMMCIF(pdb, **kwargs)
    242 except KeyError:
    243     try:

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:117, in parseMMCIF(pdb, **kwargs)
    115     kwargs['title'] = title
    116 cif = openFile(pdb, 'rt')
--> 117 result = parseMMCIFStream(cif, chain=chain, **kwargs)
    118 cif.close()
    119 return result

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:190, in parseMMCIFStream(stream, **kwargs)
    187 if header or biomol or secondary:
    188     hd = getCIFHeaderDict(lines)
--> 190 _parseMMCIFLines(ag, lines, model, chain, subset, altloc)
    192 if ag.numAtoms() > 0:
    193     LOGGER.report('{0} atoms and {1} coordinate set(s) were '
    194                   'parsed in %.2fs.'.format(ag.numAtoms(),
    195                                             ag.numCoordsets() - n_csets))

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:425, in _parseMMCIFLines(atomgroup, lines, model, chain, subset, altloc_torf)
    421 anisou = np.zeros((acount, 6),
    422                   dtype=ATOMIC_FIELDS['anisou'].dtype)
    424 if "_atom_site_anisotrop.U[1][1]_esd" in data[0].keys():
--> 425     siguij = np.zeros((alength, 6),
    426         dtype=ATOMIC_FIELDS['siguij'].dtype)
    428 for entry in data:
    429     try:

NameError: name 'alength' is not defined
```

b. After fixing that, the following is unveiled. This can be fixed with a try/except.
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Input In [4], in <module>
      1 from prody import *
----> 3 ag = parsePDB(filename, secondary=False)

File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:124, in parsePDB(*pdb, **kwargs)
    121         n_pdb = len(pdb)
    123 if n_pdb == 1:
--> 124     return _parsePDB(pdb[0], **kwargs)
    125 else:
    126     results = []

File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:241, in _parsePDB(pdb, **kwargs)
    239 try:
    240     LOGGER.warn("Trying to parse as mmCIF file instead")
--> 241     return parseMMCIF(pdb, **kwargs)
    242 except KeyError:
    243     try:

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:117, in parseMMCIF(pdb, **kwargs)
    115     kwargs['title'] = title
    116 cif = openFile(pdb, 'rt')
--> 117 result = parseMMCIFStream(cif, chain=chain, **kwargs)
    118 cif.close()
    119 return result

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:190, in parseMMCIFStream(stream, **kwargs)
    187 if header or biomol or secondary:
    188     hd = getCIFHeaderDict(lines)
--> 190 _parseMMCIFLines(ag, lines, model, chain, subset, altloc)
    192 if ag.numAtoms() > 0:
    193     LOGGER.report('{0} atoms and {1} coordinate set(s) were '
    194                   'parsed in %.2fs.'.format(ag.numAtoms(),
    195                                             ag.numCoordsets() - n_csets))

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:443, in _parseMMCIFLines(atomgroup, lines, model, chain, subset, altloc_torf)
    440 anisou[index, 5] = entry['_atom_site_anisotrop.U[2][3]']
    442 if siguij is not None:
--> 443     siguij[index, 0] = entry['_atom_site_anisotrop.U[1][1]_esd']
    444     siguij[index, 1] = entry['_atom_site_anisotrop.U[2][2]_esd']
    445     siguij[index, 2] = entry['_atom_site_anisotrop.U[3][3]_esd']

ValueError: could not convert string to float: '?'
```

Besides these, we have some header problems too:

2. It fails to parse dbref entries because of using different keys

a. We first get a problem with not having defined the item number i, which is used for raising warnings. This can be defined with enumerate at the beginning of the loop for items3 and we also increment it to start from 1 as in parsePDB.
```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
File /mnt/c/Users/james/code/ProDy/prody/proteins/cifheader.py:813, in _getPolymers(lines)
    812 first = int(item["_struct_ref_seq.pdbx_auth_seq_align_beg"])
--> 813 initICode = item["_struct_ref_seq.pdbx_db_align_beg_ins_code"]
    814 if initICode == '?':

KeyError: '_struct_ref_seq.pdbx_db_align_beg_ins_code'

During handling of the above exception, another exception occurred:

UnboundLocalError                         Traceback (most recent call last)
Input In [5], in <module>
----> 1 ag = parsePDB(filename)

File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:124, in parsePDB(*pdb, **kwargs)
    121         n_pdb = len(pdb)
    123 if n_pdb == 1:
--> 124     return _parsePDB(pdb[0], **kwargs)
    125 else:
    126     results = []

File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:241, in _parsePDB(pdb, **kwargs)
    239 try:
    240     LOGGER.warn("Trying to parse as mmCIF file instead")
--> 241     return parseMMCIF(pdb, **kwargs)
    242 except KeyError:
    243     try:

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:117, in parseMMCIF(pdb, **kwargs)
    115     kwargs['title'] = title
    116 cif = openFile(pdb, 'rt')
--> 117 result = parseMMCIFStream(cif, chain=chain, **kwargs)
    118 cif.close()
    119 return result

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:188, in parseMMCIFStream(stream, **kwargs)
    186     raise ValueError('empty PDB file or stream')
    187 if header or biomol or secondary:
--> 188     hd = getCIFHeaderDict(lines)
    190 _parseMMCIFLines(ag, lines, model, chain, subset, altloc)
    192 if ag.numAtoms() > 0:

File /mnt/c/Users/james/code/ProDy/prody/proteins/cifheader.py:162, in getCIFHeaderDict(stream, *keys)
    160 header = {}
    161 for key, func in _PDB_HEADER_MAP.items():  # PY3K: OK
--> 162     value = func(lines)
    163     if value is not None:
    164         header[key] = value

File /mnt/c/Users/james/code/ProDy/prody/proteins/cifheader.py:819, in _getPolymers(lines)
    815         initICode = ' '
    816 except:
    817     LOGGER.warn('DBREF for chain {2}: failed to parse '
    818                 'initial sequence number of the PDB sequence '
--> 819                 '({0}:{1})'.format(pdbid, i, ch))
    820 try:
    821     last = int(item["_struct_ref_seq.pdbx_auth_seq_align_end"])

UnboundLocalError: local variable 'i' referenced before assignment
```

b. We get the warnings about not being able to parse this information, but we also get an indexing error. This is because the way the data is parsed from mmCIF requires us to assign it in a separate block and we're not checking that we actually have something to assign. We can use a try/except with a pass because we already raised the error.
```
@> WARNING Trying to parse as mmCIF file instead
@> WARNING Could not find _pdbx_branch_scheme in lines.
@> WARNING DBREF for chain A: failed to parse initial sequence number of the PDB sequence (3H5V:1)
@> WARNING DBREF for chain A: failed to parse ending sequence number of the PDB sequence (3H5V:1)
@> WARNING DBREF for chain A: failed to parse initial sequence number of the database sequence (3H5V:1)
@> WARNING DBREF for chain A: failed to parse ending sequence number of the database sequence (3H5V:1)
@> WARNING DBREF for chain B: failed to parse initial sequence number of the PDB sequence (3H5V:2)
@> WARNING DBREF for chain B: failed to parse ending sequence number of the PDB sequence (3H5V:2)
@> WARNING DBREF for chain B: failed to parse initial sequence number of the database sequence (3H5V:2)
@> WARNING DBREF for chain B: failed to parse ending sequence number of the database sequence (3H5V:2)
@> WARNING DBREF for chain C: failed to parse initial sequence number of the PDB sequence (3H5V:3)
@> WARNING DBREF for chain C: failed to parse ending sequence number of the PDB sequence (3H5V:3)
@> WARNING DBREF for chain C: failed to parse initial sequence number of the database sequence (3H5V:3)
@> WARNING DBREF for chain C: failed to parse ending sequence number of the database sequence (3H5V:3)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [4], in <module>
      1 from prody import *
----> 3 ag = parsePDB(filename)

File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:124, in parsePDB(*pdb, **kwargs)
    121         n_pdb = len(pdb)
    123 if n_pdb == 1:
--> 124     return _parsePDB(pdb[0], **kwargs)
    125 else:
    126     results = []

File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:241, in _parsePDB(pdb, **kwargs)
    239 try:
    240     LOGGER.warn("Trying to parse as mmCIF file instead")
--> 241     return parseMMCIF(pdb, **kwargs)
    242 except KeyError:
    243     try:

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:117, in parseMMCIF(pdb, **kwargs)
    115     kwargs['title'] = title
    116 cif = openFile(pdb, 'rt')
--> 117 result = parseMMCIFStream(cif, chain=chain, **kwargs)
    118 cif.close()
    119 return result

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:188, in parseMMCIFStream(stream, **kwargs)
    186     raise ValueError('empty PDB file or stream')
    187 if header or biomol or secondary:
--> 188     hd = getCIFHeaderDict(lines)
    190 _parseMMCIFLines(ag, lines, model, chain, subset, altloc)
    192 if ag.numAtoms() > 0:

File /mnt/c/Users/james/code/ProDy/prody/proteins/cifheader.py:162, in getCIFHeaderDict(stream, *keys)
    160 header = {}
    161 for key, func in _PDB_HEADER_MAP.items():  # PY3K: OK
--> 162     value = func(lines)
    163     if value is not None:
    164         header[key] = value

File /mnt/c/Users/james/code/ProDy/prody/proteins/cifheader.py:862, in _getPolymers(lines)
    857             LOGGER.warn('DBREF for chain {2} is {3}, '
    858                         'expected PDB ({0}:{1})'
    859                         .format(pdbid, i, ch, dbabbr))
    860             dbref.database = 'PDB'
--> 862     resnum.append((dbref.first[0], dbref.last[0]))
    863 resnum.sort()
    864 last = -10000

TypeError: 'NoneType' object is not subscriptable
```

It is also good to realise that the source of this error is because there are two types of records for the insertion code part (see https://www.ebi.ac.uk/pdbe/docs/exchange/pdb-correspondence/pdb2mmcif.html#DBREF) and we're only providing an option of using one of them. Therefore, we can add nested try/except blocks to provide both. I also noticed a typo in the end resum ones.

3. We have a problem in this file of not having a deposition date included at that point (the latest version has been updated to include it). The answer was to provide an option for it to default to None with an else in the list comprehension, which meant restructuring it. 
```
@> WARNING Trying to parse as mmCIF file instead
@> WARNING Could not find _pdbx_branch_scheme in lines.
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Input In [2], in <module>
      1 from prody import *
----> 3 ag = parsePDB(filename)

File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:124, in parsePDB(*pdb, **kwargs)
    121         n_pdb = len(pdb)
    123 if n_pdb == 1:
--> 124     return _parsePDB(pdb[0], **kwargs)
    125 else:
    126     results = []

File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:241, in _parsePDB(pdb, **kwargs)
    239 try:
    240     LOGGER.warn("Trying to parse as mmCIF file instead")
--> 241     return parseMMCIF(pdb, **kwargs)
    242 except KeyError:
    243     try:

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:117, in parseMMCIF(pdb, **kwargs)
    115     kwargs['title'] = title
    116 cif = openFile(pdb, 'rt')
--> 117 result = parseMMCIFStream(cif, chain=chain, **kwargs)
    118 cif.close()
    119 return result

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:188, in parseMMCIFStream(stream, **kwargs)
    186     raise ValueError('empty PDB file or stream')
    187 if header or biomol or secondary:
--> 188     hd = getCIFHeaderDict(lines)
    190 _parseMMCIFLines(ag, lines, model, chain, subset, altloc)
    192 if ag.numAtoms() > 0:

File /mnt/c/Users/james/code/ProDy/prody/proteins/cifheader.py:162, in getCIFHeaderDict(stream, *keys)
    160 header = {}
    161 for key, func in _PDB_HEADER_MAP.items():  # PY3K: OK
--> 162     value = func(lines)
    163     if value is not None:
    164         header[key] = value

File /mnt/c/Users/james/code/ProDy/prody/proteins/cifheader.py:1288, in <lambda>(lines)
   1273     return model_type
   1276 # Make sure that lambda functions defined below won't raise exceptions
   1277 _PDB_HEADER_MAP = {
   1278     'helix': _getHelix,
   1279     'helix_range': _getHelixRange,
   1280     'sheet': _getSheet,
   1281     'sheet_range': _getSheetRange,
   1282     'chemicals': _getChemicals,
   1283     'polymers': _getPolymers,
   1284     'reference': _getReference,
   1285     'resolution': _getResolution,
   1286     'biomoltrans': _getBiomoltrans,
   1287     'version': _getVersion,
-> 1288     'deposition_date': lambda lines: [line.split()[1] for line in lines
   1289                                       if line.find("initial_deposition_date") != -1][0],
   1290     'classification': lambda lines: [line.split()[1] for line in lines
   1291                                      if line.find("_struct_keywords.pdbx_keywords") != -1][0],
   1292     'identifier': lambda lines: lines[0].split("_")[1].strip(),
   1293     'title': _getTitle,
   1294     'experiment': lambda lines: [line.split()[1] for line in lines
   1295                                  if line.find("_exptl.method") != -1][0],
   1296     'authors': _getAuthors,
   1297     'split': _getSplit,
   1298     'model_type': _getModelType,
   1299     'n_models': _getNumModels,
   1300     'space_group': _getSpaceGroup,
   1301     'related_entries': _getRelatedEntries,
   1302 }

IndexError: list index out of range
```
 
There were also a few more where we could potentially have problems that I made similar changes too.

After that, everything works:
```
In [4]: from prody import *
   ...:
   ...: ag = parsePDB(filename, biomol=True)
@> WARNING Trying to parse as mmCIF file instead
@> WARNING Could not find _pdbx_branch_scheme in lines.
@> 9392 atoms and 1 coordinate set(s) were parsed in 1.49s.
@> Secondary structures were assigned to 693 residues.
@> Biomolecular transformations were applied, 2 biomolecule(s) are returned.
```