### PR TITLE
add matrices to apps

### DIFF
--- a/prody/apps/prody_apps/nmaoptions.py
+++ b/prody/apps/prody_apps/nmaoptions.py
@@ -17,6 +17,7 @@ for key, txt, val in [
     ('outeig', 'write eigenvalues/vectors', False),
     ('outcov', 'write covariance matrix', False),
     ('outnpz', 'write compressed ProDy data file', False),
+    ('npzmatrices', 'write matrix to compressed ProDy data file', False),
     ('outscipion', 'write continuousflex modes directory and sqlite', False),
     ('outcc', 'write cross-correlations', False),
     ('outhm', 'write cross-correlations heatmap file', False),
@@ -95,6 +96,9 @@ def addNMAOutput(parser):
 
     parser.add_argument('-z', '--npz', dest='outnpz', action='store_true',
         default=DEFAULTS['outnpz'], help=HELPTEXT['outnpz'])
+
+    parser.add_argument('-Z', '--npzmatrices', dest='npzmatrices', action='store_true',
+        default=DEFAULTS['npzmatrices'], help=HELPTEXT['npzmatrices'])
 
     parser.add_argument('-S', '--export-scipion', dest='outscipion', action='store_true',
         default=DEFAULTS['outscipion'], help=HELPTEXT['outscipion'])

--- a/prody/apps/prody_apps/prody_anm.py
+++ b/prody/apps/prody_apps/prody_anm.py
@@ -110,7 +110,8 @@ def prody_anm(pdb, **kwargs):
     LOGGER.info('Writing numerical output.')
 
     if kwargs.get('outnpz'):
-        prody.saveModel(anm, join(outdir, prefix))
+        prody.saveModel(anm, join(outdir, prefix), 
+                        matrices=kwargs.get('npzmatrices'))
 
     if kwargs.get('outscipion'):
         prody.writeScipionModes(outdir, anm)

--- a/prody/apps/prody_apps/prody_gnm.py
+++ b/prody/apps/prody_apps/prody_gnm.py
@@ -101,7 +101,8 @@ def prody_gnm(pdb, **kwargs):
     LOGGER.info('Writing numerical output.')
 
     if kwargs.get('outnpz'):
-        prody.saveModel(gnm, join(outdir, prefix))
+        prody.saveModel(gnm, join(outdir, prefix), 
+                        matrices=kwargs.get('npzmatrices'))
 
     if kwargs.get('outscipion'):
         prody.writeScipionModes(outdir, gnm)

--- a/prody/apps/prody_apps/prody_pca.py
+++ b/prody/apps/prody_apps/prody_pca.py
@@ -145,7 +145,8 @@ def prody_pca(coords, **kwargs):
 
     LOGGER.info('Writing numerical output.')
     if kwargs.get('outnpz'):
-        prody.saveModel(pca, join(outdir, prefix))
+        prody.saveModel(pca, join(outdir, prefix), 
+                        matrices=kwargs.get('npzmatrices'))
 
     if kwargs.get('outscipion'):
         prody.writeScipionModes(outdir, pca)


### PR DESCRIPTION
Default behaviour is to not save matrices to npz files as before but now there is an option to add them -Z or --npzmatrices

```
(scipion3) jkrieger@whipple ~/software/scipion3/software/em/ProDy (prody-master) $ prody anm 3h5vA --npz
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 3h5v downloaded (3h5v.pdb.gz)
@> PDB download via FTP completed (1 downloaded, 0 failed).
@> 3225 atoms and 1 coordinate set(s) were parsed in 0.08s.
@> Secondary structures were assigned to 237 residues.
@> 376 atoms will be used for ANM calculations.
@> Using gamma 1.0
@> Hessian was built in 0.16s.
@> 10 modes were calculated in 0.15s.
@> Writing numerical output.
(scipion3) jkrieger@whipple ~/software/scipion3/software/em/ProDy (prody-master) $ ls *npz
3h5vA_anm.anm.npz
(scipion3) jkrieger@whipple ~/software/scipion3/software/em/ProDy (prody-master) $ ipython
Python 3.8.13 (default, Mar 28 2022, 11:38:47) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.3.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: anm = loadModel('3h5vA_anm.anm.npz')

In [3]: anm.getHessian()

In [4]: exit
(scipion3) jkrieger@whipple ~/software/scipion3/software/em/ProDy (prody-master) $ prody anm 3h5vA --npz --npzmatrix
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 3h5v downloaded (3h5v.pdb.gz)
@> PDB download via FTP completed (1 downloaded, 0 failed).
@> 3225 atoms and 1 coordinate set(s) were parsed in 0.07s.
@> Secondary structures were assigned to 237 residues.
@> 376 atoms will be used for ANM calculations.
@> Using gamma 1.0
@> Hessian was built in 0.12s.
@> 10 modes were calculated in 0.10s.
@> Writing numerical output.
(scipion3) jkrieger@whipple ~/software/scipion3/software/em/ProDy (prody-master) $ ipython
Python 3.8.13 (default, Mar 28 2022, 11:38:47) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.3.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: anm = loadModel('3h5vA_anm.anm.npz')

In [3]: anm.getHessian()
Out[3]: 
array([[ 3.45016139, -0.38303756, -0.8954084 , ...,  0.        ,
         0.        ,  0.        ],
       [-0.38303756,  9.42143483,  2.72867666, ...,  0.        ,
         0.        ,  0.        ],
       [-0.8954084 ,  2.72867666,  4.12840378, ...,  0.        ,
         0.        ,  0.        ],
       ...,
       [ 0.        ,  0.        ,  0.        , ...,  8.07641927,
        -0.48660224, -4.58068615],
       [ 0.        ,  0.        ,  0.        , ..., -0.48660224,
         0.77004754, -0.58782517],
       [ 0.        ,  0.        ,  0.        , ..., -4.58068615,
        -0.58782517,  5.15353319]])
```