### PR TITLE
fix 2d kde plot

### DIFF
--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -355,7 +355,10 @@ def showProjection(ensemble, modes, *args, **kwargs):
         else:
             kwargs.pop('label', None)
 
-        plot(*(list(projection[indices].T) + args), **kwargs)
+        if not show_density:
+            plot(*(list(projection[indices].T) + args), **kwargs)
+        else:
+            plot(x=list(projection[indices,0]), y=list(projection[indices,1]), **kwargs)
 
     if texts:
         ts = []


### PR DESCRIPTION
It may be a thing from the latest seaborn, but kdeplot doesn't support multi-dimensional data the way we're providing it and gives errors about the number of arguments, so it's easier to provide x and y specifically