### PR TITLE
fix nma indexing errors

### DIFF
--- a/prody/dynamics/nma.py
+++ b/prody/dynamics/nma.py
@@ -43,8 +43,10 @@ class NMA(object):
             raise ValueError('{0} modes are not calculated, use '
                              'calcModes() method'.format(str(self)))
         if isinstance(index, slice):
-            if (index.stop is not None and index.stop > self.numModes()) or (index.start is not None and index.start > self.numModes()):
-                LOGGER.warn('The selection index contains a higher number than the total mode number ({0})'.format(self.numModes()))
+            if index.stop is not None and index.stop > self.numModes():
+                LOGGER.warn('The selection index contains {0}, a higher number than the total mode number ({1})'.format(index.stop, self.numModes()))
+            if  index.start is not None and index.start > self.numModes()-1:
+                raise IndexError('The selection index starts at {0}, a higher number than the highest mode index ({1})'.format(index.start, self.numModes()-1))
             indices = np.arange(*index.indices(len(self)))
             if len(indices) > 0:
                 return ModeSet(self, indices)
@@ -55,7 +57,7 @@ class NMA(object):
         try:
             index = int(index)
         except Exception:
-            raise IndexError('indices must be int, slice, list, or tuple')
+            raise IndexError('indices must be int, slice, list, tuple or array')
         else:
             return self._getMode(index)
 

--- a/prody/tests/dynamics/test_enms.py
+++ b/prody/tests/dynamics/test_enms.py
@@ -131,6 +131,14 @@ class TestANMResults(testGNMBase):
         assert_allclose(hessian.sum(1), zeros,
                         rtol=0, atol=ATOL,
                         err_msg='hessian rows do not add up to zero')
+        
+    def testModeSlicing(self):
+        indices1 = slice(227, 230)
+        assert_equal(anm[indices1].numModes(), 1,
+                         'slicing ANM for last mode does not work')
+        indices = slice(228, 230)
+        self.assertRaises(IndexError, anm.__getitem__, indices,
+                          'slicing ANM for too many modes does not give IndexError')
 
 class TestEXANMResults(testGNMBase):
 

--- a/prody/tests/dynamics/test_enms.py
+++ b/prody/tests/dynamics/test_enms.py
@@ -137,8 +137,7 @@ class TestANMResults(testGNMBase):
         assert_equal(anm[indices1].numModes(), 1,
                          'slicing ANM for last mode does not work')
         indices = slice(228, 230)
-        self.assertRaises(IndexError, anm.__getitem__, indices,
-                          'slicing ANM for too many modes does not give IndexError')
+        self.assertRaises(IndexError, anm.__getitem__, indices)
 
 class TestEXANMResults(testGNMBase):
 


### PR DESCRIPTION
The main difference is the inclusion of a missing -1 on the number of modes for the start of the slice 