### PR TITLE
aligner bug fix

### DIFF
--- a/prody/tests/ensemble/test_functions.py
+++ b/prody/tests/ensemble/test_functions.py
@@ -78,7 +78,7 @@ class TestBuildPDBEnsemble(TestCase):
                         subset="ca",
                         biomol=True, extend_biomol=True)
         
-        ens4 = buildPDBEnsemble(ags, match_func=bestMatch)
+        ens4 = buildPDBEnsemble(biomols, match_func=bestMatch)
         assert_equal(ens4.numConfs(), 5, 
             'buildPDBEnsemble with bestMatch on biomols did not include all AMPAR dimers')    
 

--- a/prody/utilities/seqtools.py
+++ b/prody/utilities/seqtools.py
@@ -87,6 +87,10 @@ def alignBioPairwise(a_sequence, b_sequence,
         for aln in alns:
             row_1 = aln.format().split("\n")[0].replace(" ", "-")
             row_2 = aln.format().split("\n")[2].replace(" ", "-")
+            while len(row_1) < len(row_2):
+                row_1 += "-"
+            while len(row_2) < len(row_1):
+                row_2 += "-"
             begin = max([np.where(np.array(list(row_1)) != "-")[0][0],
                          np.where(np.array(list(row_2)) != "-")[0][0]])
             end = (min([np.where(np.array(list(row_1)) != "-")[0][-1],


### PR DESCRIPTION
The new biopython pairwise aligner outputs are really not so nice and need further processing to avoid problems.

Behaviour from adding the new aligner without the fix:
```
In [1]: from prody import *

In [2]: ags = parsePDB(
   ...:     ["prody/tests/datafiles/pdb3hsy.pdb", "prody/tests/datafiles/pdb3o21.pdb"],
   ...:     biomol=True,
   ...:     extend_biomol=True,
   ...:     subset="ca",
   ...: )
@> 2 PDBs were parsed in 0.17s.                             

In [3]: pdb_ens = buildPDBEnsemble(ags, seqid=50)
@> Mapping 3o21_ca biomolecule 1 to the reference... [ 33%] 1s---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
Input In [3], in <module>
----> 1 pdb_ens = buildPDBEnsemble(ags, seqid=50)

File /mnt/c/Users/james/code/scipion3_new/software/em/ProDy/prody/ensemble/functions.py:471, in buildPDBEnsemble(atomics, ref, title, labels, atommaps, unmapped, **kwargs)
    469 # find the mapping of chains of atoms to those of target
    470 debug[labels[i]] = {}
--> 471 atommaps_ = alignChains(atoms, target, debug=debug[labels[i]], **kwargs)
    473 if len(atommaps_) == 0:
    474     unmapped.append(labels[i])

File /mnt/c/Users/james/code/scipion3_new/software/em/ProDy/prody/proteins/compare.py:1724, in alignChains(atoms, target, match_func, **kwargs)
   1718 def alignChains(atoms, target, match_func=bestMatch, **kwargs):
   1719     """Aligns chains of *atoms* to those of *target* using :func:`.mapOntoChains` 
   1720     and :func:`.combineAtomMaps`. Please check out those two functions for details 
   1721     about the parameters.
   1722     """
-> 1724     mappings = mapOntoChains(atoms, target, match_func, **kwargs)
   1725     m, n = mappings.shape
   1726     if m > n:

File /mnt/c/Users/james/code/scipion3_new/software/em/ProDy/prody/proteins/compare.py:1228, in mapOntoChains(atoms, ref, match_func, **kwargs)
   1225             continue
   1227         simple_target = target_chain if isinstance(target_chain, SimpleChain) else SimpleChain(target_chain, False)
-> 1228         mappings[i, j] = mapChainOntoChain(simple_target, simple_chain, **kwargs)
   1230 return mappings

File /mnt/c/Users/james/code/scipion3_new/software/em/ProDy/prody/proteins/compare.py:1047, in mapChainOntoChain(mobile, target, **kwargs)
   1045     result = getCEAlignMapping(simple_target, simple_mobile)
   1046 elif method == 'seq':
-> 1047     result = getAlignedMapping(simple_target, simple_mobile)
   1048 else:
   1049     if isinstance(alignment, dict):

File /mnt/c/Users/james/code/scipion3_new/software/em/ProDy/prody/proteins/compare.py:1391, in getAlignedMapping(target, chain, alignment)
   1389 for i in range(len(this)):
   1390     a = this[i]
-> 1391     b = that[i]
   1392     if a not in gap_chars:
   1393         ares = next(aiter)

IndexError: string index out of range
```

It turns out that `this` and `that` can get different lengths and this is the case for chain B:
```
In [4]: from prody.utilities import (
   ...:     MATCH_SCORE,
   ...:     MISMATCH_SCORE,
   ...:     GAP_PENALTY,
   ...:     GAP_EXT_PENALTY,
   ...:     ALIGNMENT_METHOD,
   ...:     alignBioPairwise,
   ...: )

In [5]: from prody.proteins.compare import SimpleChain

In [6]: simple_mobile = SimpleChain(ags[1]["B"], False)

In [7]: simple_target = SimpleChain(ags[0]["B"], False)

In [8]: alignments = alignBioPairwise(
   ...:     simple_target.getSequence(),
   ...:     simple_mobile.getSequence(),
   ...:     "local",
   ...:     MATCH_SCORE,
   ...:     MISMATCH_SCORE,
   ...:     GAP_PENALTY,
   ...:     GAP_EXT_PENALTY,
   ...:     one_alignment_only=1,
   ...: )

In [9]: this = alignments[0][0]
   ...: this
Out[9]: '--NSIQIGGLFPRGADQEYSAFRVGMVQFSTSEFRLTPHIDNLEVANSFAVTNAFCSQFSRGVYAIFGFYDKKSVNTITSFCGTLHVSFITPSFPTDGTHPFVIQMRPDLKGALLSLIEYYQWDKFAYLYDSDRGLSTLQAVLDSAAEKKWQVTAINVGNINNDKKDETYRSLFQDLELKKERRVILDCERDKVNDIVDQVITIGKHVKGYHYIIANLGFTDGDLLKIQFGGANVSGFQIVDYDDSLVSKFIERWSTLEEKEYPGAHTATIKYTSALTYDAVQVMTEAFRNLRKQRIEISRRGNAGDCLANPAVPWGQGVEIERALKQVQVEGLSGNIKFDQNGKRINYTINIMELKTNGPRKIGYWSEVDKMVVTLT'

In [10]: that = alignments[0][1]
    ...: that
Out[10]: 'FPNTISIGGLFMRNTVQEHSAFR-FAVQLYNTPFHLNYHVDHLDSSNSFSVTNAFCSQFSRGVYAIFGFYDQMSMNTLTSFCGALHTSFVTPSFPTDADVQFVIQMRPALKGAILSLLSYYKWEKFVYLYDTERGFSVLQAIMEAAVQNNWQVTARSVGNI---KDVQEFRRIIEEMDRRQEKRYLIDCEVERINTILEQVVILGKHSRGYHYMLANLGFTDILLERVMHGGANITGFQIVNNENPMVQQFIQRWVRLDEREFPEAKNAPLKYTSALTHDAILVIAEAFRYLRRQRVDVS----AGDCL---AVPWSQGIDIERALKMVQVQGMTGNIQFDTYGRRTNYTIDVYEMKVSGSRKAGYWNEYERFVPF'

In [11]: len(this)
Out[11]: 378

In [12]: len(that)
Out[12]: 376
```

The fix adds extra gaps on the end of whichever one ends up shorter and then everything works as expected:
```
In [1]: from prody import *

In [2]: ags = parsePDB(
   ...:     ["prody/tests/datafiles/pdb3hsy.pdb", "prody/tests/datafiles/pdb3o21.pdb"],
   ...:     biomol=True,
   ...:     extend_biomol=True,
   ...:     subset="ca",
   ...: )
@> 2 PDBs were parsed in 0.16s.                             

In [3]: pdb_ens = buildPDBEnsemble(ags, seqid=50)
@> Starting iterative superposition:                          
@> Step #1: RMSD difference = 2.1829e+00
@> Step #2: RMSD difference = 2.2806e-03
@> Step #3: RMSD difference = 2.7787e-05
@> Iterative superposition completed in 0.00s.
@> Final superposition to calculate transformations.
@> Superposition completed in 0.00 seconds.
@> Ensemble (3 conformations) were built in 0.29s.
```
```