### PR TITLE
fix axes3d for new matplotlib

### DIFF
--- a/prody/chromatin/functions.py
+++ b/prody/chromatin/functions.py
@@ -212,7 +212,7 @@ def showEmbedding(modes, labels=None, trace=True, headtail=True, cmap='prism'):
         X, Y, Z = V[:,:3].T
         
         f = figure()
-        ax = Axes3D(f)
+        ax = f.add_subplot(projection="3d")
         if trace:
             ax.plot(X, Y, Z, ':', color=[0.3, 0.3, 0.3])
         if labels is None:

--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -108,7 +108,7 @@ def showEllipsoid(modes, onto=None, n_std=2, scale=1., *args, **kwargs):
             show = child
             break
     if show is None:
-        show = Axes3D(cf)
+        show = cf.add_subplot(projection="3d")
     show.plot_wireframe(x, y, z, rstride=6, cstride=6, *args, **kwargs)
     if onto is not None:
         onto = list(onto)
@@ -324,7 +324,7 @@ def showProjection(ensemble, modes, *args, **kwargs):
                 show = child
                 break
         if show is None:
-            show = Axes3D(cf)
+            show = cf.add_subplot(projection="3d")
         plot = show.plot
         text = show.text
 

--- a/prody/proteins/functions.py
+++ b/prody/proteins/functions.py
@@ -262,7 +262,7 @@ def showProtein(*atoms, **kwargs):
                 show = child
                 break
         if show is None:
-            show = Axes3D(cf)
+            show = cf.add_subplot(projection="3d")
         from matplotlib import colors
         cnames = dict(colors.cnames)
         wcolor = kwargs.get('water', 'red').lower()


### PR DESCRIPTION
fixes #1647 and similar issues for showProjection, showEllipsoid and presumably chromatin showEmbedding. I wasn't able to test the chromatin one, but I have managed to confirm that I can make the following figure with both old and new matplotlib as well as using showProtein.
![proj-and-ellipsoid](https://user-images.githubusercontent.com/13259162/215836656-78593247-8560-49ac-a5ca-8d1a6fcc473a.png)

the code is the following using the data from the trajectory analysis files on the prody website:
```
In [1]: from prody import *

In [2]: import matplotlib.pyplot as plt
   ...: 
   ...: plt.ion()
Out[2]: <contextlib.ExitStack at 0x7fd049b2aaa0>

In [3]: ens = parseDCD("mdm2.dcd")
@> DCD file contains 500 coordinate sets for 1449 atoms.
@> DCD file was parsed in 0.02 seconds.
@> 8.33 MB parsed at input rate 343.18 MB/s.
@> 500 coordinate sets parsed at input rate 20600 frame/s.

In [4]: ag = parsePDB("mdm2.pdb")
@> 1449 atoms and 1 coordinate set(s) were parsed in 0.01s.

In [5]: ens.setAtoms(ag.ca)

In [6]: pca = PCA(ens)

In [7]: pca.buildCovariance(ens)
@> Covariance is calculated using 500 coordinate sets.
@> Covariance matrix calculated in 0.088470s.

In [8]: pca.calcModes()
@> 20 modes were calculated in 0.06s.

In [9]: showProjection(ens, pca[:3])
Out[9]: <Axes3DSubplot: xlabel='Mode 1 coordinate', ylabel='Mode 2 coordinate', zlabel='Mode 3 coordinate'>

In [10]: showEllipsoid(pca[:3])
Out[10]: <Axes3DSubplot: xlabel='Mode 1 coordinate', ylabel='Mode 2 coordinate', zlabel='Mode 3 coordinate'>
```
