### PR TITLE
fix setData to not overwrite dtype

### DIFF
--- a/prody/atomic/atomgroup.py
+++ b/prody/atomic/atomgroup.py
@@ -814,7 +814,11 @@ class AtomGroup(Atomic):
             if np.isscalar(data):
                 data = [data] * self._n_atoms
 
-            data = np.asarray(data)
+            if label in self._data.keys():
+                data = np.asarray(data, dtype=self._data[label].dtype)
+            else:
+                data = np.asarray(data)
+
             ndim, dtype, shape = data.ndim, data.dtype, data.shape
 
             if ndim == 1 and dtype == bool:


### PR DESCRIPTION
This fixes a bug found when helping with #1572 

Old behaviour: dtype gets overwritten when using setData from an AtomGroup and string length is not maintained. There is a workaround of using `ag.select("all").setData` but we shouldn't need it.
```
In [1]: from prody import *
   ...: 
   ...: ag = parsePDB("6vyb")
@> PDB file is found in working directory (6vyb.pdb).
@> 22365 atoms and 1 coordinate set(s) were parsed in 0.23s.
@> Secondary structures were assigned to 1694 residues.

In [2]: ag.setData("domain", "NTD")

In [3]: ag.setData("domain", "")

In [4]: ag.select("resnum 13 to 303").setData("domain", "NTD")

In [5]: ag.getData("domain")
Out[5]: array(['N', 'N', 'N', ..., '', '', ''], dtype='<U1')
```

New behaviour: if the label already exists then the associated data is used for checking the type and it isn't lost:
```
In [1]: from prody import *
   ...: 
   ...: ag = parsePDB("6vyb")
@> PDB file is found in working directory (6vyb.pdb).
@> 22365 atoms and 1 coordinate set(s) were parsed in 0.23s.
@> Secondary structures were assigned to 1694 residues.

In [2]: ag.setData("domain", "NTD")

In [3]: ag.setData("domain", "")

In [4]: ag.select("resnum 13 to 303").setData("domain", "NTD")

In [5]: ag.getData("domain")
Out[5]: array(['NTD', 'NTD', 'NTD', ..., '', '', ''], dtype='<U3')
```