### PR TITLE
Water bridging module

### DIFF
--- a/prody/proteins/__init__.py
+++ b/prody/proteins/__init__.py
@@ -216,6 +216,10 @@ from . import starfile
 from .starfile import *
 __all__.extend(starfile.__all__)
 
+from . import waterbridges
+from .waterbridges import *
+__all__.extend(waterbridges.__all__)
+
 from . import fixer
 from .fixer import *
 __all__.extend(fixer.__all__)

--- a/prody/proteins/waterbridges.py
+++ b/prody/proteins/waterbridges.py
@@ -275,7 +275,7 @@ def getInfoOutput(waterBridgesAtomic):
 
 
 def getWaterBridgesInfoOutput(waterBridgesAtomic):
-    """Coverts single frame/trajectory atomic output from calcWaterBridges/Trajectory to info output.
+    """Converts single frame/trajectory atomic output from calcWaterBridges/Trajectory to info output.
 
     :arg waterBridgesAtomic: water bridges from calcWaterBridges/Trajectory
     :type waterBridgesAtomic: list
@@ -462,8 +462,19 @@ def calcWaterBridges(atoms, **kwargs):
 
 # took from interactions.py
 def calcWaterBridgesTrajectory(atoms, trajectory, **kwargs):
-    """Compute selected type interactions for DCD trajectory or multi-model PDB 
-    using default parameters."""
+    """Computes water bridges for a given trajectory. Kwargs for options are the same as in calcWaterBridges.
+
+    :arg atoms: Atomic object from which atoms are considered
+    :type atoms: :class:`.Atomic`
+
+    :arg trajectory: trajectory object, DCD or multimodal PDB
+
+    :arg start_frame: frame to start from
+    :type start_frame: int
+
+    :arg stop_frame: frame to stop
+    :type stop_frame: int
+    """
 
     interactions_all = []
     start_frame = kwargs.pop('start_frame', 0)

--- a/prody/proteins/waterbridges.py
+++ b/prody/proteins/waterbridges.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+
+"""This module detect, predicts and analyzes water bridges.
+"""
+
+__author__ = 'Karolina Mikulska-Ruminska'
+__credits__ = ['Frane Doljanin', 'Karolina Mikulska-Ruminska']
+__email__ = ['karolamik@fizyka.umk.pl', 'fdoljanin@pmfst.hr']
+
+
+import numpy as np
+
+from numpy import *
+from prody import LOGGER, SETTINGS, PY3K
+from prody.atomic import AtomGroup, Atom, Atomic, Selection, Select
+from prody.atomic import flags
+from prody.utilities import importLA, checkCoords, showFigure, getCoords
+from prody.measure import calcDistance, calcAngle, calcCenter
+from prody.measure.contacts import findNeighbors
+from prody.proteins import writePDB, parsePDB
+from collections import Counter
+
+from prody.trajectory import TrajBase, Trajectory
+from prody.ensemble import Ensemble
+
+from enum import Enum, auto
+
+__all__ = ['calcWaterBridges']
+
+
+class ResType(Enum):
+    WATER = auto()
+    PROTEIN = auto()
+
+
+class HydrophilicGroup:
+    def __init__(self, hydrophilicAtom, hydrogens, type):
+        self.hydrophilic = hydrophilicAtom
+        self.hydrogens = hydrogens if hydrogens else []
+        self.type = type
+
+
+def getResidueAtoms(atom, atomGroup):
+    return atomGroup.select(f'resnum {atom.getResnum()}')
+
+
+def checkHBondAngle(donorGroup, acceptorGroup, angleRange):
+    for hydrogen in donorGroup.hydrogens:
+        bondAngle = calcAngle(donorGroup.hydrophilic,
+                              hydrogen, acceptorGroup.hydrophilic)
+        if angleRange[0] < bondAngle < angleRange[1]:
+            return True
+
+    return False
+
+
+def getNeighborsForAtom(atom, selection, dist):
+    return list(map(lambda p: p[1], findNeighbors(atom, dist, selection)))
+
+
+def checkDoesGroupFormBridge(waterGroup):
+    resAtomIndices = []
+    for pair in waterGroup:
+        if pair[0].type == ResType.PROTEIN:
+            resAtomIndices.append(pair[0].hydrophilic.getIndex())
+        if pair[1].type == ResType.PROTEIN:
+            resAtomIndices.append(pair[1].hydrophilic.getIndex())
+
+    return len(set(resAtomIndices)) >= 2
+
+
+def getWaterGroupAtoms(group):
+    currentGroupAtoms = []
+    for bond in group:
+        currentGroupAtoms += [bond[0].hydrophilic,
+                              bond[1].hydrophilic]
+
+    uniqueAtomIndices = set([cga.getIndex() for cga in currentGroupAtoms])
+
+    return uniqueAtomIndices
+
+
+def calcWaterBridges(atoms, **kwargs):
+    """Compute water bridges for a protein that has water molecules.
+
+    :arg atoms: Atomic object from which atoms are considered
+    :type atoms: :class:`.Atomic`
+
+    :arg distDA: maximal distance between water/protein donor and acceptor
+        default is 3.5
+    :type distDA: int, float
+
+    :arg anglePDWA: angle range where protein is donor and water is acceptor
+        default is (100, 200)
+    :type anglePDWA: (int, int)
+
+    :arg anglePAWD: angle range where protein is acceptor and water is donor
+        default is (100, 140)
+    :type anglePDWA: (int, int)
+
+    :arg angleWW: angle between water donor/acceptor
+        default is (140, 180)
+    :type angleWW: (int, int)
+
+    :arg donors: which atoms to count as donors 
+        default is ['N', 'O', 'S', 'F']
+    :type donors: list
+
+    :arg acceptors: which atoms to count as acceptors 
+        default is ['N', 'O', 'S', 'F']
+    :type acceptors: list
+    """
+
+    distDA = kwargs.pop('distDA', 3.5)
+    anglePDWA = kwargs.pop('anglePDWA', (100, 200))
+    anglePAWD = kwargs.pop('anglePAWD', (100, 140))
+    angleWW = kwargs.pop('angleWW', (140, 180))
+    donors = kwargs.pop('donors', ['nitrogen', 'oxygen', 'sulfur'])
+    acceptors = kwargs.pop('acceptors', ['nitrogen', 'oxygen', 'sulfur'])
+
+    waterHydrogens = atoms.select('water and hydrogen')
+    waterOxygens = atoms.select('water and oxygen')
+    neighborWaterOxygens = findNeighbors(waterOxygens, distDA)
+    contactingWaters = []
+    for nbPair in neighborWaterOxygens:
+        hydrogens_0, hydrogens_1 = getResidueAtoms(
+            nbPair[0], waterHydrogens), getResidueAtoms(nbPair[1], waterHydrogens)
+        water_0, water_1 = HydrophilicGroup(
+            nbPair[0], hydrogens_0, ResType.WATER), HydrophilicGroup(nbPair[1], hydrogens_1, ResType.WATER)
+        contactingWaters.append((water_0, water_1))
+    LOGGER.info(f'Water contacts ({len(contactingWaters)}) saved.')
+
+    proteinHydrogens = atoms.select('protein and hydrogen')
+    proteinHydrophilic = atoms.select(
+        f'protein and ({" or ".join(donors + acceptors)})')
+    neighborWaterProtein = findNeighbors(
+        waterOxygens, distDA, proteinHydrophilic)
+    contactingWaterProtein = []
+
+    for nbPair in neighborWaterProtein:
+        hydrogens_w, hydrogens_p = getResidueAtoms(
+            nbPair[0], waterHydrogens), getNeighborsForAtom(nbPair[1], proteinHydrogens, 1.4)
+        water, protein = HydrophilicGroup(
+            nbPair[0], hydrogens_w, ResType.WATER), HydrophilicGroup(nbPair[1], hydrogens_p, ResType.PROTEIN)
+        contactingWaterProtein.append((water, protein))
+    LOGGER.info(
+        f'Water-protein contacts ({len(contactingWaterProtein)}) saved.')
+
+    hydrogenBonds = []
+
+    for nbPair in contactingWaters:
+        if checkHBondAngle(nbPair[0], nbPair[1], angleWW):
+            hydrogenBonds.append((nbPair[0], nbPair[1]))
+
+        if checkHBondAngle(nbPair[1], nbPair[0], angleWW):
+            hydrogenBonds.append((nbPair[1], nbPair[0]))
+    LOGGER.info(f'Hydrogen bonds ({len(hydrogenBonds)}) calculated.')
+
+    for nbPair in contactingWaterProtein:
+        if nbPair[1].hydrophilic.getName()[0] in ['N', 'S', 'F', 'O'] and checkHBondAngle(nbPair[0], nbPair[1], anglePDWA):
+            hydrogenBonds.append((nbPair[0], nbPair[1]))
+
+        if nbPair[1].hydrophilic.getName()[0] in ['N', 'S', 'F', 'O'] and checkHBondAngle(nbPair[1], nbPair[0], anglePAWD):
+            hydrogenBonds.append((nbPair[1], nbPair[0]))
+    LOGGER.info(f'Hydrogen bonds ({len(hydrogenBonds)}) calculated.')
+
+    waterBridges = []
+
+    while len(hydrogenBonds):
+        if not len(hydrogenBonds) % 500:
+            LOGGER.info(len(hydrogenBonds))
+        waterGroup = []
+        firstWater = hydrogenBonds[0][0] if hydrogenBonds[0][0].type == ResType.WATER else hydrogenBonds[0][1]
+        newWaters = [firstWater]
+
+        while True:
+            currentWater = newWaters[0]
+            for bond in hydrogenBonds.copy():
+                if currentWater.hydrophilic.getIndex() not in [bond[0].hydrophilic.getIndex(), bond[1].hydrophilic.getIndex()]:
+                    continue
+
+                hydrogenBonds.remove(bond)
+                waterGroup.append(bond)
+                otherAtom = bond[0] if currentWater == bond[1] else bond[1]
+                if otherAtom.type == ResType.WATER:
+                    newWaters.append(otherAtom)
+
+            newWaters.pop(0)
+            if not len(newWaters):
+                if checkDoesGroupFormBridge(waterGroup):
+                    atoms = getWaterGroupAtoms(waterGroup)
+                    waterBridges.append(atoms)
+
+                break
+    LOGGER.info('Water bridges calculated.')
+
+    return waterBridges

--- a/prody/proteins/waterbridges.py
+++ b/prody/proteins/waterbridges.py
@@ -520,6 +520,9 @@ def calcWaterBridgesStatistics(frames, trajectory, **kwargs):
     :type output: 'resname' | 'resid'
     """
     output = kwargs.pop('output', 'resid')
+    if output not in ['resid', 'resname']:
+        raise TypeError('Output should be resname or resid!')
+
     allCoordinates = trajectory.getCoordsets()
     interactionCount = DictionaryList(0)
     distances = DictionaryList([])
@@ -554,6 +557,7 @@ def calcWaterBridgesStatistics(frames, trajectory, **kwargs):
                 resNames[res_2] = res_2_name
 
     info = {}
+    LOGGER.info(f'{"RES1":<{15}}{"RES2":<{15}}\tPERC\tDIST_AVG\tDIST_STD')
     for key in interactionCount.keys():
         percentage = 100 * interactionCount[key]/len(frames)
         distAvg = np.average(distances[key])
@@ -562,9 +566,12 @@ def calcWaterBridgesStatistics(frames, trajectory, **kwargs):
                     "distAvg": distAvg, "distStd": distStd}
 
         outputKey = key
+        x, y = key
         if output == 'resname':
-            x, y = key
             outputKey = (resNames[x], resNames[y])
+
+        logMessage = f'{resNames[x]:<{15}}{resNames[y]:<{15}}\t{percentage:.2f}\t{distAvg:.4f}\t\t{distStd:.4f}'
+        LOGGER.info(logMessage)
 
         info[outputKey] = pairInfo
 

--- a/prody/proteins/waterbridges.py
+++ b/prody/proteins/waterbridges.py
@@ -516,10 +516,10 @@ def calcWaterBridgesStatistics(frames, trajectory, **kwargs):
     :type frames: list
 
     :arg output: return dictorinary whose keys are tuples of resnames or resids
-        default is 'resname'
+        default is 'resid'
     :type output: 'resname' | 'resid'
     """
-    output = kwargs.pop('output', 'resname')
+    output = kwargs.pop('output', 'resid')
     allCoordinates = trajectory.getCoordsets()
     interactionCount = DictionaryList(0)
     distances = DictionaryList([])
@@ -580,10 +580,6 @@ def calcWaterBridgeMatrix(data, metric):
     :arg metric: dict key from data
     :type metric: 'percentage' | 'distAvg' | 'distStd'
     """
-    if not all(isinstance(ind, np.int32) for key in data.keys() for ind in key):
-        raise TypeError(
-            'Data output from calcWaterBridgesStatistics should be resid!')
-
     maxResnum = max(max(key) for key in data.keys()) + 1
     resMatrix = np.zeros((maxResnum, maxResnum), dtype=float)
 

--- a/prody/proteins/waterbridges.py
+++ b/prody/proteins/waterbridges.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-"""This module detect, predicts and analyzes water bridges.
+"""This module detects, predicts and analyzes water bridges.
 """
 
 __author__ = 'Karolina Mikulska-Ruminska'
@@ -8,22 +8,14 @@ __credits__ = ['Frane Doljanin', 'Karolina Mikulska-Ruminska']
 __email__ = ['karolamik@fizyka.umk.pl', 'fdoljanin@pmfst.hr']
 
 
-import numpy as np
-
-from numpy import *
-from prody import LOGGER, SETTINGS, PY3K
-from prody.atomic import AtomGroup, Atom, Atomic, Selection, Select
-from prody.atomic import flags
-from prody.utilities import importLA, checkCoords, showFigure, getCoords
-from prody.measure import calcDistance, calcAngle, calcCenter
-from prody.measure.contacts import findNeighbors
-from prody.proteins import writePDB, parsePDB
-from collections import Counter
-
-from prody.trajectory import TrajBase, Trajectory
-from prody.ensemble import Ensemble
-
+from itertools import chain
 from enum import Enum, auto
+from numpy import *
+
+from prody import LOGGER
+from prody.measure import calcAngle
+from prody.measure.contacts import findNeighbors
+
 
 __all__ = ['calcWaterBridges']
 
@@ -79,6 +71,76 @@ def getWaterGroupAtoms(group):
 
     return uniqueAtomIndices
 
+def 
+
+def calcBridgesFromHBonds_cluster(hydrogenBonds):
+    waterBridges = []
+
+    while len(hydrogenBonds):
+        if not (len(hydrogenBonds) % 500):
+            LOGGER.info(len(hydrogenBonds))
+        waterGroup = []
+        firstWater = hydrogenBonds[0][0] if hydrogenBonds[0][0].type == ResType.WATER else hydrogenBonds[0][1]
+        newWaters = [firstWater]
+
+        while True:
+            currentWater = newWaters[0]
+            for bond in hydrogenBonds.copy():
+                if currentWater.hydrophilic.getIndex() not in [bond[0].hydrophilic.getIndex(), bond[1].hydrophilic.getIndex()]:
+                    continue
+
+                hydrogenBonds.remove(bond)
+                waterGroup.append(bond)
+                otherAtom = bond[0] if currentWater == bond[1] else bond[1]
+                if otherAtom.type == ResType.WATER:
+                    newWaters.append(otherAtom)
+
+            newWaters.pop(0)
+            if not len(newWaters):
+                if checkDoesGroupFormBridge(waterGroup):
+                    atoms = getWaterGroupAtoms(waterGroup)
+                    waterBridges.append(atoms)
+
+                break
+            
+    return waterBridges
+
+def listToSmallerDim(list):
+    newList = []
+    for el_1 in list:
+      for el_2 in el_1:
+          newList.append(el_2)
+    
+    return newList
+
+def goDeeper(currentBond, hydrogenBondsWithDepth, maxDepth):
+    if currentBond[2] != 0 and ResType.PROTEIN in [currentBond[0].type, currentBond[1].type]:
+        return [[currentBond]]
+
+    if currentBond[2] == maxDepth:
+        return [[]]
+    
+    newBonds = []
+    for bond in hydrogenBondsWithDepth:
+        if bond[2] == None and (currentBond[0].hydrophilic.getIndex() in [bond[0].hydrophilic.getIndex(), bond[1].hydrophilic.getIndex()] or currentBond[1].hydrophilic.getIndex() in [bond[0].hydrophilic.getIndex(), bond[1].hydrophilic.getIndex()]):
+            bond[2] = currentBond[2] + 1
+            newBonds.append(bond)
+    
+    newBondsChains = listToSmallerDim([goDeeper(bond, hydrogenBondsWithDepth, maxDepth) for bond in newBonds])
+    return [[currentBond, *chain] for chain in newBondsChains if chain]
+    
+
+
+def calcBridgesFromHBonds_two(hydrogenBonds, hydrophilic):
+    hydrogenBondsWithDepth = [[hb[0], hb[1], None] for hb in hydrogenBonds]
+    initialBonds = []
+    for bond in hydrogenBonds:
+      if hydrophilic.getIndex() in [bond[0].hydrophilic.getIndex(), bond[1].hydrophilic.getIndex()]:
+          initialBonds.append([bond[0], bond[1], 0])
+
+    newBondsChains = listToSmallerDim([goDeeper(bond, hydrogenBondsWithDepth, 3) for bond in initialBonds])
+    return newBondsChains
+
 
 def calcWaterBridges(atoms, **kwargs):
     """Compute water bridges for a protein that has water molecules.
@@ -89,6 +151,10 @@ def calcWaterBridges(atoms, **kwargs):
     :arg distDA: maximal distance between water/protein donor and acceptor
         default is 3.5
     :type distDA: int, float
+
+    :arg distPR: maximal distance between water and residue
+        default is 4
+    :type distPR: int, float
 
     :arg anglePDWA: angle range where protein is donor and water is acceptor
         default is (100, 200)
@@ -112,16 +178,19 @@ def calcWaterBridges(atoms, **kwargs):
     """
 
     distDA = kwargs.pop('distDA', 3.5)
+    distPR = kwargs.pop('distPR', 4)
     anglePDWA = kwargs.pop('anglePDWA', (100, 200))
     anglePAWD = kwargs.pop('anglePAWD', (100, 140))
     angleWW = kwargs.pop('angleWW', (140, 180))
     donors = kwargs.pop('donors', ['nitrogen', 'oxygen', 'sulfur'])
     acceptors = kwargs.pop('acceptors', ['nitrogen', 'oxygen', 'sulfur'])
 
-    waterHydrogens = atoms.select('water and hydrogen')
-    waterOxygens = atoms.select('water and oxygen')
+    consideredAtoms = ~atoms.select(f'water and not within {distPR} of protein')
+    waterHydrogens = consideredAtoms.select('water and hydrogen')
+    waterOxygens = consideredAtoms.select('water and oxygen')
     neighborWaterOxygens = findNeighbors(waterOxygens, distDA)
     contactingWaters = []
+
     for nbPair in neighborWaterOxygens:
         hydrogens_0, hydrogens_1 = getResidueAtoms(
             nbPair[0], waterHydrogens), getResidueAtoms(nbPair[1], waterHydrogens)
@@ -164,34 +233,9 @@ def calcWaterBridges(atoms, **kwargs):
             hydrogenBonds.append((nbPair[1], nbPair[0]))
     LOGGER.info(f'Hydrogen bonds ({len(hydrogenBonds)}) calculated.')
 
-    waterBridges = []
-
-    while len(hydrogenBonds):
-        if not len(hydrogenBonds) % 500:
-            LOGGER.info(len(hydrogenBonds))
-        waterGroup = []
-        firstWater = hydrogenBonds[0][0] if hydrogenBonds[0][0].type == ResType.WATER else hydrogenBonds[0][1]
-        newWaters = [firstWater]
-
-        while True:
-            currentWater = newWaters[0]
-            for bond in hydrogenBonds.copy():
-                if currentWater.hydrophilic.getIndex() not in [bond[0].hydrophilic.getIndex(), bond[1].hydrophilic.getIndex()]:
-                    continue
-
-                hydrogenBonds.remove(bond)
-                waterGroup.append(bond)
-                otherAtom = bond[0] if currentWater == bond[1] else bond[1]
-                if otherAtom.type == ResType.WATER:
-                    newWaters.append(otherAtom)
-
-            newWaters.pop(0)
-            if not len(newWaters):
-                if checkDoesGroupFormBridge(waterGroup):
-                    atoms = getWaterGroupAtoms(waterGroup)
-                    waterBridges.append(atoms)
-
-                break
-    LOGGER.info('Water bridges calculated.')
+    #waterBridges = calcBridgesFromHBonds_cluster(hydrogenBonds)
+    for i in range(100):
+      waterBridges = calcBridgesFromHBonds_two(hydrogenBonds, atoms[2459])
+    LOGGER.info(f'Water bridges calculated.')
 
     return waterBridges

--- a/prody/proteins/waterbridges.py
+++ b/prody/proteins/waterbridges.py
@@ -16,6 +16,9 @@ from prody import LOGGER
 from prody.measure import calcAngle
 from prody.measure.contacts import findNeighbors
 
+from timeit import default_timer as timer
+
+
 
 __all__ = ['calcWaterBridges']
 
@@ -71,8 +74,6 @@ def getWaterGroupAtoms(group):
 
     return uniqueAtomIndices
 
-def 
-
 def calcBridgesFromHBonds_cluster(hydrogenBonds):
     waterBridges = []
 
@@ -113,33 +114,70 @@ def listToSmallerDim(list):
     
     return newList
 
-def goDeeper(currentBond, hydrogenBondsWithDepth, maxDepth):
+def goDeeper_old(currentBond, hydrogenBondsWithDepth, maxDepth):
     if currentBond[2] != 0 and ResType.PROTEIN in [currentBond[0].type, currentBond[1].type]:
         return [[currentBond]]
 
     if currentBond[2] == maxDepth:
         return [[]]
-    
+
     newBonds = []
     for bond in hydrogenBondsWithDepth:
         if bond[2] == None and (currentBond[0].hydrophilic.getIndex() in [bond[0].hydrophilic.getIndex(), bond[1].hydrophilic.getIndex()] or currentBond[1].hydrophilic.getIndex() in [bond[0].hydrophilic.getIndex(), bond[1].hydrophilic.getIndex()]):
             bond[2] = currentBond[2] + 1
             newBonds.append(bond)
-    
+
     newBondsChains = listToSmallerDim([goDeeper(bond, hydrogenBondsWithDepth, maxDepth) for bond in newBonds])
     return [[currentBond, *chain] for chain in newBondsChains if chain]
     
-
-
-def calcBridgesFromHBonds_two(hydrogenBonds, hydrophilic):
+def calcBridgesFromHBonds_depth_old(hydrogenBonds, hydrophilic):
     hydrogenBondsWithDepth = [[hb[0], hb[1], None] for hb in hydrogenBonds]
     initialBonds = []
     for bond in hydrogenBonds:
       if hydrophilic.getIndex() in [bond[0].hydrophilic.getIndex(), bond[1].hydrophilic.getIndex()]:
           initialBonds.append([bond[0], bond[1], 0])
 
-    newBondsChains = listToSmallerDim([goDeeper(bond, hydrogenBondsWithDepth, 3) for bond in initialBonds])
+    newBondsChains = listToSmallerDim([goDeeper(bond, hydrogenBondsWithDepth, 2) for bond in initialBonds])
     return newBondsChains
+
+def getRelationsList(hydrogenBonds, numAtoms):
+    relations = [[None, [], [], False] for _ in range(numAtoms)]
+    for bond in hydrogenBonds:
+        index_0, index_1 = bond[0].hydrophilic.getIndex(), bond[1].hydrophilic.getIndex()
+        relations[index_0][0] = bond[0]
+        relations[index_1][0] = bond[1]
+
+        relations[index_0][1].append(bond)
+        relations[index_1][1].append(bond)
+        
+        relations[index_0][2].append(index_1)
+        relations[index_1][2].append(index_0)
+
+    return relations
+    
+def goDeeper(currentAtom, relationsList, depthLeft):
+    currentIndex = currentAtom.hydrophilic.getIndex()
+    relationsList[currentIndex] = True
+
+    if currentAtom.type == ResType.PROTEIN:
+        return [[currentAtom]]
+    
+    if depthLeft == 0:
+        return [[]]
+    
+    newAtoms = []
+    for atomIndex in relationsList[currentIndex][2]:
+        if not relationsList[atomIndex][3]:
+            newAtoms.append(relationsList[atomIndex][0])
+    
+    newAtomsChains = listToSmallerDim([goDeeper(atom, relationsList, depthLeft-1) for atom in newAtoms])
+    return [[currentAtom, *chain] for chain in newAtomsChains if chain]
+    
+def calcBridgesFromHBonds(watchedAtom, relationsList, depth):
+    initialAtom = relationsList[watchedAtom[0].hydrophilic.getIndex()]
+    initialAtom[2] = True
+    
+    return goDeeper(initialAtom, relationsList, depth-1)
 
 
 def calcWaterBridges(atoms, **kwargs):
@@ -152,9 +190,9 @@ def calcWaterBridges(atoms, **kwargs):
         default is 3.5
     :type distDA: int, float
 
-    :arg distPR: maximal distance between water and residue
+    :arg distWR: maximal distance between water and residue
         default is 4
-    :type distPR: int, float
+    :type distWR: int, float
 
     :arg anglePDWA: angle range where protein is donor and water is acceptor
         default is (100, 200)
@@ -178,14 +216,14 @@ def calcWaterBridges(atoms, **kwargs):
     """
 
     distDA = kwargs.pop('distDA', 3.5)
-    distPR = kwargs.pop('distPR', 4)
+    distWR = kwargs.pop('distWR', 4)
     anglePDWA = kwargs.pop('anglePDWA', (100, 200))
     anglePAWD = kwargs.pop('anglePAWD', (100, 140))
     angleWW = kwargs.pop('angleWW', (140, 180))
     donors = kwargs.pop('donors', ['nitrogen', 'oxygen', 'sulfur'])
     acceptors = kwargs.pop('acceptors', ['nitrogen', 'oxygen', 'sulfur'])
 
-    consideredAtoms = ~atoms.select(f'water and not within {distPR} of protein')
+    consideredAtoms = ~atoms.select(f'water and not within {distWR} of protein')
     waterHydrogens = consideredAtoms.select('water and hydrogen')
     waterOxygens = consideredAtoms.select('water and oxygen')
     neighborWaterOxygens = findNeighbors(waterOxygens, distDA)
@@ -234,8 +272,11 @@ def calcWaterBridges(atoms, **kwargs):
     LOGGER.info(f'Hydrogen bonds ({len(hydrogenBonds)}) calculated.')
 
     #waterBridges = calcBridgesFromHBonds_cluster(hydrogenBonds)
-    for i in range(100):
-      waterBridges = calcBridgesFromHBonds_two(hydrogenBonds, atoms[2459])
+    start = timer()
+    relations = getRelationsList(hydrogenBonds, len(atoms))
+    waterBridges = calcBridgesFromHBonds(relations[2459], relations, 2)
+    end = timer()
+    LOGGER.info(end-start)
     LOGGER.info(f'Water bridges calculated.')
 
     return waterBridges


### PR DESCRIPTION
New module for detection and analysis of water bridges in proteins.

Water bridges are hydrogen bonds formed when water molecules bridge between two or more protein residues, creating a hydrogen-bonding network stabilising protein-protein and protein-ligand interactions. The developed code aims to identify and analyze conserved water molecules and protein regions involved in interactions mediated by water bridges. This will benefit the scientific community in understanding protein interactions and stability.

# Methods
More information on the methodology can be found [here](https://drive.google.com/file/d/1CmD1F66DqQwt4_PKWM5fq-NWRZtWCYFf/view?usp=sharing).

`calcWaterBridges` returns calculated bridges in one of three output types:
1. indices -bridge is just a list of indices of atoms involved in a bridge
2. atomic - bridge is an object which has _waters_ and _proteins_ attributes, and each is a list of Atom objects involved in bridging
3. info - bridge is a list of strings containing bridge info

`calcWaterBridgesTrajectory` does the same but for multiple frame trajectory
`getWaterBridgesInfoOutput` converts atomic output from calcWaterBridges/Trajectory into info
`calcWaterBridgesStatistics` returns statistics for trajectory; analyses every two residues involved in the bridge (number of occurrences, average distance, distance std)
`getWaterBridgeStatInfo` converts indices output from calcWaterBridgesStatistics to info
`calcWaterBridgeMatrix` calculates matrix based on calcWaterBridgesStatistics indices output
`showWaterBridgeMatrix` shows a matrix based on calcWaterBridgesStatistics indices output
`calcBridgingResiduesHistogram` shows a histogram with frame occurrence count for each residue
`calcWaterBridgesDistribution` shows distributions for various metrics
`savePDBWaterBridges` saves one PDB with occupancy = 1 for involved residues and just waters that participate in the bridge
`savePDBWaterBridgesTrajectory` is the same as savePDBWaterBridges but for multiple frames + modifies beta so that it shows the percentage of interactions for a residue
`saveWaterBridges` saves atomic water bridges into an info file for read-only, or atomic file so that it can be loaded faster next time instead of computing again
`parseWaterBridges` parses saveWaterBridges output so that it behaves like it was returned from calcWaterBridges/Trajectory

This module was developed with mentorship from @karolamik13 and is part of InSty development project.