### PR TITLE
Setting the atoms for ensemble even if the atoms is a subset

### DIFF
--- a/prody/ensemble/ensemble.py
+++ b/prody/ensemble/ensemble.py
@@ -257,15 +257,14 @@ class Ensemble(object):
                 self._indices = None
 
             else: # atoms is a subset
-                if not self._atoms:
-                    try:
-                        ag = atoms.getAtomGroup()
-                    except AttributeError:
-                        ag = atoms
-                    if ag.numAtoms() != n_atoms:
-                        raise ValueError('size mismatch between this ensemble ({0} atoms) and atoms ({1} atoms)'
-                                        .format(n_atoms, ag.numAtoms()))
-                    self._atoms = ag
+                try:
+                    ag = atoms.getAtomGroup()
+                except AttributeError:
+                    ag = atoms
+                if ag.numAtoms() != n_atoms:
+                    raise ValueError('size mismatch between this ensemble ({0} atoms) and atoms ({1} atoms)'
+                                    .format(n_atoms, ag.numAtoms()))
+                self._atoms = ag
                 self._indices, _ = sliceAtoms(self._atoms, atoms)
                 
         else: # if assigning atoms to a new ensemble


### PR DESCRIPTION
Before this change, setting the ensemble's atoms _the second time_ with a subset would subset the ensemble's atoms which is the desired behavior. However, it would not set the underlying atomgroup to the subset's atomgroup, which is inconsistent with the behaviors of calling `ensemble.setAtoms` with any other input types. This may also lead to (hidden) discrepancies between the ensemble's atoms and the atoms the user used to subset.

This issue can be verified by the following script:
```
import prody as pd

prot = pd.parsePDB('3tt1')

ens = pd.Ensemble()
ens.addCoordset(prot)
ens.setAtoms(prot)
title = ens.getAtoms().getTitle()
print(title)

prot2 = prot.copy()
prot2.setTitle("3tt1 copy")

ens.setAtoms(prot2.ca)
title = ens.getAtoms().getTitle()
print(title)
```
**Old behavior:**
```
3tt1
3tt1
```
**New behavior:**
```
3tt1
3tt1 copy
```