### PR TITLE
added prody energy app

### DIFF
--- a/prody/apps/prody_apps/__init__.py
+++ b/prody/apps/prody_apps/__init__.py
@@ -15,7 +15,7 @@ path_apps = imp.find_module('apps', [path_prody])[1]
 path_apps = imp.find_module('prody_apps', [path_apps])[1]
 
 PRODY_APPS = ['anm', 'gnm', 'pca', 'eda', 'align', 'blast', 'biomol',
-                  'catdcd', 'contacts', 'fetch', 'select',]
+                  'catdcd', 'contacts', 'fetch', 'select', 'energy']
 
 __all__ = ['prody_main']
 

--- a/prody/apps/prody_apps/prody_energy.py
+++ b/prody/apps/prody_apps/prody_energy.py
@@ -68,7 +68,11 @@ def prody_energy(*pdbs, **kwargs):
         
         for i in range(ag.numCoordsets()):
             
-            ag = parsePDB(pdb, model=i+1)
+            model_num = i + 1
+            
+            LOGGER.info('\nAnalysing model {0} from {1}'.format(model_num, pdb))
+            
+            ag = parsePDB(pdb, model=model_num)
 
             clu = ClustENM()
             clu.setAtoms(ag)
@@ -89,7 +93,7 @@ def prody_energy(*pdbs, **kwargs):
             f.write(str(energy) + " kJ/mol\n")
         
         f.close()
-        LOGGER.info('Energy is written into: ' + outname)
+        LOGGER.info('\nEnergy is written into: ' + outname + '\n')
 
 
 

--- a/prody/apps/prody_apps/prody_energy.py
+++ b/prody/apps/prody_apps/prody_energy.py
@@ -1,0 +1,155 @@
+"""Extract a selection of atoms from a PDB file."""
+
+from ..apptools import *
+
+__all__ = ['prody_select']
+
+def prody_energy(*pdbs, **kwargs):
+    """Write out potential energy in kJ/mol from OpenMM using ClustENM wrapper.
+
+    :arg pdbs: PDB identifier(s) or filename(s)
+
+    :arg output: output filename, default is :file:`pdb_selected.pdb`
+
+    :arg prefix: prefix for output file, default is PDB filename
+
+    :arg suffix: output filename suffix, default is :file:`_selected`
+    
+    :arg solvent: "imp" for implicit solvent (default) or "exp" for explicit solvent
+    
+    :arg padding: padding in nanometers
+    
+    :arg force_field_protein: name of force field for protein in OpenMM
+        default depends on solvent type as in ClustENM
+    
+    :arg force_field_sol: name of force field for solvent in OpenMM 
+        default depends on solvent type as in ClustENM
+        
+    :arg model: model to analyse. Default is use all
+    """
+
+    from os.path import isfile
+    from prody import LOGGER, parsePDB, ClustENM
+
+    if not pdbs:
+        raise ValueError('pdb argument must be provided')
+
+    prefix = kwargs.get('prefix', None)
+    suffix = kwargs.get('suffix', '_energy')
+    output = kwargs.get('output', None)
+    altloc = kwargs.get('altloc', None)
+    
+    sol = kwargs.get('solvent', 'imp')
+    if sol not in ["imp", "exp"]:
+        LOGGER.warn('Solvent {0} did not match "imp" or "exp".'
+                    .format(repr(sol)))
+        return
+        
+    padding = kwargs.get('padding', 1.0)
+    
+    force_field_protein = kwargs.get('force_field_protein', None)
+    force_field_solvent = kwargs.get('force_field_solvent', None)
+    
+    model = kwargs.get('model', 0)
+    if model == 0:
+        model = None
+    
+    force_field = (force_field_protein, force_field_solvent)
+    if force_field == (None, None):
+        force_field = None
+
+    for pdb in pdbs:
+        ag = parsePDB(pdb, model=model)
+
+        outname = output or ((prefix or ag.getTitle()) + suffix)
+        if outname[-4] != '.':
+            outname += '.txt'        
+        f = open(outname, 'w')
+        
+        for i in range(ag.numCoordsets()):
+            
+            ag = parsePDB(pdb, model=i+1)
+
+            clu = ClustENM()
+            clu.setAtoms(ag)
+            
+            clu._sol = sol
+            
+            if clu._sol == 'imp':
+                clu._force_field = ('amber99sbildn.xml', 'amber99_obc.xml') if force_field is None else force_field
+            if clu._sol == 'exp':
+                clu._force_field = ('amber14-all.xml', 'amber14/tip3pfb.xml') if force_field is None else force_field
+                
+            clu._padding = padding
+            
+            simulation = clu._prep_sim(clu._atoms.getCoords())
+            state = simulation.context.getState(getEnergy=True)
+            energy = state.getPotentialEnergy()._value
+            
+            f.write(str(energy) + " kJ/mol\n")
+        
+        f.close()
+        LOGGER.info('Energy is written into: ' + outname)
+
+
+
+def addCommand(commands):
+
+    subparser = commands.add_parser('energy',
+    help='fix missing atoms, solvate and write a file containing energy')
+
+    subparser.add_argument('--quiet', help="suppress info messages to stderr",
+        action=Quiet, nargs=0)
+
+    subparser.add_argument('--examples', action=UsageExample, nargs=0,
+        help='show usage examples and exit')
+    
+    subparser.add_argument('-m', '--model', dest='model', type=int,
+        default=0, metavar='INT',
+        help=('index of model that will be used in the calculations (default: all of them)'))
+
+    subparser.set_defaults(usage_example=
+    """This command selects specified atoms and writes them in a PDB file.
+
+Fetch PDB files 1p38 and 1r39 and write backbone atoms in a file:
+
+  $ prody select backbone 1p38 1r39""",
+    test_examples=[0])
+
+
+    group = subparser.add_argument_group('output options')
+
+    group.add_argument('-o', '--output', dest='output', metavar='STR',
+        type=str, help='output PDB filename (default: pdb_energy.txt)')
+
+    group.add_argument('-p', '--prefix', dest='prefix', metavar='STR',
+        type=str, help=('output filename prefix (default: PDB filename)'))
+
+    group.add_argument('-x', '--suffix', dest='suffix', metavar='STR',
+        type=str, default='_energy',
+        help=('output filename suffix (default: %(default)s)'))
+
+    subparser.add_argument('pdb', nargs='+',
+        help='PDB identifier(s) or filename(s)')
+
+    subparser.set_defaults(func=lambda ns: prody_energy(*ns.pdb,
+                                                        **ns.__dict__))
+    subparser.set_defaults(subparser=subparser)
+    
+    group_energy = subparser.add_argument_group('energy options')
+
+    group_energy.add_argument('-s', '--solvent', 
+                              dest='solvent', metavar='STR',
+                              type=str, default="imp",
+            help=('name of force field for protein in OpenMM (default: %(default)s)'))
+    
+    group_energy.add_argument('-P', '--force_field_protein', 
+                              dest='force_field_protein', metavar='STR',
+                              type=str, default=None,
+            help=('name of force field for protein in OpenMM (default: ClustENM default)'))
+
+    group_energy.add_argument('-S', '--force_field_sol', 
+                              dest='force_field_sol', metavar='STR',
+                              type=str, default=None,
+            help=('name of force field for solvent in OpenMM (default: ClustENM default)'))
+    


### PR DESCRIPTION
There is now a `prody energy` app that can fix missing atoms, solvate and calculate energy.
```
(scipion3) jkrieger@DESKTOP-QL82H8Q /mnt/c/Users/james/code/ProDy (energy_app) $ prody --help
usage: prody [-h] [-c] [-v] {anm,gnm,pca,eda,align,blast,biomol,catdcd,contacts,fetch,select,energy} ...

ProDy: A Python Package for Protein Dynamics Analysis

optional arguments:
  -h, --help            show this help message and exit
  -c, --cite            print citation info and exit
  -v, --version         print ProDy version and exit

subcommands:
  {anm,gnm,pca,eda,align,blast,biomol,catdcd,contacts,fetch,select,energy}
    anm                 perform anisotropic network model calculations
    gnm                 perform Gaussian network model calculations
    pca                 perform principal component analysis calculations
    eda                 perform essential dynamics analysis calculations
    align               align models or structures
    blast               blast search Protein Data Bank
    biomol              build biomolecules
    catdcd              concatenate dcd files
    contacts            identify contacts between a target and ligand(s)
    fetch               fetch a PDB file
    select              select atoms and write a PDB file
    energy              fix missing atoms, solvate and write a file containing energy

See 'prody <command> -h' for more information on a specific command.
(scipion3) jkrieger@DESKTOP-QL82H8Q /mnt/c/Users/james/code/ProDy (energy_app) $ prody energy --help
usage: prody energy [-h] [--quiet] [--examples] [-m INT] [-o STR] [-p STR] [-x STR] [-s STR] [-P STR] [-S STR] pdb [pdb ...]

positional arguments:
  pdb                   PDB identifier(s) or filename(s)

optional arguments:
  -h, --help            show this help message and exit
  --quiet               suppress info messages to stderr
  --examples            show usage examples and exit
  -m INT, --model INT   index of model that will be used in the calculations (default: all of them)

output options:
  -o STR, --output STR  output PDB filename (default: pdb_energy.txt)
  -p STR, --prefix STR  output filename prefix (default: PDB filename)
  -x STR, --suffix STR  output filename suffix (default: _energy)

energy options:
  -s STR, --solvent STR
                        name of force field for protein in OpenMM (default: imp)
  -P STR, --force_field_protein STR
                        name of force field for protein in OpenMM (default: ClustENM default)
  -S STR, --force_field_sol STR
                        name of force field for solvent in OpenMM (default: ClustENM default)
```

It can be provided with multiple pdb or mmcif files like the `prody select` app. 

If a file has multiple models, then all of them are analysed unless one is selected.

```
(scipion3) jkrieger@DESKTOP-QL82H8Q /mnt/c/Users/james/code/ProDy (energy_app) $ prody energy prody/tests/datafiles/pdb2k39_truncated.pdb prody/tests/datafiles/pdb1ejg.pdb 
@> 167 atoms and 3 coordinate set(s) were parsed in 0.01s.
@> Secondary structures were assigned to 6 residues.
@> 
Analysing model 1 from prody/tests/datafiles/pdb2k39_truncated.pdb
@> 167 atoms and 1 coordinate set(s) were parsed in 0.01s.
@> Secondary structures were assigned to 6 residues.
@> Fixing the structure ...
Warning: importing 'simtk.openmm' is deprecated.  Import 'openmm' instead.
@> 168 atoms and 1 coordinate set(s) were parsed in 0.00s.
@> The structure was fixed in 1.85s.
@> 
Analysing model 2 from prody/tests/datafiles/pdb2k39_truncated.pdb
@> 167 atoms and 1 coordinate set(s) were parsed in 0.01s.
@> Secondary structures were assigned to 6 residues.
@> Fixing the structure ...
@> 168 atoms and 1 coordinate set(s) were parsed in 0.00s.
@> The structure was fixed in 0.57s.
@> 
Analysing model 3 from prody/tests/datafiles/pdb2k39_truncated.pdb
@> 167 atoms and 1 coordinate set(s) were parsed in 0.01s.
@> Secondary structures were assigned to 6 residues.
@> Fixing the structure ...
@> 168 atoms and 1 coordinate set(s) were parsed in 0.00s.
@> The structure was fixed in 0.56s.
@> 
Energy is written into: pdb2k39_truncated_energy.txt

@> 637 atoms and 1 coordinate set(s) were parsed in 0.02s.
@> Secondary structures were assigned to 27 residues.
@> 
Analysing model 1 from prody/tests/datafiles/pdb1ejg.pdb
@> 637 atoms and 1 coordinate set(s) were parsed in 0.02s.
@> Secondary structures were assigned to 27 residues.
@> Fixing the structure ...
@> 642 atoms and 1 coordinate set(s) were parsed in 0.01s.
@> The structure was fixed in 0.39s.
@> 
Energy is written into: 1ejg_energy.txt
```

2k39_truncated_energy.txt:
```
-692.0694580078125 kJ/mol
-772.9723510742188 kJ/mol
-650.1993408203125 kJ/mol

```

1ejg_energy.txt:
```
-5247.2431640625 kJ/mol

```