### PR TITLE
clustenm title to str

### DIFF
--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -112,7 +112,7 @@ class ClustENM(Ensemble):
         self._tmdk = 10.
 
         super(ClustENM, self).__init__('Unknown')   # dummy title; will be replaced in the next line
-        self._title = title
+        self._title = str(title).strip()
 
     def __getitem__(self, index):
 


### PR DESCRIPTION
The current implementation let's the title have any time including AtomGroup and makes problems for loadEnsemble:
```
In [14]: ens = prody.loadEnsemble("/home/jkrieger/ScipionUserData/projects/D614G_prody/Runs/003495_ProDyClustENM/clustenm.ens.npz")
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In [14], line 1
----> 1 ens = prody.loadEnsemble("/home/jkrieger/ScipionUserData/projects/D614G_prody/Runs/003495_ProDyClustENM/clustenm.ens.npz")

File /losdato/jkrieger/scipion3/software/em/ProDy/prody/ensemble/functions.py:121, in loadEnsemble(filename, **kwargs)
    118         title = None
    120 if isinstance(title, np.ndarray):
--> 121     title = title.item()
    123 if not isinstance(title, str) and title is not None:
    124     try:

ValueError: can only convert an array of size 1 to a Python scalar

In [15]: kwargs = {}

In [16]: filename = "/home/jkrieger/ScipionUserData/projects/D614G_prody/Runs/003495_ProDyClustENM/clustenm.ens.npz"

In [17]: import numpy as np

    ...:         kwargs['allow_pickle'] = True
    ...: 
    ...:     attr_dict = np.load(filename, **kwargs)
    ...:     if '_weights' in attr_dict:
    ...:         weights = attr_dict['_weights']
    ...:     else:
    ...:         weights = None
    ...: 
    ...:     # backward compatibility
    ...:     try:
    ...:         type_ = attr_dict['_type']
    ...:     except KeyError:
    ...:         if weights is not None and weights.ndim == 3:
    ...:             type_ = 'PDBEnsemble'
    ...:         else:
    ...:             type_ = 'Ensemble'
    ...: 
    ...:     try:
    ...:         title = attr_dict['_title']
    ...:     except KeyError:
    ...:         try:
    ...:             title = attr_dict['_name']
    ...:         except KeyError:
    ...:             title = None
    ...: 

In [19]: title
Out[19]: 
array([<Atom: N from 7KEC_1|Chains.B99990001_fixed (index 0)>,
       <Atom: H from 7KEC_1|Chains.B99990001_fixed (index 1)>,
       <Atom: H2 from 7KEC_1|Chains.B99990001_fixed (index 2)>, ...,
       <Atom: C from 7KEC_1|Chains.B99990001_fixed (index 51701)>,
       <Atom: O from 7KEC_1|Chains.B99990001_fixed (index 51702)>,
       <Atom: OXT from 7KEC_1|Chains.B99990001_fixed (index 51703)>],
      dtype=object)
```

 I've taken the title setting line from class Ensemble instead, which ensures that we get a short string. Is there any reason not to do this or, in fact, any reason not to just use the title setting from Ensemble directly?