### PR TITLE
try fixing tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,7 @@ jobs:
         source activate test
         conda install --yes numpy scipy nose pyparsing biopython requests
         if [[ ${{ matrix.python-version }} == "2.7" ]]; then conda install --yes unittest2; fi
+        python setup.py install
         python setup.py build_ext --inplace --force
     - name: Test with pytest
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.6", "3.9", "3.10", "3.11"]
+        python-version: ["2.7", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2
@@ -27,7 +27,6 @@ jobs:
     - name: Install dependencies
       run: |
         if [[ ${{ matrix.python-version }} == "3.11" ]]; then conda config --add channels conda-forge; fi
-        if [[ ${{ matrix.python-version }} == "3.6" ]]; then conda config --add channels conda-forge; fi
         conda create --yes -n test python=${{ matrix.python-version }}
         source activate test
         conda install --yes numpy scipy nose pyparsing biopython requests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         source activate test
         conda install --yes numpy scipy nose pyparsing biopython requests
         if [[ ${{ matrix.python-version }} == "2.7" ]]; then conda install --yes unittest2; fi
-        python setup.py install
+        pip install .
         python setup.py build_ext --inplace --force
     - name: Test with pytest
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         if [[ ${{ matrix.python-version }} == "3.11" ]]; then conda config --add channels conda-forge; fi
+        if [[ ${{ matrix.python-version }} == "3.6" ]]; then conda config --add channels conda-forge; fi
         conda create --yes -n test python=${{ matrix.python-version }}
         source activate test
         conda install --yes numpy scipy nose pyparsing biopython requests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.9", "3.10", "3.11"]
+        python-version: ["2.7", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=1.10", "pyparsing", "biopython<=1.76", "scipy"]
+requires = ["setuptools", "wheel", "numpy>=1.10,<1.24", "pyparsing", "biopython<=1.76", "scipy"]

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ if sys.version_info[:2] < (2, 7):
     sys.exit()
 
 if sys.version_info[:2] == (2, 7) or sys.version_info[:2] <= (3, 5):
-    INSTALL_REQUIRES=['numpy>=1.10', 'biopython<=1.76', 'pyparsing', 'scipy']
+    INSTALL_REQUIRES=['numpy>=1.10,<1.24', 'biopython<=1.76', 'pyparsing', 'scipy']
 else:
-    INSTALL_REQUIRES=['numpy>=1.10', 'biopython', 'pyparsing', 'scipy']
+    INSTALL_REQUIRES=['numpy>=1.10,<1.24', 'biopython', 'pyparsing', 'scipy']
 
 if sys.version_info[0] == 3:
     if sys.version_info[1] < 6:


### PR DESCRIPTION
1. Remove python 3.6 as we can't even get it from conda-forge now
2. Require numpy older than 1.24 to keep np.bool and suchlike and use `pip install .` to make it check dependencies
3. Remove python 3.11 as the biopython installation mechanism isn't supported either