### PR TITLE
added match_func sameChainPos

### DIFF
--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -26,7 +26,7 @@ if PY3K:
     basestring = str
 
 __all__ = ['matchChains', 'matchAlign', 'mapChainOntoChain', 'mapOntoChain', 'alignChains',
-           'mapOntoChains', 'bestMatch', 'sameChid', 'userDefined', 
+           'mapOntoChains', 'bestMatch', 'sameChid', 'userDefined', 'sameChainPos',
            'mapOntoChainByAlignment', 'getMatchScore', 'setMatchScore',
            'getMismatchScore', 'setMismatchScore', 'getGapPenalty', 
            'setGapPenalty', 'getGapExtPenalty', 'setGapExtPenalty',
@@ -1150,6 +1150,17 @@ def userDefined(chain1, chain2, correspondence):
 
 def sameChid(chain1, chain2):
     return chain1.getChid() == chain2.getChid()
+
+def sameChainPos(chain1, chain2):
+    chids_arr1 = np.array([chain.getChid() 
+                           for chain in list(chain1.getAtomGroup().getHierView())])
+    position1 = np.where(chids_arr1 == chain1.getChid())[0][0]
+    
+    chids_arr2 = np.array([chain.getChid() 
+                           for chain in list(chain2.getAtomGroup().getHierView())])
+    position2 = np.where(chids_arr2 == chain2.getChid())[0][0]
+                         
+    return position1 == position2
 
 def bestMatch(chain1, chain2):
     return True


### PR DESCRIPTION
This match_func is for cases where the two structures have different chain IDs so `sameChid` can't be used. It produces a similarly robust chain matching, which is not sensitive to selections and things like `bestMatch`.

```
In [2]: ags = parsePDB(['3hsy', '3o21', '3p3w'], biomol=True, extend_biomol=True, subset='ca', compressed=False)

In [3]: [list(ag.getHierView()) for ag in ags]
Out[3]: 
[[<Chain: A from Segment A from 3hsy_ca biomolecule 1 (354 residues, 354 atoms)>,
  <Chain: B from Segment A from 3hsy_ca biomolecule 1 (376 residues, 376 atoms)>],
 [<Chain: A from Segment A from 3o21_ca biomolecule 1 (374 residues, 374 atoms)>,
  <Chain: B from Segment A from 3o21_ca biomolecule 1 (365 residues, 365 atoms)>],
 [<Chain: C from Segment A from 3o21_ca biomolecule 2 (375 residues, 375 atoms)>,
  <Chain: D from Segment A from 3o21_ca biomolecule 2 (375 residues, 375 atoms)>],
 [<Chain: A from Segment A from 3p3w_ca biomolecule 1 (373 residues, 373 atoms)>,
  <Chain: C from Segment A from 3p3w_ca biomolecule 1 (362 residues, 362 atoms)>],
 [<Chain: B from Segment A from 3p3w_ca biomolecule 2 (374 residues, 374 atoms)>,
  <Chain: D from Segment A from 3p3w_ca biomolecule 2 (373 residues, 373 atoms)>]]

In [4]: amaps_2_0_sc = alignChains(ags[2], ags[0], match_func=sameChid); amaps_2_0_sc
Out[4]: []

In [5]: amaps_2_0_bm = alignChains(ags[2], ags[0]); amaps_2_0_bm
Out[5]: [<AtomMap: (Chain C from 3o21_ca biomolecule 2 -> Chain B from 3hsy_ca biomolecule 1) + (Chain D from 3o21_ca biomolecule 2 -> Chain A from 3hsy_ca biomolecule 1) from 3o21_ca biomolecule 2 (730 atoms, 704 mapped, 26 dummy)>]

In [6]: amaps_2_0_sel_bm = alignChains(ags[2].select('resnum 1 to 300'), ags[0]); amaps_2_0_sel_bm
Out[6]: [<AtomMap: (Chain D from 3o21_ca biomolecule 2 -> Chain B from 3hsy_ca biomolecule 1) + (Chain C from 3o21_ca biomolecule 2 -> Chain A from 3hsy_ca biomolecule 1) from 3o21_ca biomolecule 2 (730 atoms, 552 mapped, 178 dummy)>]

In [7]: amaps_2_0_scp = alignChains(ags[2], ags[0], match_func=sameChainPos); amaps_2_0_scp
Out[7]: [<AtomMap: (Chain D from 3o21_ca biomolecule 2 -> Chain B from 3hsy_ca biomolecule 1) + (Chain C from 3o21_ca biomolecule 2 -> Chain A from 3hsy_ca biomolecule 1) from 3o21_ca biomolecule 2 (730 atoms, 664 mapped, 66 dummy)>]

In [8]: amaps_2_0_sel_scp = alignChains(ags[2].select('resnum 1 to 300'), ags[0], match_func=sameChainPos); amaps_2_0_sel_scp
Out[8]: [<AtomMap: (Chain D from 3o21_ca biomolecule 2 -> Chain B from 3hsy_ca biomolecule 1) + (Chain C from 3o21_ca biomolecule 2 -> Chain A from 3hsy_ca biomolecule 1) from 3o21_ca biomolecule 2 (730 atoms, 552 mapped, 178 dummy)>]
```

We should really have tests for each match_func and also for buildPDBEnsemble, alignChains, mapOntoChains, mapChainOntoChain, etc. generally