### PR TITLE
cif header custom keys and unobserved

### DIFF
--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -6,7 +6,7 @@ import os.path
 
 from prody import LOGGER
 from prody.atomic import flags, AAMAP
-from prody.utilities import openFile, alignBioPairwise
+from prody.utilities import openFile, alignBioPairwise, GAP_PENALTY, GAP_EXT_PENALTY
 
 from .localpdb import fetchPDB
 from .header import (Chemical, Polymer, DBRef, _PDB_DBREF,
@@ -1269,7 +1269,11 @@ def _getUnobservedSeq(lines):
     for key, seq in full_seqs.items():
         if key in unobs_seqs.keys():
             unobs_seq = unobs_seqs[key]
-            alns[key] = alignBioPairwise(unobs_seq, seq, MATCH_SCORE=1000, MISMATCH_SCORE=-1000)[0][:2]
+            alns[key] = alignBioPairwise(unobs_seq, seq, MATCH_SCORE=1000,
+                                         MISMATCH_SCORE=-1000,
+                                         ALIGNMENT_METHOD='global',
+                                         GAP_PENALTY=GAP_PENALTY,
+                                         GAP_EXT_PENALTY=GAP_EXT_PENALTY)[0][:2]
 
     return alns
 

--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -4,21 +4,15 @@
 from collections import defaultdict, OrderedDict
 import os.path
 
-import numpy as np
-
 from prody import LOGGER
-from prody.atomic import ATOMIC_FIELDS
-from prody.atomic import Atomic, AtomGroup
-from prody.atomic import getSequence
-from prody.atomic import flags
-from prody.measure import Transformation
-from prody.utilities import openFile, split
+from prody.atomic import flags, AAMAP
+from prody.utilities import openFile, alignBioPairwise
 
 from .localpdb import fetchPDB
 from .header import (Chemical, Polymer, DBRef, _PDB_DBREF,
                      cleanString)
 
-from .starfile import parseSTARLines, parseSTARSection
+from .starfile import parseSTARSection
 
 __all__ = ['parseCIFHeader', 'getCIFHeaderDict']
 
@@ -147,8 +141,12 @@ def getCIFHeaderDict(stream, *keys):
                 value = _PDB_HEADER_MAP[key](lines)
                 keys[k] = value
             else:
-                raise KeyError('{0} is not a valid header data identifier'
-                               .format(repr(key)))
+                try:
+                    value = _PDB_HEADER_MAP['others'](lines, key)
+                    keys[k] = value
+                except:
+                    raise KeyError('{0} is not a valid header data identifier'
+                                .format(repr(key)))
             if key in ('chemicals', 'polymers'):
                 for component in value:
                     component.pdbentry = pdbid
@@ -1215,6 +1213,67 @@ def _getModelType(lines):
     return model_type
 
 
+def _getOther(lines, key=None):
+
+    if key is None:
+        return None
+
+    data = []
+
+    try:
+        data = parseSTARSection(lines, key)
+    except:
+        pass
+
+    if len(data) == 0:
+        data = None
+
+    return data
+
+
+def _getUnobservedSeq(lines):
+
+    key_unobs = '_pdbx_unobs_or_zero_occ_residues'
+
+    try:
+        unobs = parseSTARSection(lines, key_unobs)
+        polymers = _getPolymers(lines)
+    except:
+        pass
+
+    if len(unobs) == 0:
+        return None
+
+    unobs_seqs = OrderedDict()
+    for item in unobs:
+        chid = item['_pdbx_unobs_or_zero_occ_residues.label_asym_id']
+        if not chid in unobs_seqs.keys():
+            unobs_seqs[chid] = ''
+        unobs_seqs[chid] += AAMAP[item['_pdbx_unobs_or_zero_occ_residues.label_comp_id']]
+
+    if len(unobs_seqs) == 0:
+        return None
+
+    if len(polymers) == 0:
+        return None
+
+    full_seqs = OrderedDict()
+    for item in polymers:
+        chid = item.chid
+        full_seqs[chid] = item.sequence
+
+    if len(full_seqs) == 0:
+        return None
+
+    alns = OrderedDict()
+    for key, seq in full_seqs.items():
+        if key in unobs_seqs.keys():
+            unobs_seq = unobs_seqs[key]
+            alns[key] = alignBioPairwise(unobs_seq, seq, MATCH_SCORE=1000, MISMATCH_SCORE=-1000)[0][:2]
+
+    return alns
+
+
 # Make sure that lambda functions defined below won't raise exceptions
 _PDB_HEADER_MAP = {
     'helix': _getHelix,
@@ -1244,4 +1303,6 @@ _PDB_HEADER_MAP = {
     'n_models': _getNumModels,
     'space_group': _getSpaceGroup,
     'related_entries': _getRelatedEntries,
+    'others': _getOther,
+    'unobserved': _getUnobservedSeq
 }


### PR DESCRIPTION
addresses #1685 

1. parseCIFHeader can get results from any key:
```
In [1]: from prody import *

In [2]: header = parseCIFHeader('7E1B.cif', '_pdbx_unobs_or_zero_occ_residues')

In [3]: header
Out[3]: 
[OrderedDict([('_pdbx_unobs_or_zero_occ_residues.id', '1'),
              ('_pdbx_unobs_or_zero_occ_residues.PDB_model_num', '1'),
              ('_pdbx_unobs_or_zero_occ_residues.polymer_flag', 'Y'),
              ('_pdbx_unobs_or_zero_occ_residues.occupancy_flag', '1'),
              ('_pdbx_unobs_or_zero_occ_residues.auth_asym_id', 'A'),
              ('_pdbx_unobs_or_zero_occ_residues.auth_comp_id', 'MET'),
              ('_pdbx_unobs_or_zero_occ_residues.auth_seq_id', '1'),
              ('_pdbx_unobs_or_zero_occ_residues.PDB_ins_code', '?'),
              ('_pdbx_unobs_or_zero_occ_residues.label_asym_id', 'A'),
              ('_pdbx_unobs_or_zero_occ_residues.label_comp_id', 'MET'),
              ('_pdbx_unobs_or_zero_occ_residues.label_seq_id', '1')]),
 OrderedDict([('_pdbx_unobs_or_zero_occ_residues.id', '2'),
              ('_pdbx_unobs_or_zero_occ_residues.PDB_model_num', '1'),
              ('_pdbx_unobs_or_zero_occ_residues.polymer_flag', 'Y'),
              ('_pdbx_unobs_or_zero_occ_residues.occupancy_flag', '1'),
              ('_pdbx_unobs_or_zero_occ_residues.auth_asym_id', 'A'),
              ('_pdbx_unobs_or_zero_occ_residues.auth_comp_id', 'PRO'),
              ('_pdbx_unobs_or_zero_occ_residues.auth_seq_id', '118'),
              ('_pdbx_unobs_or_zero_occ_residues.PDB_ins_code', '?'),
              ('_pdbx_unobs_or_zero_occ_residues.label_asym_id', 'A'),
              ('_pdbx_unobs_or_zero_occ_residues.label_comp_id', 'PRO'),
              ('_pdbx_unobs_or_zero_occ_residues.label_seq_id', '118')]),
.
.
.
```

2. There is a specific option "unobserved" that returns alignments between unobserved sequences and full sequences:
```
In [1]: from prody import *

In [2]: header = parseCIFHeader('7E1B.cif', 'unobserved')
@> WARNING Could not find _pdbx_struct_mod_residue in lines.
@> WARNING Could not find _struct_ref_seq_dif in lines.

In [3]: header
Out[3]: 
OrderedDict([('A',
              ('M--------------------------------------------------------------------------------------------------------------------PDSADQA------------------------------------------------------------HFP---------------------------------',
               'MKQTLLLVEDDKNLADGLLVSLEQAGYECLHVERIADVEPQWKKADLVILDRQLPDGDSVQHLPEWKKIKDVPVILLTALVTVKDKVAGLDSGANDYLTKPFAEAELFARIRAQLRAPDSADQANADKVMTKDLEIDRATREVIFKGDLITLTRTEFDLLLFLASNLGRVFTRDELLDHVWGYNHFPTTRTVDTHVLQLRQKLPGLEIETLRGVGYKMKA')),
             ('B',
              ('--------------------------------------------------------------------------------------------------------------------APDSADQA------------------------------------------------------------HFPT--------------------------------',
               'MKQTLLLVEDDKNLADGLLVSLEQAGYECLHVERIADVEPQWKKADLVILDRQLPDGDSVQHLPEWKKIKDVPVILLTALVTVKDKVAGLDSGANDYLTKPFAEAELFARIRAQLRAPDSADQANADKVMTKDLEIDRATREVIFKGDLITLTRTEFDLLLFLASNLGRVFTRDELLDHVWGYNHFPTTRTVDTHVLQLRQKLPGLEIETLRGVGYKMKA')),
.
.
.
```