### PR TITLE
Proper handling of fragments when bonds are absent

### DIFF
--- a/prody/atomic/atomgroup.py
+++ b/prody/atomic/atomgroup.py
@@ -1652,8 +1652,7 @@ class AtomGroup(Atomic):
         information."""
 
         if self._bmap is None:
-            raise ValueError('bonds must be set for fragment determination, '
-                             'use `setBonds` or `inferBonds` to set them')
+            return None
 
         fids = np.zeros(self._n_atoms, int)
         fdict = {}

--- a/prody/atomic/atomgroup.py
+++ b/prody/atomic/atomgroup.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from prody import LOGGER, PY2K
 from prody.kdtree import KDTree
-from prody.utilities import checkCoords, rangeString, getDistance
+from prody.utilities import checkCoords, rangeString, getDistance, copy
 
 from .atomic import Atomic
 from .fields import ATOMIC_FIELDS, READONLY
@@ -1627,6 +1627,8 @@ class AtomGroup(Atomic):
         """Returns number of connected atom subsets."""
 
         self._fragment()
+        if self._fragments is None:
+            return 0
         return self._data['fragindex'].max() + 1
 
     def iterFragments(self):
@@ -1637,6 +1639,9 @@ class AtomGroup(Atomic):
             acsi = self._acsi
             if self._fragments is None:
                 self._fragment()
+                if self._fragments is None:
+                    return
+
             for i, frag in enumerate(self._fragments):
                 try:
                     frag.getAtomGroup()
@@ -1652,7 +1657,11 @@ class AtomGroup(Atomic):
         information."""
 
         if self._bmap is None:
-            return None
+            LOGGER.warn('bonds must be set for fragment determination, '
+                        'use `setBonds` or `inferBonds` to set them')
+            self._data['fragindex'] = None
+            self._fragments = None
+            return
 
         fids = np.zeros(self._n_atoms, int)
         fdict = {}
@@ -1711,10 +1720,10 @@ for fname, field in ATOMIC_FIELDS.items():
         if not field.private:
             def getData(self, var=fname, call=field.call):
                 try:
-                    return self._data[var].copy()
+                    return copy(self._data[var])
                 except KeyError:
                     [getattr(self, meth)() for meth in call]
-                    return self._data[var].copy()
+                    return copy(self._data[var])
 
         # Define private method for retrieving actual data array
         def _getData(self, var=fname, call=field.call):
@@ -1722,12 +1731,12 @@ for fname, field in ATOMIC_FIELDS.items():
                 return self._data[var]
             except KeyError:
                 [getattr(self, meth)() for meth in call]
-                return self._data[var].copy()
+                return copy(self._data[var])
     else:
         if not field.private:
             def getData(self, var=fname):
                 try:
-                    return self._data[var].copy()
+                    return copy(self._data[var])
                 except KeyError:
                     pass
 

--- a/prody/atomic/functions.py
+++ b/prody/atomic/functions.py
@@ -55,7 +55,7 @@ def saveAtoms(atoms, filename=None, **kwargs):
 
     if filename is None:
         filename = ag.getTitle().replace(' ', '_')
-    if filename.endswith('.npz'):
+    if filename.lower().endswith('.npz'):
         filename += '.ag.npz'
 
     attr_dict = {'title': title}

--- a/prody/atomic/functions.py
+++ b/prody/atomic/functions.py
@@ -55,7 +55,7 @@ def saveAtoms(atoms, filename=None, **kwargs):
 
     if filename is None:
         filename = ag.getTitle().replace(' ', '_')
-    if '.ag.npz' not in filename:
+    if filename.endswith('.npz'):
         filename += '.ag.npz'
 
     attr_dict = {'title': title}

--- a/prody/chromatin/hic.py
+++ b/prody/chromatin/hic.py
@@ -525,9 +525,9 @@ def saveHiC(hic, filename=None, map=True, **kwargs):
     if filename is None:
         filename = hic.getTitle().replace(' ', '_')
     
-    if filename.endswith('.hic'):
+    if filename.lower().endswith('.hic'):
         filename += '.npz'
-    elif not filename.endswith('.hic.npz'):
+    elif not filename.lower().endswith('.hic.npz'):
         filename += '.hic.npz'
 
     attr_dict = hic.__dict__.copy()
@@ -574,9 +574,9 @@ def saveHiC_h5(hic, filename=None, **kwargs):
     if filename is None:
         filename = hic.getTitle().replace(' ', '_')
     
-    if filename.endswith('.hic'):
+    if filename.lower().endswith('.hic'):
         filename += '.hic'
-    elif not filename.endswith('.hic.h5'):
+    elif not filename.lower().endswith('.hic.h5'):
         filename += '.hic.h5'
 
     attr_dict = hic.__dict__.copy()

--- a/prody/dynamics/nmdfile.py
+++ b/prody/dynamics/nmdfile.py
@@ -380,7 +380,7 @@ def writeNMD(filename, modes, atoms):
           before it is written. It's length before normalization will be
           written as the scaling factor of the vector."""
 
-    if not filename.endswith(".nmd"):
+    if not filename.lower().endswith(".nmd"):
         filename += '.nmd'
 
     if not isinstance(modes, (NMA, ModeSet, Mode, Vector)):

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -73,9 +73,9 @@ def saveEnsemble(ensemble, filename=None, **kwargs):
 
     attr_dict['_type'] = ensemble.__class__.__name__
 
-    if filename.endswith('.ens'):
+    if filename.lower().endswith('.ens'):
         filename += '.npz'
-    if not filename.endswith('.npz'):
+    if not filename.lower().endswith('.npz'):
         filename += '.ens.npz'
     ostream = openFile(filename, 'wb', **kwargs)
     np.savez(ostream, **attr_dict)

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1530,8 +1530,8 @@ def writePDB(filename, atoms, csets=None, autoext=True, **kwargs):
     :type renumber: bool
     """
 
-    if not (filename.endswith('.pdb') or filename.endswith('.pdb.gz') or
-            filename.endswith('.ent') or filename.endswith('.ent.gz')):
+    if not (filename.lower().endswith('.pdb') or filename.lower().endswith('.pdb.gz') or
+            filename.lower().endswith('.ent') or filename.lower().endswith('.ent.gz')):
         filename += '.pdb'
     out = openFile(filename, 'wt')
     writePDBStream(out, atoms, csets, **kwargs)

--- a/prody/proteins/starfile.py
+++ b/prody/proteins/starfile.py
@@ -987,7 +987,7 @@ def parseImagesFromSTAR(particlesSTAR, **kwargs):
             raise ValueError('particlesSTAR does not contain data about particle image '
                              '{0} location in either RELION or XMIPP format'.format(i))
 
-        if filename.endswith('.stk'):
+        if filename.lower().endswith('.stk'):
             stk_images.append(str(i))
             continue
 

--- a/prody/trajectory/psffile.py
+++ b/prody/trajectory/psffile.py
@@ -277,7 +277,7 @@ def writePSF(filename, atoms):
     *filename*.  This function will write available atom and bond information
     only."""
 
-    if not filename.endswith('.psf'):
+    if not filename.lower().endswith('.psf'):
         filename = filename + '.psf'
 
     try:

--- a/prody/utilities/pathtools.py
+++ b/prody/utilities/pathtools.py
@@ -207,11 +207,11 @@ def gunzip(filename, outname=None):
 
     if afile:
         if outname is None:
-            if filename.endswith('.gz'):
+            if filename.lower().endswith('.gz'):
                 outname = filename[:-3]
-            elif filename.endswith('.tgz'):
+            elif filename.lower().endswith('.tgz'):
                 outname = filename[:-4] + '.tar'
-            elif filename.endswith('.gzip'):
+            elif filename.lower().endswith('.gzip'):
                 outname = filename[:-5]
             else:
                 outname = filename


### PR DESCRIPTION
**Old behavior:** calling `atom.getFragindex()` without bond info would lead to an error.
**New behavior:** calling `atom.getFragindex()` without bond info would return `None` and a warning.

The reason for this change is that raising an error for calling a `get` function seems to be too harsh. Besides, the new behavior provides an easier way (checking if `None` vs. catching an error) to programmatically check if the bond/fragment information is present.