### PR TITLE
add unite_chains option to parseMMCIF

### DIFF
--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -69,9 +69,14 @@ def parseMMCIF(pdb, **kwargs):
 
     :arg chain: comma separated string or list-like of chain IDs
     :type chain: str, tuple, list, :class:`~numpy.ndarray`
+
+    :arg unite_chains: unite chains with the same segment name
+        Default is *False*
+    :type unite_chains: bool
     """
     chain = kwargs.pop('chain', None)
     title = kwargs.get('title', None)
+    unite_chains = kwargs.get('unite_chains', False)
     auto_bonds = SETTINGS.get('auto_bonds')
     get_bonds = kwargs.get('bonds', auto_bonds)
     if get_bonds:
@@ -116,6 +121,8 @@ def parseMMCIF(pdb, **kwargs):
     cif = openFile(pdb, 'rt')
     result = parseMMCIFStream(cif, chain=chain, **kwargs)
     cif.close()
+    if unite_chains:
+        result.setSegnames(result.getChids())
     return result
 
 


### PR DESCRIPTION
Helps with #1666 

New behaviour:
```
In [1]: from prody import *

In [2]: structure = parseMMCIF("2jfz")

In [3]: list(structure.getHierView())
Out[3]: 
[<Chain: A from Segment A from 2jfz (255 residues, 2012 atoms)>,
 <Chain: B from Segment B from 2jfz (249 residues, 1959 atoms)>,
 <Chain: A from Segment C from 2jfz (1 residues, 33 atoms)>,
 <Chain: A from Segment D from 2jfz (1 residues, 10 atoms)>,
 <Chain: B from Segment E from 2jfz (1 residues, 33 atoms)>,
 <Chain: B from Segment F from 2jfz (1 residues, 10 atoms)>,
 <Chain: A from Segment G from 2jfz (228 residues, 228 atoms)>,
 <Chain: B from Segment H from 2jfz (222 residues, 222 atoms)>]

In [4]: structure = parseMMCIF("2jfz", unite_chains=True)

In [5]: list(structure.getHierView())
Out[5]: 
[<Chain: A from Segment A from 2jfz (485 residues, 2283 atoms)>,
 <Chain: B from Segment B from 2jfz (473 residues, 2224 atoms)>]
```