### PR TITLE
ignore_ids option for mergeMSA to use different ids

### DIFF
--- a/prody/sequence/msa.py
+++ b/prody/sequence/msa.py
@@ -658,7 +658,19 @@ def mergeMSA(*msa, **kwargs):
     based on protein identifiers found in the sequence labels.  Order of
     sequences in the merged MSA will follow the order of sequences in the
     first *msa* instance.  Note that protein identifiers that map to multiple
-    sequences will be excluded."""
+    sequences will be excluded.
+    
+    MSAs with different identifiers can be merged with the *ignore_ids* kwarg.
+    This only works when all MSAs have the same number of sequences.
+    
+    :arg msa: a set of :class:`.MSA` objects to be analysed
+    :type msa: list, tuple, :class:`~numpy.ndarray`
+    
+    :arg ignore_ids: where to ignore identifiers instead of matching them
+        Default is False
+    :type ignore_ids: bool
+    """
+    ignore_ids = kwargs.pop('ignore_ids', False)
 
     if len(msa) <= 1:
         raise ValueError('more than one msa instances are needed')
@@ -676,11 +688,20 @@ def mergeMSA(*msa, **kwargs):
     except AttributeError:
         raise TypeError('all msa arguments must be MSA instances')
 
+    num_seqs = [len(aset) for aset in sets]
     sets = iter(sets)
     common = next(sets)
+    if not all(array(num_seqs) == num_seqs[0]):
+        LOGGER.warn("Can only ignore identifiers if all MSAs have the same number of sequences")
+        return None
+    
     for aset in sets:
-        common = common.intersection(aset)
+        if not ignore_ids:
+            common = common.intersection(aset)
+        else:
+            [common.add(item) for item in aset]
     if not common:
+        LOGGER.warn("No sequences with common identifiers to merge")
         return None
 
     lens = [m.numResidues() for m in msa]
@@ -688,17 +709,25 @@ def mergeMSA(*msa, **kwargs):
     rngs.extend(cumsum(lens))
     rngs = [(start, end) for start, end in zip(rngs[:-1], rngs[1:])]
 
-    idx_arr_rng = list(zip([m.getIndex for m in msa], arrs, rngs))
-
-    merger = zeros((len(common), sum(lens)), '|S1')
-    labels = []
-    for index, label in enumerate(common):
-        if label not in common:
-            continue
-        for idx, arr, (start, end) in idx_arr_rng:
-            merger[index, start:end] = arr[idx(label)]
-
-        labels.append(label)
+    if not ignore_ids:
+        idx_arr_rng = list(zip([m.getIndex for m in msa], arrs, rngs))
+        merger = zeros((len(common), sum(lens)), '|S1')
+        labels = []
+        for index, label in enumerate(common):
+            if label not in common:
+                continue
+            for idx, arr, (start, end) in idx_arr_rng:
+                merger[index, start:end] = arr[idx(label)]
+            labels.append(label)
+    else:
+        idx_arr_rng = list(zip([i for i in range(len(msa))], arrs, rngs))
+        merger = zeros((len(num_seqs), sum(lens)), '|S1')
+        labels = msa[0].getLabels()
+        for index, label in enumerate(msa[0].getLabels()):
+            for i, arr, (start, end) in idx_arr_rng:
+                    merger[index, start:end] = arr[index]
+            labels[index] += '_' + msa[i].getLabels()[index]
+            
     merger = MSA(merger, labels=labels,
                  title=' + '.join([m.getTitle() for m in msa]))
     return merger


### PR DESCRIPTION
Fixes #1631 and gives the following additional functionality:
```
In [1]: from prody import *

In [2]: msa1 = parseMSA("prody/tests/datafiles/msa_3hsyA_3o21A.fasta")
@> 2 sequence(s) with 380 residues were parsed in 0.02s.

In [3]: msa1.getLabels()
Out[3]: ['1', '2']

In [4]: msa2 = parseMSA("prody/tests/datafiles/msa_Cys_knot.fasta")
@> 25 sequence(s) with 112 residues were parsed in 0.02s.

In [5]: msa2_ = msa2[1:3]

In [6]: msa2_.getLabels()
Out[6]: ['GTHB2_ONCKE', 'GTHB2_CTEID']

In [7]: merged = mergeMSA(msa1, msa2)
@> WARNING Can only ignore identifiers if all MSAs have the same number of sequences

In [8]: merged = mergeMSA(msa1, msa2, ignore_ids=True)
@> WARNING Can only ignore identifiers if all MSAs have the same number of sequences

In [9]: merged = mergeMSA(msa1, msa2_, ignore_ids=True)

In [10]: merged
Out[10]: <MSA: msa_3hsyA_3o21A + msa_Cys_knot (2 sequences, 492 residues)>

In [11]: merged.getLabels()
Out[11]: ['1_GTHB2_ONCKE', '2_GTHB2_CTEID']

In [12]: showAlignment(merged)
1_GTHB2_ONCKE   --NSIQIGGLFPRGADQEYSAFRVGMVQ-----FSTSE--FRLTPHIDNLEVANSFAVTN
2_GTHB2_CTEID   FPNTISIGGLFMRNTVQEHSAFR-FAVQLYNTNQNTTEKPFHLNYHVDHLDSSNSFSVTN

1_GTHB2_ONCKE   AFCSQFSRGVYAIFGFYDKKSVNTITSFCGTLHVSFITPSFPTDGTHPFVIQMRPDLKGA
2_GTHB2_CTEID   AFCSQFSRGVYAIFGFYDQMSMNTLTSFCGALHTSFVTPSFPTDADVQFVIQMRPALKGA

1_GTHB2_ONCKE   LLSLIEYYQWDKFAYLYDSDRGLSTLQAVLDSAAEKKWQVTAINVGNI-----NRRVI--
2_GTHB2_CTEID   ILSLLSYYKWEKFVYLYDTERGFSVLQAIMEAAVQNNWQVTARSVGNIKDVQEFRRIIEE

1_GTHB2_ONCKE   ---------L-DCERDKVNDIVDQVITIGKHVKGYHYIIANLGFTDGDLLKIQFGGANVS
2_GTHB2_CTEID   MDRRQEKRYLIDCEVERINTILEQVVILGKHSRGYHYMLANLGFTDILLERVMHGGANIT

1_GTHB2_ONCKE   GFQIVDYDDSLVSKFIERWSTLEEKEYPGAHTATIKYTSALTYDAVQVMTEAFRNLRKQR
2_GTHB2_CTEID   GFQIVNNENPMVQQFIQRWVRLDEREFPEAKNAPLKYTSALTHDAILVIAEAFRYLRRQR

1_GTHB2_ONCKE   IEISRRGNAGDCLANPAVPWGQGVEIERALKQVQVEGLSGNIKFDQNGKRINYTINIMEL
2_GTHB2_CTEID   VDVS-----GDCLANPAVPWSQGIDIERALKMVQVQGMTGNIQFDTYGRRTNYTIDVYEM

1_GTHB2_ONCKE   KTNGPRKIGYWSEVDKMVVTMQPCQPIN...QTVSLEKEGCPTCLVIQTPICSGHCVTKE
2_GTHB2_CTEID   KVSGSRKAGYWNEYERFVPFLPPCEPVN...ETVAVEKEGCPKCLVFQTTICSGHCLTKE

1_GTHB2_ONCKE   ..PVFKSPFSTVYQHVCTYRDVRYETIRLPDCPPWVDPHVTYPVALSCDCS..LCNMDTS
2_GTHB2_CTEID   ..PVYKSPFSTVYQHVCTYRDVRYETVRLPDCPPGVDPHITYPVALSCDCS..LCTMDTS

1_GTHB2_ONCKE   DCTIESLQPDFC
2_GTHB2_CTEID   DCTIESLQPDFC
```