### PR TITLE
Fix IndexError exception when local pairwise alignment produces 0 alignments

### DIFF
--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -799,8 +799,9 @@ def getAlignedMatch(ach, bch):
     try:
         this = alignment[0][0]
         that = alignment[0][1]
-    except IndexError:                                                                                                                                                                                                                     
-        return amatch, bmatch, match    
+    except IndexError:
+        LOGGER.warning('Matching chains resulted in empty alignment.')
+        return amatch, bmatch, match
     aiter = ach.__iter__()
     biter = bch.__iter__()
     for i in range(len(this)):

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -793,13 +793,16 @@ def getAlignedMatch(ach, bch):
                                              GAP_PENALTY, GAP_EXT_PENALTY,
                                              one_alignment_only=1)
 
-    this = alignment[0][0]
-    that = alignment[0][1]
     amatch = []
     bmatch = []
+    match = 0.0
+    try:
+        this = alignment[0][0]
+        that = alignment[0][1]
+    except IndexError:                                                                                                                                                                                                                     
+        return amatch, bmatch, match    
     aiter = ach.__iter__()
     biter = bch.__iter__()
-    match = 0.0
     for i in range(len(this)):
         a = this[i]
         b = that[i]


### PR DESCRIPTION
It is possible for local alignment between pairs of chains to produce an empty list of alignments, resulting in an IndexError in the current code. This patch takes care of this issue.

Original error:

> File .../prody/proteins/compare.py:796, in getAlignedMatch(ach, bch)
>     789 else:
>     790     alignment = pairwise2.align.globalms(ach.getSequence(),
>     791                                          bch.getSequence(),
>     792                                          MATCH_SCORE, MISMATCH_SCORE,
>     793                                          GAP_PENALTY, GAP_EXT_PENALTY,
>     794                                          one_alignment_only=1)
> --> 796 this = alignment[0][0]
>     797 that = alignment[0][1]
>     798 amatch = []
> 
> IndexError: list index out of range
> 