### PR TITLE
only split twice in fetchPDB if ending is gz

### DIFF
--- a/prody/proteins/localpdb.py
+++ b/prody/proteins/localpdb.py
@@ -473,7 +473,10 @@ def findPDBFiles(path, case=None, **kwargs):
     pdbs = {}
     for fn in iterPDBFilenames(path, sort=True, reverse=True, **kwargs):
         fn = normpath(fn)
-        pdb = splitext(splitext(split(fn)[1])[0])[0]
+        pdb = splitext(split(fn)[1])[0]
+        ending = splitext(splitext(split(fn)[1])[0])[1]
+        if ending == 'gz':
+            pdb = splittext(pdb)[0]
         if len(pdb) == 7 and pdb.startswith('pdb'):
             pdb = pdb[3:]
         if upper:


### PR DESCRIPTION
Otherwise, we get the following incorrect behaviour, taking a file with two dots in the filename as the original one and not fetching it again:
```
In [1]: from prody import *

In [2]: ag = parsePDB("6xr8", compressed=False)
@> PDB file is found in working directory (6xr8.cif_atoms.pdb).
@> 25998 atoms and 1 coordinate set(s) were parsed in 0.24s.
@> Secondary structures were assigned to 0 residues.
```

With the fix, this doesn't happen:
```
In [1]: from prody import *

In [2]: ag = parsePDB("6xr8", compressed=False)
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> pdb6xr8.ent.gz download failed. 6xr8 does not exist on ftp.wwpdb.org.
@> PDB download via FTP completed (0 downloaded, 1 failed).
@> Downloading PDB files via FTP failed, trying HTTP.
@> WARNING 6xr8 download failed ('https://files.rcsb.org/download/6XR8.pdb.gz' could not be opened for reading, invalid URL or no internet connection).
@> PDB download via HTTP completed (0 downloaded, 1 failed).
@> WARNING Trying to parse mmCIF file instead
@> WARNING Could not find _pdbx_struct_mod_residue in lines.
@> WARNING Could not find _atom_site_anisotrop in lines.
@> WARNING No anisotropic B factors found
@> 27627 atoms and 1 coordinate set(s) were parsed in 0.59s.
@> Secondary structures were assigned to 1927 residues.
```