### PR TITLE
Make sure PDB chain id is only a single character.

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1525,7 +1525,7 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
 
             write(pdbline % (hetero[i], serial,
                              atomnames[i], altlocs[i],
-                             resname, chainids[i][0], resnum,
+                             resname, chainids[i][:1], resnum,
                              icodes[i],
                              xyz[0], xyz[1], xyz[2],
                              occupancies[i], bfactors[i],

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1525,7 +1525,7 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
 
             write(pdbline % (hetero[i], serial,
                              atomnames[i], altlocs[i],
-                             resname, chainids[i], resnum,
+                             resname, chainids[i][0], resnum,
                              icodes[i],
                              xyz[0], xyz[1], xyz[2],
                              occupancies[i], bfactors[i],


### PR DESCRIPTION
Some structures can have multi-character chain identifiers (see 6Z4H). Really Bad Things happen when trying to write these out.