### PR TITLE
bug fix for delCoordset not deleting transformation

### DIFF
--- a/prody/ensemble/pdbensemble.py
+++ b/prody/ensemble/pdbensemble.py
@@ -521,6 +521,10 @@ class PDBEnsemble(Ensemble):
         for i in index:
             self._labels.pop(i)
 
+        if self._trans is not None:
+            for i in index:
+                self._trans = np.delete(self._trans, i, 0)
+
         if self._msa is not None:
             rest = []
             for i in range(self._msa.numSequences()):

--- a/prody/tests/ensemble/test_pdbensemble.py
+++ b/prody/tests/ensemble/test_pdbensemble.py
@@ -102,6 +102,17 @@ class TestPDBEnsemble(TestCase):
                      ATOMS.getCoordsets([0,2])[WEIGHTS_BOOL[[0,2]]],
                     'failed to delete middle coordinate set')
 
+    def testDelCoordsetMiddleTrans(self):
+
+        PDBENSEMBLEB = PDBENSEMBLEA[:]
+        PDBENSEMBLEB.iterpose()
+
+        ensemble = PDBENSEMBLEB[:]
+        ensemble.delCoordset(1)
+        assert_equal(ensemble._trans,
+                     PDBENSEMBLEB._trans[[0,2]],
+                     'failed to delete middle transformation')
+
     def testDelCoordsetAll(self):
         """Test consequences of deleting all coordinate sets."""
 


### PR DESCRIPTION
This resulted in a failure with trimPDBEnsemble after using delCoordset:
```
Input In [227], in <module>
----> 1 h_trim_ens = trimPDBEnsemble(ens)

File /mnt/c/Users/james/code/ProDy/prody/ensemble/functions.py:270, in trimPDBEnsemble(pdb_ensemble, occupancy, **kwargs)
    268             msa = msa[:, torf]
    269         trans = pdb_ensemble._trans
--> 270         trimmed.addCoordset(confs[:, torf], weights[:, torf], labels, sequence=msa, transformation=trans)
    271 else:
    272     indices = np.where(torf)[0]

File /mnt/c/Users/james/code/ProDy/prody/ensemble/pdbensemble.py:362, in PDBEnsemble.addCoordset(self, coords, weights, label, **kwargs)
    360 if transformations:
    361     if len(transformations) != n_repeats:
--> 362         raise ValueError('the number of transformations should be either one or '
    363                          'that of coordsets')
    365 # assign new values
    366 # update labels
    367 if n_csets > 1 and not degeneracy:

ValueError: the number of transformations should be either one or that of coordsets
```

With the fix, transformations are deleted too and there's no longer any problem.

I also checked that the test only passes with the change and not on the master branch.