### PR TITLE
only get and set acs ind if hasattr

### DIFF
--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -1242,8 +1242,7 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
         Default is **False**, which means using hexadecimal instead.
         NB: ChimeraX seems to prefer hybrid36 and may have problems with hexadecimal.
     :type hybrid36: bool
-    """
-    initialACSI = atoms.getACSIndex()
+    """    
     renumber = kwargs.get('renumber', True)
 
     remark = str(atoms)
@@ -1262,8 +1261,10 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
     if coordsets is None:
         raise ValueError('atoms does not have any coordinate sets')
 
+    had_atoms = False
     try:
         acsi = atoms.getACSIndex()
+        had_atoms = True
     except AttributeError:
         try:
             atoms = atoms.getAtoms()
@@ -1438,7 +1439,8 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
     num_ter_lines = 0
     for m, coords in enumerate(coordsets):
 
-        atoms.setACSIndex(m)
+        if had_atoms:
+            atoms.setACSIndex(m)
         anisous = atoms._getAnisous()
         if anisous is not None:
             anisous = np.array(anisous * 10000, dtype=int)
@@ -1614,7 +1616,8 @@ def writePDBStream(stream, atoms, csets=None, **kwargs):
             
     write('END   ' + " "*74 + '\n')
 
-    atoms.setACSIndex(initialACSI)
+    if had_atoms:
+        atoms.setACSIndex(acsi)
 
 writePDBStream.__doc__ += _writePDBdoc
 

--- a/prody/tests/proteins/test_pdbfile.py
+++ b/prody/tests/proteins/test_pdbfile.py
@@ -262,6 +262,11 @@ class TestWritePDB(unittest.TestCase):
         self.ag = parsePDB(self.pdb['path'])
         self.tmp = os.path.join(TEMPDIR, 'test.pdb')
 
+        self.ens = PDBEnsemble()
+        self.ens.setAtoms(self.ag)
+        self.ens.setCoords(self.ag.getCoords())
+        self.ens.addCoordset(self.ag.getCoordsets())
+
         self.ubi = parsePDB(DATA_FILES['1ubi']['path'], secondary=True)
 
         self.hex = parsePDB(DATA_FILES['hex']['path'])
@@ -446,6 +451,16 @@ class TestWritePDB(unittest.TestCase):
         
         self.assertEqual(lines1[8], lines2[8],
             'writePDB failed to write correct ANISOU line 8 for 6flr selection with altloc None')
+        
+    def testWriteEnsembleToPDB(self):
+        """Test that writePDB can handle ensembles."""
+
+        out = writePDB(self.tmp, self.ens)
+        out = parsePDB(out)
+        self.assertEqual(out.numCoordsets(), self.ens.numCoordsets(),
+            'failed to write correct number of models from ensemble')
+        assert_equal(out.getCoords(), self.ag.getCoordsets(0),
+                'failed to write ensemble model 1 coordinates correctly')
 
     @dec.slow
     def tearDown(self):


### PR DESCRIPTION
fixes a problem created by #1783 because I didn't think about using writePDB on ensembles