### PR TITLE
Improve ed-ENM and docs

### DIFF
--- a/prody/apps/prody_apps/prody_anm.py
+++ b/prody/apps/prody_apps/prody_anm.py
@@ -13,7 +13,7 @@ HELPTEXT = {}
 for key, txt, val in [
     ('model', 'index of model that will be used in the calculations', 1),
     ('altloc', 'alternative location identifiers for residues used in the calculations', "A"),
-    ('cutoff', 'cutoff distance (A)', 15.),
+    ('cutoff', 'cutoff distance (A)', '15.'),
     ('gamma', 'spring constant', '1.'),
     ('sparse', 'use sparse matrices', False),
     ('kdtree', 'use kdtree for Hessian', False),    
@@ -57,7 +57,6 @@ def prody_anm(pdb, **kwargs):
 
     selstr = kwargs.get('select')
     prefix = kwargs.get('prefix')
-    cutoff = kwargs.get('cutoff')
     sparse = kwargs.get('sparse')
     kdtree = kwargs.get('kdtree')
     nmodes = kwargs.get('nmodes')
@@ -91,6 +90,19 @@ def prody_anm(pdb, **kwargs):
             raise NameError("Please provide gamma as a float or ProDy Gamma class")
         except TypeError:
             raise TypeError("Please provide gamma as a float or ProDy Gamma class")
+        
+    try:
+        cutoff = float(kwargs.get('cutoff'))
+        LOGGER.info("Using cutoff {0}".format(cutoff))
+    except ValueError:
+        try:
+            import math
+            cutoff = eval(kwargs.get('cutoff'))
+            LOGGER.info("Using cutoff {0}".format(cutoff))
+        except NameError:
+            raise NameError("Please provide cutoff as a float or equation using math")
+        except TypeError:
+            raise TypeError("Please provide cutoff as a float or equation using math")
 
     anm = prody.ANM(pdb.getTitle())
 
@@ -276,7 +288,7 @@ graphical output files:
 
     group = addNMAParameters(subparser)
 
-    group.add_argument('-c', '--cutoff', dest='cutoff', type=float,
+    group.add_argument('-c', '--cutoff', dest='cutoff', type=str,
         default=DEFAULTS['cutoff'], metavar='FLOAT',
         help=HELPTEXT['cutoff'] + ' (default: %(default)s)')
 

--- a/prody/dynamics/gamma.py
+++ b/prody/dynamics/gamma.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from prody.atomic import Atomic
 
-__all__ = ['Gamma', 'GammaStructureBased', 'GammaVariableCutoff', 'GammaGOdMD']
+__all__ = ['Gamma', 'GammaStructureBased', 'GammaVariableCutoff', 'GammaED', 'GammaGOdMD']
 
 
 class Gamma(object):

--- a/prody/dynamics/gamma.py
+++ b/prody/dynamics/gamma.py
@@ -37,7 +37,7 @@ class GammaStructureBased(Gamma):
     """Facilitate setting the spring constant based on the secondary structure
     and connectivity of the residues.
 
-    A recent systematic study [LT10]_ of a large set of NMR-structures analyzed
+    A systematic study [LT10]_ of a large set of NMR-structures analyzed
     using a method based on entropy maximization showed that taking into
     consideration properties such as sequential separation between
     contacting residues and the secondary structure types of the interacting
@@ -301,15 +301,37 @@ class GammaVariableCutoff(Gamma):
         return gamma
 
 
-class GammaGOdMD(Gamma):
+class GammaED(Gamma):
     """Facilitate setting the spring constant based on 
-    sequence distance and spatial distance as in GOdMD.
+    sequence distance and spatial distance as in ed-ENM [OL10]_.
+    This ENM is refined based on comparison to essential dynamics 
+    from MD simulations and can reproduce flexibility in NMR ensembles.
+
+    It has also been implemented in FlexServ [CJ09]_ and 
+    used in MDdMD [SP12]_ and GOdMD [SP13]_.
 
     The sequence distance-dependent term is Cseq/(S**2)
     for S=abs(i,j) <= Slim
 
     The structure distance-dependent term is (Ccart/dist)**Ex
 
+    .. [OL10] Orellana L, Rueda M, Ferrer-Costa C, Lopez-Blanco JR, Chacón P, Orozco M. 
+       Approaching Elastic Network Models to Molecular Dynamics Flexibility.
+       *J Chem Theory Comput* **2010** 6(9):2910-23.
+
+    .. [CJ09] Camps J, Carrillo O, Emperador A, Orellana L, Hospital A, Rueda M, 
+       Cicin-Sain D, D'Abramo M, Gelpí JL, Orozco M.
+       FlexServ: an integrated tool for the analysis of protein flexibility.
+       *Bioinformatics* **2009** 25(13):1709-10.
+
+    .. [SP12] Sfriso P, Emperador A, Orellana L, Hospital A, Gelpí JL, Orozco M.
+       Finding Conformational Transition Pathways from Discrete Molecular Dynamics Simulations.
+       *J Chem Theory Comput* **2012** 8(11):4707-18.
+
+    .. [SP13] Sfriso P, Hospital A, Emperador A, Orozco M. 
+       Exploration of conformational transition pathways from coarse-grained simulations.
+       *Bioinformatics* **2013** 29(16):1980-6.     
+       
     **Example**:
 
     Let's parse coordinates from a PDB file.
@@ -396,3 +418,5 @@ class GammaGOdMD(Gamma):
         else:
             dist = dist2**0.5
             return (Ccart/dist)**Ex
+
+GammaGOdMD = GammaED

--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -923,12 +923,12 @@ def mapChainOntoChain(mobile, target, **kwargs):
     :type overlap: float
 
     :keyword mapping: what method will be used if the trivial mapping based on residue numbers 
-        fails. If ``"ce"`` or ``"cealign"``, then the CE algorithm [IS98]_ will be 
+        fails. If ``"ce"`` or ``"cealign"``, then the CE structural alignment [IS98]_ will be
         performed. It can also be a list of prealigned sequences, a :class:`.MSA` instance,
         or a dict of indices such as that derived from a :class:`.DaliRecord`.
         If set to **True** then the sequence alignment from Biopython 
         will be used. If set to **False**, only the trivial mapping will be performed. 
-        Default is **"auto"**
+        Default is **"auto"**, which means try sequence alignment then CE.
     :type mapping: list, str, bool
 
     :keyword pwalign: if **True**, then pairwise sequence alignment will 


### PR DESCRIPTION
GammaGOdMD is renamed as GammaED and its origin is acknowledged properly as ed-ENM. There is also an alias to keep the name GammaGOdMD.

The default mapping is also explained properly as this was missing.
