### PR TITLE
fix default altloc mask size for parseMMCIF

### DIFF
--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -170,6 +170,7 @@ def parseMMCIFStream(stream, **kwargs):
     unite_chains = kwargs.get('unite_chains', False)
     altloc = kwargs.get('altloc', 'A')
     header = kwargs.get('header', False)
+    report = kwargs.get('report', False)
     assert isinstance(header, bool), 'header must be a boolean'
 
     if model is not None:
@@ -235,7 +236,7 @@ def parseMMCIFStream(stream, **kwargs):
             hd = getCIFHeaderDict(lines)
 
         _parseMMCIFLines(ag, lines, model, chain, subset, altloc, 
-                         segment, unite_chains)
+                         segment, unite_chains, report)
 
         if ag.numAtoms() > 0:
             LOGGER.report('{0} atoms and {1} coordinate set(s) were '
@@ -281,7 +282,7 @@ parseMMCIFStream.__doc__ += _parseMMCIFdoc
 
 def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
                      altloc_torf, segment, unite_chains,
-                     report=False):
+                     report):
     """Returns an AtomGroup. See also :func:`.parsePDBStream()`.
 
     :arg lines: mmCIF lines

--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -487,7 +487,7 @@ def _parseMMCIFLines(atomgroup, lines, model, chain, subset,
     else:
         modelSize = acount
 
-    mask = np.full(modelSize, True, dtype=bool)
+    mask = np.full(acount, True, dtype=bool)
     if which_altlocs != 'all':
         #mask out any unwanted alternative locations
         mask = (altlocs == ' ') | np.logical_or(*[(altlocs == altloc)

--- a/prody/tests/proteins/test_ciffile.py
+++ b/prody/tests/proteins/test_ciffile.py
@@ -280,3 +280,14 @@ class TestParseMMCIF(unittest.TestCase):
 
         assert_allclose(hisB234.getAnisous(), self.altlocs['anisousA'],
             err_msg='parsePDB failed to have right His B234 CA atoms getAnisous A with altloc "all"')
+
+    def testAltlocAllMultiModels(self):
+        """Test number of coordinate sets and atoms for multi-model case with altloc='all'."""
+
+        path = pathDatafile(self.multi['file'])
+
+        ag = parsePDB(path, altloc="all")
+        self.assertEqual(ag.numAtoms(), self.multi['atoms'],
+            'parsePDB failed to parse correct number of atoms for multi-model with altloc "all"')
+        self.assertEqual(ag.numCoordsets(), self.multi['models'],
+            'parsePDB failed to parse correct number of coordsets ({0}) with altloc "all"'.format(self.multi['models']))


### PR DESCRIPTION
Otherwise, we get an index error with altloc='all'