### PR TITLE
better biopython dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ if sys.version_info[:2] < (2, 7):
     sys.stderr.write('Python 2.6 and older is not supported\n')
     sys.exit()
 
-if sys.version_info[:2] == (2, 7):
+if sys.version_info[:2] == (2, 7) or sys.version_info[:2] <= (3, 5):
     INSTALL_REQUIRES=['numpy>=1.10', 'biopython<=1.76', 'pyparsing', 'scipy']
 else:
-    INSTALL_REQUIRES=['numpy>=1.10', 'biopython<=1.76', 'pyparsing', 'scipy']
+    INSTALL_REQUIRES=['numpy>=1.10', 'biopython', 'pyparsing', 'scipy']
 
 if sys.version_info[0] == 3:
     if sys.version_info[1] < 5:


### PR DESCRIPTION
Properly addresses Biopython version compatibility message "Version 1.76 is the last release to support Python 2.7 and 3.5, all later releases require Python 3.6 or greater" and recent requests including in #1546.

I haven't changed pyproject.toml but things seem to work anyway:

```
(scipion3) jkrieger@DESKTOP-QL82H8Q /mnt/c/Users/james/code/ProDy (biop_dep) $ pip install -U biopython
Requirement already satisfied: biopython in /home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages (1.76)
Collecting biopython
  Downloading biopython-1.79-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (2.7 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.7/2.7 MB 25.2 MB/s eta 0:00:00
Requirement already satisfied: numpy in /home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages (from biopython) (1.18.4)
Installing collected packages: biopython
  Attempting uninstall: biopython
    Found existing installation: biopython 1.76
    Uninstalling biopython-1.76:
      Successfully uninstalled biopython-1.76
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
prody 2.2.0 requires biopython<=1.76, but you have biopython 1.79 which is incompatible.
scipion-em 3.0.17 requires biopython==1.76, but you have biopython 1.79 which is incompatible.
Successfully installed biopython-1.79
(scipion3) jkrieger@DESKTOP-QL82H8Q /mnt/c/Users/james/code/ProDy (biop_dep) $ pip install -Ue .
Obtaining file:///mnt/c/Users/james/code/ProDy
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Requirement already satisfied: biopython in /home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages (from ProDy==2.2.0) (1.79)
Requirement already satisfied: scipy in /home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages (from ProDy==2.2.0) (1.8.0)
Requirement already satisfied: numpy>=1.10 in /home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages (from ProDy==2.2.0) (1.18.4)
Requirement already satisfied: pyparsing in /home/jkrieger/anaconda3/envs/scipion3/lib/python3.8/site-packages (from ProDy==2.2.0) (3.0.7)
Building wheels for collected packages: ProDy
  Building editable for ProDy (pyproject.toml) ... done
  Created wheel for ProDy: filename=ProDy-2.2.0-0.editable-cp38-cp38-linux_x86_64.whl size=6575 sha256=a81aa0005dc61e07a7beb0d6fd90d6368454370a95743933a36e47ec401b95e2
  Stored in directory: /tmp/pip-ephem-wheel-cache-vu1mkbfy/wheels/f5/cf/e0/8080d18994f07fec301b5f2442b883f721c2c82d99164cfb15
Successfully built ProDy
Installing collected packages: ProDy
  Attempting uninstall: ProDy
    Found existing installation: ProDy 2.2.0
    Uninstalling ProDy-2.2.0:
      Successfully uninstalled ProDy-2.2.0
Successfully installed ProDy-2.2.0
(scipion3) jkrieger@DESKTOP-QL82H8Q /mnt/c/Users/james/code/ProDy (biop_dep) $ ipython
Python 3.8.12 | packaged by conda-forge | (default, Jan 30 2022, 23:42:07) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.0.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import prody

In [2]: exit
```

I didn't get the import error in #1546 and it doesn't seem like most others do either, so still not sure what was wrong there.