### PR TITLE
Error during writeout PQR file

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1617,7 +1617,7 @@ def writePQRStream(stream, atoms, **kwargs):
             for item2 in sorted_sheet[i-num_strands:i]:
                 item2.append(num_strands)
 
-    num_strands = item1[1]
+    num_strands = len(num_strands_list)
     for item2 in sorted_sheet[i-num_strands+1:]:
         item2.append(num_strands)
 


### PR DESCRIPTION
```
File ~/envs/prody/lib/python3.9/site-packages/prody/proteins/pdbfile.py:1620, in writePQRStream(stream, atoms, **kwargs)
   1617         for item2 in sorted_sheet[i-num_strands:i]:
   1618             item2.append(num_strands)
-> 1620 num_strands = item[1]
   1621 for item2 in sorted_sheet[i-num_strands+1:]:
   1622     item2.append(num_strands)

NameError: name 'item' is not defined
```

**I am not sure but it works after modification**