### PR TITLE
Redefine protein

### DIFF
--- a/prody/atomic/flags.py
+++ b/prody/atomic/flags.py
@@ -789,6 +789,15 @@ def setProtein(ag, label):
         flags = torf[resindices]
     else:
         flags = zeros(ag.numAtoms(), bool)
+        
+    water = ag._getSubset("water")
+    if len(water):
+        flags[water] = False
+        
+    ions = ag._getSubset("ion")
+    if len(ions):
+        flags[ions] = False
+    
     ag._setFlags('protein', flags)
     return flags
 

--- a/prody/tests/atomic/test_select.py
+++ b/prody/tests/atomic/test_select.py
@@ -392,6 +392,13 @@ SELECTION_TESTS['imatinib'] = {
         ('fragindex 0:2', len(ligand)),],
 }
 
+pdb_gromacs = prody.parsePDB(pathDatafile('pdb6fpj_Bb_fixed_solv_ions.pdb'), secondary=True)
+SELECTION_TESTS['gromacs'] = {
+    'n_atoms': len(pdb_gromacs),
+    'ag': pdb_gromacs,
+    'all': pdb_gromacs.all,
+    'test_flags':  [('protein', 12194, 'aminoacid')],
+}
 
 pdb3mht = SELECTION_TESTS['pdb3mht']['ag']
 pdb3mht.setCharges(pdb3mht.getOccupancies())

--- a/prody/tests/datafiles/__init__.py
+++ b/prody/tests/datafiles/__init__.py
@@ -197,6 +197,15 @@ DATA_FILES = {
         'models': 1,
         'biomols': 2
     },
+    'gromacs': {
+        'pdb': '6fpj',
+        'file': 'pdb6fpj_Bb_fixed_solv_ions.pdb',
+        'atoms': 83473,
+        'ca_atoms': 758,
+        'models': 1,
+        'biomols': 1,
+        'protein': 12194
+    },
 }
 
 


### PR DESCRIPTION
Some MD simulation systems, such as those from gromacs, lack chain IDs and therefore create sets of atoms with the same residue indices that are not in fact the same residue:
```
In [1]: from prody import *

In [2]: from prody.tests.datafiles import *

In [3]: pdb_gromacs = prody.parsePDB(
   ...:     pathDatafile("pdb6fpj_Bb_fixed_solv_ions.pdb"), secondary=True
   ...: )
@> 83473 atoms and 1 coordinate set(s) were parsed in 1.07s.

In [4]: list(pdb_gromacs.getHierView())
Out[4]: [<Chain: A from pdb6fpj_Bb_fixed_solv_ions (17290 residues, 83473 atoms)>]

In [5]: pdb_gromacs.select("chain A and resnum 2").getResnames()
Out[5]: 
array(['PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE',
       'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE',
       'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE',
       'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE',
       'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'HOH',
       'HOH', 'HOH', 'HOH', 'HOH', 'HOH'], dtype='<U6')
```

Selecting protein in the old way with this pdb file includes these water molecules as they belong to the same residues:
```
In [7]: pdb_gromacs.select("protein and chain A and resnum 2").getResnames()
Out[7]: 
array(['PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE',
       'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE',
       'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE',
       'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE',
       'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'PHE', 'HOH',
       'HOH', 'HOH', 'HOH', 'HOH', 'HOH'], dtype='<U6')
```
 
![bad_prody](https://user-images.githubusercontent.com/13259162/213757491-a89bce8a-6ca7-4c9b-8e45-00c2d9a1cafd.png)

With the fix, we don't have this problem anymore:
![good_prody](https://user-images.githubusercontent.com/13259162/213757976-29ff4a6c-c585-4c73-9553-8e7cdc83ef40.png)
