### PR TITLE
alignBioPairwise max alns fix

### DIFF
--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -782,14 +782,14 @@ def getAlignedMatch(ach, bch):
                                      "local",
                                      MATCH_SCORE, MISMATCH_SCORE,
                                      GAP_PENALTY, GAP_EXT_PENALTY,
-                                     one_alignment_only=1)
+                                     max_alignments=1)
     else:
         alignment = alignBioPairwise(ach.getSequence(),
                                      bch.getSequence(),
                                      "global",
                                      MATCH_SCORE, MISMATCH_SCORE,
                                      GAP_PENALTY, GAP_EXT_PENALTY,
-                                     one_alignment_only=1)
+                                     max_alignments=1)
 
     amatch = []
     bmatch = []
@@ -1342,14 +1342,14 @@ def getAlignedMapping(target, chain, alignment=None):
                                           "local",
                                           MATCH_SCORE, MISMATCH_SCORE,
                                           GAP_PENALTY,  GAP_EXT_PENALTY,
-                                          one_alignment_only=1)
+                                          max_alignments=1)
         else:
             alignments = alignBioPairwise(target.getSequence(),
                                           chain.getSequence(),
                                           "global",
                                           MATCH_SCORE, MISMATCH_SCORE,
                                           GAP_PENALTY, GAP_EXT_PENALTY,
-                                          one_alignment_only=1)
+                                          max_alignments=1)
         alignment = alignments[0]
         this, that = alignment[:2]
     else:

--- a/prody/sequence/analysis.py
+++ b/prody/sequence/analysis.py
@@ -1078,11 +1078,11 @@ def alignSequenceToMSA(seq, msa, **kwargs):
     if method == 'local':
         alignment = alignBioPairwise(sequence, str(refMsaSeq), "local",
                                      match, mismatch, gap_opening, gap_extension,
-                                     one_alignment_only=1)
+                                     max_alignments=1)
     elif method == 'global':
         alignment = alignBioPairwise(sequence, str(refMsaSeq), "global",
                                      match, mismatch, gap_opening, gap_extension,
-                                     one_alignment_only=1)
+                                     max_alignments=1)
     else:
         raise ValueError('method should be local or global')
 

--- a/prody/sequence/msa.py
+++ b/prody/sequence/msa.py
@@ -552,7 +552,7 @@ def refineMSA(msa, index=None, label=None, rowocc=None, seqid=None, colocc=None,
                                         "local",
                                         MATCH_SCORE, MISMATCH_SCORE,
                                         GAP_PENALTY, GAP_EXT_PENALTY,
-                                        one_alignment_only=1)
+                                        max_alignments=1)
                 torf = []
                 for s, c in zip(*algn[0][:2]):
                     if s == '-':

--- a/prody/utilities/seqtools.py
+++ b/prody/utilities/seqtools.py
@@ -33,10 +33,10 @@ def splitSeqLabel(label):
 
 
 def alignBioPairwise(a_sequence, b_sequence,
-                     ALIGNMENT_METHOD,
-                     MATCH_SCORE, MISMATCH_SCORE,
-                     GAP_PENALTY, GAP_EXT_PENALTY,
-                     one_alignment_only=True):
+                     ALIGNMENT_METHOD=ALIGNMENT_METHOD,
+                     MATCH_SCORE=MATCH_SCORE, MISMATCH_SCORE=MISMATCH_SCORE,
+                     GAP_PENALTY=GAP_PENALTY, GAP_EXT_PENALTY=GAP_EXT_PENALTY,
+                     max_alignments=1):
     """
     Wrapper function to align two sequences using Biopython to support deprecation
     and associated warnings.
@@ -67,8 +67,8 @@ def alignBioPairwise(a_sequence, b_sequence,
     :arg GAP_EXT_PENALTY: a negative integer, used to penalise extending a gap
     :type GAP_EXT_PENALTY: int
 
-    :arg one_alignment_only: whether to return one alignment only or all generated
-    :type one_alignment_only: bool
+    :arg max_alignments: maximum number of alignments to extract
+    :type max_alignments: int
     """
     import numpy as np
 
@@ -84,27 +84,27 @@ def alignBioPairwise(a_sequence, b_sequence,
         alns = aligner.align(a_sequence, b_sequence)
 
         results = []
-        aln = alns[0]
 
-        split_aln = aln.format().split('\n')
+        for i, aln in enumerate(alns):
+            if i == max_alignments:
+                break
 
-        begin = split_aln[1].find('|')
-        end = len(split_aln[1])
+            split_aln = aln.format().split('\n')
 
-        row_1 = split_aln[0].replace(" ", "-")
-        row_2 = split_aln[2].replace(" ", "-")
+            begin = split_aln[1].find('|')
+            end = len(split_aln[1])
 
-        if len(row_1) < len(row_2):
-            row_1 += "-"*(len(row_2)-len(row_1))
-        elif len(row_2) < len(row_1):
-            row_2 += "-"*(len(row_1)-len(row_2))
+            row_1 = split_aln[0].replace(" ", "-")
+            row_2 = split_aln[2].replace(" ", "-")
 
-        results.append((row_1, row_2, aln.score, begin, end))
+            if len(row_1) < len(row_2):
+                row_1 += "-"*(len(row_2)-len(row_1))
+            elif len(row_2) < len(row_1):
+                row_2 += "-"*(len(row_1)-len(row_2))
 
-        if one_alignment_only:
-            return [results[0]]
-        else:
-            return results
+            results.append((row_1, row_2, aln.score, begin, end))
+
+        return results
         
     except (ImportError, AttributeError):
         from Bio import pairwise2


### PR DESCRIPTION
improved fix to #1689. This was missed in #1700 

I can confirm this still works with buildPDBEnsemble

New result from the function itself:
```
In [1]: from prody import *

In [2]: ag1 = parsePDB('1n5y', subset='ca')
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 1n5y downloaded (1n5y.pdb.gz)
@> PDB download via FTP completed (1 downloaded, 0 failed).
@> 1423 atoms and 1 coordinate set(s) were parsed in 0.03s.
@> Secondary structures were assigned to 748 residues.

In [3]: ag2 = parsePDB('1dlo', subset='ca')
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 1dlo downloaded (1dlo.pdb.gz)
@> PDB download via FTP completed (1 downloaded, 0 failed).
@> 971 atoms and 1 coordinate set(s) were parsed in 0.02s.
@> Secondary structures were assigned to 481 residues.

In [4]: a_sequence = ag1['L'].getSequence()

In [5]: b_sequence = ag2['A'].getSequence()

In [6]: x = prody.utilities.alignBioPairwise(a_sequence, b_sequence, ALIGNMENT_METHOD='global', max_alignments=2)

In [7]: x
Out[7]: 
[('-------------------------------------------------------------------------------------DIQMTQTTSSLSASL--GDRVTISCSASQDISSYLNWYQQKPEGTVKLLI--------YYTSSLHSGVPSRFSGSGSGTDYSLTISNLEP-----EDIATY-Y-CQQYSKFPWTFG-GGTKLEIKRADAAPTVSIFPPSSEQLTSGGASVVCFLNNFYPKDINVKWKIDGSERQNGVL---NSWTDQD-----SKDSTYS----------MSSTLTLTKDEYERHNSYTCEA-THKTSTSPIVKSFNR-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------',
  'PISPIETVPVKLKPGMDGPKVKQWPLTEEKIKALVEICTEMEKEGKISKIGPENPYNTPVFAIKKKDSTKWRKLVDFRELNKRTQDFWEVQLGIPHPAGLKKKKSVTVLDVGDAYFSVPLDEDFRKYTAFTIPSINNETPGIRYQYNVL----PQGWKGSPAIFQSSMT-KILEPFKKQNPDIVIYQYMDDLYVGSDLEIGQHRTKIEELRQHLLRWGLTTPDKKHQ------KEPPFLWMGY-ELHPDKW-----TVQPIVLPEKDSWTVNDIQKLVGKLNWASQIYPGIKVRQLSKLLRGTKALTE-VIPLTEEAELELAENREILKEPVHGVYYDPSKDLIAEIQKQGQGQWTYQIYQEPFKNLKTGKYARMRGAHTNDVKQLTEAVQKITTESIVIWGKTPKFKLPIQKETWETWWTEYWQATWIPEWEFVNTPPLVKLWYQLEKEPIVGAETFYVDGAANRETKLGKAGYVTNKGRQKVVPLTNTTNQKTELQAIYLALQDSGLEVNIVTDSQYALGIIQAQPDKSESELVNQIIEQLIKKEKVYLAWVPAHKGIGGNEQVDKLVSAGI',
  36.09999999999997,
  85,
  574),
 ('-------------------------------------------------------------------------------------DIQMTQTTSSLSASLG--DRVTISCSASQDISSYLNWYQQKPEGTVKLLI--------YYTSSLHSGVPSRFSGSGSGTDYSLTISNLEP-----EDIATY-Y-CQQYSKFPWTFG-GGTKLEIKRADAAPTVSIFPPSSEQLTSGGASVVCFLNNFYPKDINVKWKIDGSERQNGVL---NSWTDQD-----SKDSTYS----------MSSTLTLTKDEYERHNSYTCEA-THKTSTSPIVKSFNR-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------',
  'PISPIETVPVKLKPGMDGPKVKQWPLTEEKIKALVEICTEMEKEGKISKIGPENPYNTPVFAIKKKDSTKWRKLVDFRELNKRTQDFWEVQLGIPHPAGLKKKKSVTVLDVGDAYFSVPLDEDFRKYTAFTIPSINNETPGIRYQYNVL----PQGWKGSPAIFQSSMT-KILEPFKKQNPDIVIYQYMDDLYVGSDLEIGQHRTKIEELRQHLLRWGLTTPDKKHQ------KEPPFLWMGY-ELHPDKW-----TVQPIVLPEKDSWTVNDIQKLVGKLNWASQIYPGIKVRQLSKLLRGTKALTE-VIPLTEEAELELAENREILKEPVHGVYYDPSKDLIAEIQKQGQGQWTYQIYQEPFKNLKTGKYARMRGAHTNDVKQLTEAVQKITTESIVIWGKTPKFKLPIQKETWETWWTEYWQATWIPEWEFVNTPPLVKLWYQLEKEPIVGAETFYVDGAANRETKLGKAGYVTNKGRQKVVPLTNTTNQKTELQAIYLALQDSGLEVNIVTDSQYALGIIQAQPDKSESELVNQIIEQLIKKEKVYLAWVPAHKGIGGNEQVDKLVSAGI',
  36.09999999999997,
  85,
  574)]
```
