### PR TITLE
remove pairwise2 check

### DIFF
--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -561,7 +561,7 @@ def matchChains(atoms1, atoms2, **kwargs):
     This function tries to match chains based on residue numbers and names.
     All chains in *atoms1* is compared to all chains in *atoms2*.  This works
     well for different structures of the same protein.  When it fails,
-    :mod:`Bio.pairwise2` is used for pairwise sequence alignment, and matching
+    Biopython is used for pairwise sequence alignment, and matching
     is performed based on the sequence alignment.  User can control, whether
     sequence alignment is performed or not with *pwalign* keyword.  If
     ``pwalign=True`` is passed, pairwise alignment is enforced."""
@@ -648,30 +648,27 @@ def matchChains(atoms1, atoms2, **kwargs):
                     unmatched.append((simpch1, simpch2))
 
     if pwalign or (not matches and (pwalign is None or pwalign)):
-        if pairwise2:
-            if unmatched:
-                LOGGER.debug('Trying to match chains based on {0} sequence '
-                            'alignment:'.format(ALIGNMENT_METHOD))
-                for simpch1, simpch2 in unmatched:
-                    LOGGER.debug(' Comparing {0} (len={1}) and {2} '
-                                '(len={3}):'
-                                .format(simpch1.getTitle(), len(simpch1),
-                                        simpch2.getTitle(), len(simpch2)))
-                    match1, match2, nmatches = getAlignedMatch(simpch1, simpch2)
-                    _seqid = nmatches * 100 / min(len(simpch1), len(simpch2))
-                    _cover = len(match2) * 100 / max(len(simpch1), len(simpch2))
-                    if _seqid >= seqid and _cover >= coverage:
-                        LOGGER.debug('\tMatch: {0} residues match with {1:.0f}% '
-                                    'sequence identity and {2:.0f}% overlap.'
-                                    .format(len(match1), _seqid, _cover))
-                        matches.append((match1, match2, _seqid, _cover,
-                                        simpch1, simpch2))
-                    else:
-                        LOGGER.debug('\tFailed to match chains (seqid={0:.0f}%, '
-                                    'overlap={1:.0f}%).'
-                                    .format(_seqid, _cover))
-        else:
-            LOGGER.warning('Pairwise alignment could not be performed.')
+        if unmatched:
+            LOGGER.debug('Trying to match chains based on {0} sequence '
+                        'alignment:'.format(ALIGNMENT_METHOD))
+            for simpch1, simpch2 in unmatched:
+                LOGGER.debug(' Comparing {0} (len={1}) and {2} '
+                            '(len={3}):'
+                            .format(simpch1.getTitle(), len(simpch1),
+                                    simpch2.getTitle(), len(simpch2)))
+                match1, match2, nmatches = getAlignedMatch(simpch1, simpch2)
+                _seqid = nmatches * 100 / min(len(simpch1), len(simpch2))
+                _cover = len(match2) * 100 / max(len(simpch1), len(simpch2))
+                if _seqid >= seqid and _cover >= coverage:
+                    LOGGER.debug('\tMatch: {0} residues match with {1:.0f}% '
+                                'sequence identity and {2:.0f}% overlap.'
+                                .format(len(match1), _seqid, _cover))
+                    matches.append((match1, match2, _seqid, _cover,
+                                    simpch1, simpch2))
+                else:
+                    LOGGER.debug('\tFailed to match chains (seqid={0:.0f}%, '
+                                'overlap={1:.0f}%).'
+                                .format(_seqid, _cover))
     if not matches:
         return None
     subset = _SUBSETS[subset]
@@ -929,7 +926,7 @@ def mapChainOntoChain(mobile, target, **kwargs):
         fails. If ``"ce"`` or ``"cealign"``, then the CE algorithm [IS98]_ will be 
         performed. It can also be a list of prealigned sequences, a :class:`.MSA` instance,
         or a dict of indices such as that derived from a :class:`.DaliRecord`.
-        If set to **True** then the sequence alignment from :mod:`~Bio.pairwise2` 
+        If set to **True** then the sequence alignment from Biopython 
         will be used. If set to **False**, only the trivial mapping will be performed. 
         Default is **"auto"**
     :type mapping: list, str, bool


### PR DESCRIPTION
This check is very ancestral and should have been removed a while ago. ProDy now depends on Biopython and handles pairwise alignment versions fine and the importBioPairwise2 function doesn't exist anymore, so we wouldn't have a case where the pairwise2 option isn't available and this variable is set to False.

This was picked up in #1653 in response to changes related to non-protein residues