### PR TITLE
use 4-digit hy36 numbers for segments

### DIFF
--- a/prody/proteins/header.py
+++ b/prody/proteins/header.py
@@ -11,7 +11,7 @@ from prody.atomic import ATOMIC_FIELDS
 from prody.atomic import Atomic, AtomGroup
 from prody.atomic import getSequence
 from prody.measure import Transformation
-from prody.utilities import openFile
+from prody.utilities import openFile, decToHybrid36
 
 from .localpdb import fetchPDB
 
@@ -1114,7 +1114,7 @@ def buildBiomolecules(header, atoms, biomol=None):
             newag = atoms.select('chain ' + ' '.join(mt[times*4+0])).copy()
             if newag is None:
                 continue
-            newag.all.setSegnames(segnm.pop(0))
+            newag.all.setSegnames(decToHybrid36(times+1,resnum=True))
             for acsi in range(newag.numCoordsets()):
                 newag.setACSIndex(acsi)
                 newag = t.apply(newag)


### PR DESCRIPTION
This allows support for more segments for biomol assemblies than 26 repeating ones.