### PR TITLE
chain id mmCIF fixes

### DIFF
--- a/prody/atomic/fields.py
+++ b/prody/atomic/fields.py
@@ -125,7 +125,7 @@ ATOMIC_FIELDS = {
                        selstr=('altloc A B', 'altloc _'),),
     'anisou':    Field('anisou', float, doc='anisotropic temperature factor',
                        ndim=2),
-    'chain':     Field('chain', DTYPE + '2',  doc='chain identifier',
+    'chain':     Field('chain', DTYPE + '3',  doc='chain identifier',
                        meth='Chid', none=HVNONE, synonym='chid',
                        selstr=('chain A', 'chid A B C', 'chain _')),
     'element':   Field('element', DTYPE + '2', doc='element symbol',

--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -285,8 +285,8 @@ def _getHelix(lines):
             data = line.split()
 
             try:
-                chid = data[fields["beg_label_asym_id"]]
-                segn = data[fields["beg_auth_asym_id"]]
+                chid = data[fields["beg_auth_asym_id"]]
+                segn = data[fields["beg_label_asym_id"]]
                 value = (int(data[fields["pdbx_PDB_helix_class"]]),
                         int(data[fields["id"]][6:]),
                         data[fields["pdbx_PDB_helix_id"]].strip())
@@ -352,7 +352,7 @@ def _getHelixRange(lines):
             data = line.split()
 
             try:
-                chid = data[fields["beg_label_asym_id"]]
+                chid = data[fields["beg_auth_asym_id"]]
                 Hclass=int(data[fields["pdbx_PDB_helix_class"]])
                 Hnr=int(data[fields["id"]][6:])
             except:
@@ -504,8 +504,8 @@ def _getSheet(lines):
             data = line.split()
 
             try:
-                chid = data[fields3["beg_label_asym_id"]]
-                segn = data[fields3["beg_auth_asym_id"]]
+                chid = data[fields3["beg_auth_asym_id"]]
+                segn = data[fields3["beg_label_asym_id"]]
 
                 strand_id = int(data[fields3["id"]])
                 sheet_id = data[fields3["sheet_id"]]
@@ -675,7 +675,7 @@ def _getSheetRange(lines):
             data = line.split()
 
             try:
-                chid = data[fields3["beg_label_asym_id"]]
+                chid = data[fields3["beg_auth_asym_id"]]
 
                 Snr = int(data[fields3["id"]])
                 sheet_id = data[fields3["sheet_id"]]

--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -867,53 +867,24 @@ def _getPolymers(lines):
             last = temp
 
     # MODRES block
-    i = 0
-    fields4 = OrderedDict()
-    fieldCounter4 = -1
-    foundPolyBlock4 = False
-    foundPolyBlockData4 = False
-    donePolyBlock4 = False
-    start4 = 0
-    stop4 = 0
-    while not donePolyBlock4 and i < len(lines):
-        line = lines[i]
-        if line.split('.')[0] == '_pdbx_struct_mod_residue':
-            fieldCounter4 += 1
-            fields4[line.split('.')[1].strip()] = fieldCounter4
-            if not foundPolyBlock4:
-                foundPolyBlock4 = True
+    data4 = parseSTARSection(lines, "_pdbx_struct_mod_residue")
 
-        if foundPolyBlock4:
-            if not line.startswith('#') and not line.startswith('_'):
-                if not foundPolyBlockData4:
-                    start4 = i
-                    foundPolyBlockData4 = True
-            else:
-                if foundPolyBlockData4:
-                    donePolyBlock4 = True
-                    stop4 = i
+    for data in data4:
+        ch = data["_pdbx_struct_mod_residue.label_asym_id"]
 
-        i += 1
+        poly = polymers.get(ch, Polymer(ch))
+        polymers[ch] = poly
+        if poly.modified is None:
+            poly.modified = []
 
-    if i < len(lines):
-        for line in lines[start4:stop4]:
-            data = split(line, shlex=True)
-
-            ch = data[fields4["label_asym_id"]]
-
-            poly = polymers.get(ch, Polymer(ch))
-            polymers[ch] = poly
-            if poly.modified is None:
-                poly.modified = []
-
-            iCode = data[fields4["PDB_ins_code"]]
-            if iCode == '?':
-                iCode == '' # PDB one is stripped
-            poly.modified.append((data[fields4["auth_comp_id"]],
-                                  data[fields4["auth_asym_id"]],
-                                  data[fields4["auth_seq_id"]] + iCode,
-                                  data[fields4["parent_comp_id"]],
-                                  data[fields4["details"]]))
+        iCode = data["_pdbx_struct_mod_residue.PDB_ins_code"]
+        if iCode == '?':
+            iCode == '' # PDB one is stripped
+        poly.modified.append((data["_pdbx_struct_mod_residue.auth_comp_id"],
+                                data["_pdbx_struct_mod_residue.auth_asym_id"],
+                                data["_pdbx_struct_mod_residue.auth_seq_id"] + iCode,
+                                data["_pdbx_struct_mod_residue.parent_comp_id"],
+                                data["_pdbx_struct_mod_residue.details"]))
 
     # SEQADV block
     data5 = parseSTARSection(lines, "_struct_ref_seq_dif")


### PR DESCRIPTION
fixes #1576 

Main error: 'pdbx_pdb_strand_id' is in a data block not a loop so the parsing method I had for polymers didn't work in this case

Incidental 1: the strand/chain id has 3 characters (AAA) so we needed to support that

Incidental 2: having a mismatch in length between chain id (AAA) and seg name (A) allowed the identification of a problem with parsing secondary structure data from mmCIF files where the two were switched.

These are all now fixed and everything works fine.

Previous behaviour: file cannot be parsed with header options such as secondary active (default behaviour). It can be if secondary=False, but the chain ID only has 2 characters:
```
In [1]: from prody import *

In [2]: ag = parsePDB("4abz")
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> pdb4abz.ent.gz download failed. 4abz does not exist on ftp.wwpdb.org.
@> PDB download via FTP completed (0 downloaded, 1 failed).
@> Downloading PDB files via FTP failed, trying HTTP.
@> WARNING 4abz download failed ('https://files.rcsb.org/download/4ABZ.pdb.gz' could not be opened for reading, invalid URL or no internet connection).
@> PDB download via HTTP completed (0 downloaded, 1 failed).
@> WARNING Trying to parse mmCIF file instead
@> WARNING Could not find _pdbx_branch_scheme in lines.
@> WARNING Trying to parse EMD file instead
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:214, in _parsePDB(pdb, **kwargs)
    213     LOGGER.warn("Trying to parse mmCIF file instead")
--> 214     return parseMMCIF(pdb+chain, **kwargs)
    215 except:

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:117, in parseMMCIF(pdb, **kwargs)
    116 cif = openFile(pdb, 'rt')
--> 117 result = parseMMCIFStream(cif, chain=chain, **kwargs)
    118 cif.close()

File /mnt/c/Users/james/code/ProDy/prody/proteins/ciffile.py:188, in parseMMCIFStream(stream, **kwargs)
    187 if header or biomol or secondary:
--> 188     hd = getCIFHeaderDict(lines)
    190 _parseMMCIFLines(ag, lines, model, chain, subset, altloc)

File /mnt/c/Users/james/code/ProDy/prody/proteins/cifheader.py:162, in getCIFHeaderDict(stream, *keys)
    161 for key, func in _PDB_HEADER_MAP.items():  # PY3K: OK
--> 162     value = func(lines)
    163     if value is not None:

File /mnt/c/Users/james/code/ProDy/prody/proteins/cifheader.py:951, in _getPolymers(lines)
    949 data = split(line, shlex=True)
--> 951 ch = data[fields5["pdbx_pdb_strand_id"]]
    953 poly = polymers.get(ch, Polymer(ch))

KeyError: 'pdbx_pdb_strand_id'

During handling of the above exception, another exception occurred:

OSError                                   Traceback (most recent call last)
File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:218, in _parsePDB(pdb, **kwargs)
    217     LOGGER.warn("Trying to parse EMD file instead")
--> 218     return parseEMD(pdb+chain, **kwargs)
    219 except:

File /mnt/c/Users/james/code/ProDy/prody/proteins/emdfile.py:85, in parseEMD(emd, **kwargs)
     84     else:
---> 85         raise IOError('EMD file {0} is not available in the directory {1}'
     86                       .format(emd, os.getcwd()))
     87 if title is None:

OSError: EMD file 4abz is not available in the directory /mnt/c/Users/james/code/ProDy

During handling of the above exception, another exception occurred:

OSError                                   Traceback (most recent call last)
Input In [2], in <module>
----> 1 ag = parsePDB("4abz")

File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:124, in parsePDB(*pdb, **kwargs)
    121         n_pdb = len(pdb)
    123 if n_pdb == 1:
--> 124     return _parsePDB(pdb[0], **kwargs)
    125 else:
    126     results = []

File /mnt/c/Users/james/code/ProDy/prody/proteins/pdbfile.py:220, in _parsePDB(pdb, **kwargs)
    218                 return parseEMD(pdb+chain, **kwargs)
    219             except:
--> 220                 raise IOError('PDB file for {0} could not be downloaded.'
    221                             .format(pdb))
    222     pdb = filename
    223 if title is None:

OSError: PDB file for 4abz could not be downloaded.

In [3]: ag = parsePDB("4abz", secondary=False)
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> pdb4abz.ent.gz download failed. 4abz does not exist on ftp.wwpdb.org.
@> PDB download via FTP completed (0 downloaded, 1 failed).
@> Downloading PDB files via FTP failed, trying HTTP.
@> WARNING 4abz download failed ('https://files.rcsb.org/download/4ABZ.pdb.gz' could not be opened for reading, invalid URL or no internet connection).
@> PDB download via HTTP completed (0 downloaded, 1 failed).
@> WARNING Trying to parse mmCIF file instead
@> 1638 atoms and 1 coordinate set(s) were parsed in 0.28s.

In [4]: list(ag.getHierView())
Out[4]:
[<Chain: AA from Segment A from 4abz (195 residues, 1550 atoms)>,
 <Chain: AA from Segment B from 4abz (1 residues, 42 atoms)>,
 <Chain: AA from Segment C from 4abz (1 residues, 1 atoms)>,
 <Chain: AA from Segment D from 4abz (1 residues, 1 atoms)>,
 <Chain: AA from Segment E from 4abz (1 residues, 1 atoms)>,
 <Chain: AA from Segment F from 4abz (1 residues, 1 atoms)>,
 <Chain: AA from Segment G from 4abz (42 residues, 42 atoms)>]
```

New behaviour: file can be parsed fine, chain ID has 3 characters, and secondary structures are assigned to helices appropriately
```
In [2]: ag = parsePDB("4abz")
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> pdb4abz.ent.gz download failed. 4abz does not exist on ftp.wwpdb.org.
@> PDB download via FTP completed (0 downloaded, 1 failed).
@> Downloading PDB files via FTP failed, trying HTTP.
@> WARNING 4abz download failed ('https://files.rcsb.org/download/4ABZ.pdb.gz' could not be opened for reading, invalid URL or no internet connection).
@> PDB download via HTTP completed (0 downloaded, 1 failed).
@> WARNING Trying to parse mmCIF file instead
@> WARNING Could not find _pdbx_branch_scheme in lines.
@> WARNING Could not find _entity_name_com in lines.
@> 1638 atoms and 1 coordinate set(s) were parsed in 0.31s.
@> Secondary structures were assigned to 163 residues.

In [3]: list(ag.getHierView())
Out[3]:
[<Chain: AAA from Segment A from 4abz (195 residues, 1550 atoms)>,
 <Chain: AAA from Segment B from 4abz (1 residues, 42 atoms)>,
 <Chain: AAA from Segment C from 4abz (1 residues, 1 atoms)>,
 <Chain: AAA from Segment D from 4abz (1 residues, 1 atoms)>,
 <Chain: AAA from Segment E from 4abz (1 residues, 1 atoms)>,
 <Chain: AAA from Segment F from 4abz (1 residues, 1 atoms)>,
 <Chain: AAA from Segment G from 4abz (42 residues, 42 atoms)>]
```
