### PR TITLE
Gamma from GOdMD

### DIFF
--- a/prody/apps/prody_apps/nmaoptions.py
+++ b/prody/apps/prody_apps/nmaoptions.py
@@ -56,7 +56,7 @@ def addNMAParameters(parser):
         help=HELPTEXT['nmodes'] + ' (default: %(default)s)')
 
     parser.add_argument('-s', '--select', dest='select', type=str,
-        default=DEFAULTS['select'], metavar='SEL',
+        default=DEFAULTS['select'], metavar='STR',
         help=HELPTEXT['select'] + ' (default: "%(default)s")')
 
     return parser

--- a/prody/apps/prody_apps/prody_anm.py
+++ b/prody/apps/prody_apps/prody_anm.py
@@ -14,7 +14,7 @@ for key, txt, val in [
     ('model', 'index of model that will be used in the calculations', 1),
     ('altloc', 'alternative location identifiers for residues used in the calculations', "A"),
     ('cutoff', 'cutoff distance (A)', 15.),
-    ('gamma', 'spring constant', 1.),
+    ('gamma', 'spring constant', '1.'),
     ('sparse', 'use sparse matrices', False),
     ('kdtree', 'use kdtree for Hessian', False),    
     ('zeros', 'calculate zero modes', False),
@@ -58,7 +58,6 @@ def prody_anm(pdb, **kwargs):
     selstr = kwargs.get('select')
     prefix = kwargs.get('prefix')
     cutoff = kwargs.get('cutoff')
-    gamma = kwargs.get('gamma')
     sparse = kwargs.get('sparse')
     kdtree = kwargs.get('kdtree')
     nmodes = kwargs.get('nmodes')
@@ -79,6 +78,19 @@ def prody_anm(pdb, **kwargs):
         return
     LOGGER.info('{0} atoms will be used for ANM calculations.'
                 .format(len(select)))
+
+    try:
+        gamma = float(kwargs.get('gamma'))
+        LOGGER.info("Using gamma {0}".format(gamma))
+    except ValueError:
+        try:
+            Gamma = eval('prody.' + kwargs.get('gamma'))
+            gamma = Gamma(select)
+            LOGGER.info("Using gamma {0}".format(Gamma))
+        except NameError:
+            raise NameError("Please provide gamma as a float or ProDy Gamma class")
+        except TypeError:
+            raise TypeError("Please provide gamma as a float or ProDy Gamma class")
 
     anm = prody.ANM(pdb.getTitle())
 
@@ -267,8 +279,8 @@ graphical output files:
         default=DEFAULTS['cutoff'], metavar='FLOAT',
         help=HELPTEXT['cutoff'] + ' (default: %(default)s)')
 
-    group.add_argument('-g', '--gamma', dest='gamma', type=float,
-        default=DEFAULTS['gamma'], metavar='FLOAT',
+    group.add_argument('-g', '--gamma', dest='gamma', type=str,
+        default=DEFAULTS['gamma'], metavar='STR',
         help=HELPTEXT['gamma'] + ' (default: %(default)s)')
 
     group.add_argument('-C', '--sparse-hessian', dest='sparse', action='store_true',

--- a/prody/apps/prody_apps/prody_gnm.py
+++ b/prody/apps/prody_apps/prody_gnm.py
@@ -13,7 +13,7 @@ for key, txt, val in [
     ('model', 'index of model that will be used in the calculations', 1),
     ('altloc', 'alternative location identifiers for residues used in the calculations', "A"),
     ('cutoff', 'cutoff distance (A)', 10.),
-    ('gamma', 'spring constant', 1.),
+    ('gamma', 'spring constant', '1.'),
     ('zeros', 'calculate zero modes', False),
 
     ('outbeta', 'write beta-factors calculated from GNM modes', False),
@@ -52,7 +52,6 @@ def prody_gnm(pdb, **kwargs):
     selstr = kwargs.get('select')
     prefix = kwargs.get('prefix')
     cutoff = kwargs.get('cutoff')
-    gamma = kwargs.get('gamma')
     nmodes = kwargs.get('nmodes')
     selstr = kwargs.get('select')
     model = kwargs.get('model')
@@ -69,6 +68,19 @@ def prody_gnm(pdb, **kwargs):
                           .format(repr(selstr)))
     LOGGER.info('{0} atoms will be used for GNM calculations.'
                 .format(len(select)))
+
+    try:
+        gamma = float(kwargs.get('gamma'))
+        LOGGER.info("Using gamma {0}".format(gamma))
+    except ValueError:
+        try:
+            Gamma = eval('prody.' + kwargs.get('gamma'))
+            gamma = Gamma(select)
+            LOGGER.info("Using gamma {0}".format(Gamma))
+        except NameError:
+            raise NameError("Please provide gamma as a float or ProDy Gamma class")
+        except TypeError:
+            raise TypeError("Please provide gamma as a float or ProDy Gamma class")
 
     gnm = prody.GNM(pdb.getTitle())
 
@@ -280,8 +292,8 @@ save all of the graphical output files:
         default=DEFAULTS['cutoff'], metavar='FLOAT',
         help=HELPTEXT['cutoff'] + ' (default: %(default)s)')
 
-    group.add_argument('-g', '--gamma', dest='gamma', type=float,
-        default=DEFAULTS['gamma'], metavar='FLOAT',
+    group.add_argument('-g', '--gamma', dest='gamma', type=str,
+        default=DEFAULTS['gamma'], metavar='STR',
         help=HELPTEXT['gamma'] + ' (default: %(default)s)')
 
     group.add_argument('-m', '--model', dest='model', type=int,

--- a/prody/dynamics/gamma.py
+++ b/prody/dynamics/gamma.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from prody.atomic import Atomic
 
-__all__ = ['Gamma', 'GammaStructureBased', 'GammaVariableCutoff']
+__all__ = ['Gamma', 'GammaStructureBased', 'GammaVariableCutoff', 'GammaGOdMD']
 
 
 class Gamma(object):
@@ -299,3 +299,100 @@ class GammaVariableCutoff(Gamma):
                   'effective cutoff:', str(cutoff), 'distance:',
                   str(dist2**0.5), 'gamma:', str(gamma)]))  # PY3K: OK
         return gamma
+
+
+class GammaGOdMD(Gamma):
+    """Facilitate setting the spring constant based on 
+    sequence distance and spatial distance as in GOdMD.
+
+    The sequence distance-dependent term is Cseq/(S**2)
+    for S=abs(i,j) <= Slim
+
+    The structure distance-dependent term is (Ccart/dist)**Ex
+
+    **Example**:
+
+    Let's parse coordinates from a PDB file.
+
+    .. ipython:: python
+
+       from prody import *
+       ubi, header = parsePDB('1aar', chain='A', subset='calpha')
+
+    In the above we parsed only the atoms needed for this calculation, i.e.
+    Cα atoms from chain A.
+
+    We build the Hessian matrix using GOdMD spring constants as
+    follows;
+
+    .. ipython:: python
+
+       gamma = GammaGOdMD(ubi)
+       anm = ANM('')
+       anm.buildHessian(ubi, gamma=gamma)
+    
+    """
+
+    def __init__(self, atoms, Ccart=6., Ex=6, Cseq=60., Slim=3):
+        """Setup the parameters.
+
+        :arg atoms: A set of atoms
+        :type atoms: :class:`.Atomic`
+
+        :arg Ccart: Multiplication constant inside the exponential
+            in the spatial distance-dependent term 
+            Default is 6.
+        :type Ccart: float
+
+        :arg Ex: Exponent in spatial distance-dependent term
+            Default is 6
+        :type sheet: float
+
+        :arg Cseq: Multiplication constant in sequence distance-dependent term 
+            Default is 60.
+        :type Cseq: float
+
+        :arg Slim: Sequence distance limit for sequence distance-dependence
+            This limit is used with a less-or-equal operator
+            Default is 3
+        :type Slim: float
+
+    """
+
+        if not isinstance(atoms, Atomic):
+            raise TypeError('atoms must be an Atomic instance')
+
+        n_atoms = atoms.numAtoms()
+        if n_atoms < 3:
+            raise ValueError('number of atoms must be larger than 2')
+
+        rnum = atoms.getResindices()
+        assert rnum is not None, 'residue numbers must be set'
+
+        Ccart = float(Ccart)
+        assert Ccart > 0, 'gamma must be greater than 0'
+
+        Cseq = float(Cseq)
+        assert Cseq > 0, 'helix must be greater than 0'
+
+        self._Ccart = Ccart
+        self._Ex = Ex
+
+        self._Cseq = Cseq
+        self._Slim = Slim
+
+    def gamma(self, dist2, i, j):
+        """Returns force constant."""
+
+        Ccart = self._Ccart
+        Ex = self._Ex
+
+        Cseq = self._Cseq
+        Slim = self._Slim
+
+        S = abs(i-j)
+        if S <= Slim:
+            return Cseq/(S**2)
+        else:
+            dist = dist2**0.5
+            return (Ccart/dist)**Ex


### PR DESCRIPTION
- [x] Added a new Gamma class based on sequence distance and structure distance that is found in GOdMD (http://mmb.irbbarcelona.org/GOdMD/index.php?id=about)

```
(scipion3) jkrieger@DESKTOP-QL82H8Q /mnt/c/Users/james/code/ProDy (gamma_godmd) $ ipython
Python 3.8.12 | packaged by conda-forge | (default, Jan 30 2022, 23:42:07) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.0.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: ag = parsePDB("4akeA", subset="ca")
@> PDB file is found in working directory (4ake.pdb.gz).
@> 214 atoms and 1 coordinate set(s) were parsed in 0.03s.
@> Secondary structures were assigned to 139 residues.

In [3]: gamma = GammaGOdMD(ag)

In [4]: anm = prody.ANM()

In [5]: anm.buildHessian(ag, gamma=gamma)
@> Hessian was built in 0.07s.

In [6]: anm.calcModes()
@> 20 modes were calculated in 0.29s.
```

- [x] Added support for Gamma classes in prody anm and prody gnm apps, while maintaining support for floats

```
(scipion3) jkrieger@DESKTOP-QL82H8Q /mnt/c/Users/james/code/ProDy (gamma_godmd) $ prody anm 4ake.pdb.gz -s "chain A and name CA" -g GammaGOdMD
@> 3459 atoms and 1 coordinate set(s) were parsed in 0.06s.
@> Secondary structures were assigned to 279 residues.
@> 214 atoms will be used for ANM calculations.
@> Using gamma <class 'prody.dynamics.gamma.GammaGOdMD'>
@> Hessian was built in 0.08s.
@> 10 modes were calculated in 0.30s.
@> Writing numerical output.
```
```
(scipion3) jkrieger@DESKTOP-QL82H8Q /mnt/c/Users/james/code/ProDy (gamma_godmd) $ prody anm 4ake.pdb.gz -s "chain A and name CA"
@> 3459 atoms and 1 coordinate set(s) were parsed in 0.06s.
@> Secondary structures were assigned to 279 residues.
@> 214 atoms will be used for ANM calculations.
@> Using gamma 1.0
@> Hessian was built in 0.10s.
@> 10 modes were calculated in 0.16s.
@> Writing numerical output.
```
```
(scipion3) jkrieger@DESKTOP-QL82H8Q /mnt/c/Users/james/code/ProDy (gamma_godmd) $ prody anm 4ake.pdb.gz -s "chain A and name CA" -g 1.1
@> 3459 atoms and 1 coordinate set(s) were parsed in 0.05s.
@> Secondary structures were assigned to 279 residues.
@> 214 atoms will be used for ANM calculations.
@> Using gamma 1.1
@> Hessian was built in 0.07s.
@> 10 modes were calculated in 0.24s.
@> Writing numerical output.
```
```
(scipion3) jkrieger@DESKTOP-QL82H8Q /mnt/c/Users/james/code/ProDy (gamma_godmd) $ prody gnm 4ake.pdb.gz -s "chain A and name CA" -g GammaGOdMD
@> 3459 atoms and 1 coordinate set(s) were parsed in 0.05s.
@> Secondary structures were assigned to 279 residues.
@> 214 atoms will be used for GNM calculations.
@> Using gamma <class 'prody.dynamics.gamma.GammaGOdMD'>
@> Kirchhoff was built in 0.01s.
@> 10 modes were calculated in 0.10s.
@> Writing numerical output.
```
```
(scipion3) jkrieger@DESKTOP-QL82H8Q /mnt/c/Users/james/code/ProDy (gamma_godmd) $ prody gnm 4ake.pdb.gz -s "chain A and name CA"
@> 3459 atoms and 1 coordinate set(s) were parsed in 0.06s.
@> Secondary structures were assigned to 279 residues.
@> 214 atoms will be used for GNM calculations.
@> Using gamma 1.0
@> Kirchhoff was built in 0.01s.
@> 10 modes were calculated in 0.34s.
@> Writing numerical output.
```