### PR TITLE
fix networkx for updated versions

### DIFF
--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -2278,7 +2278,7 @@ def showTree_networkx(tree, node_size=20, node_color='red', node_shape='o',
     networkx.draw_networkx_edges(G, pos=layout)
     
     if np.isscalar(node_shape):
-        networkx.draw_networkx_nodes(G, pos=layout, withlabels=False, node_size=sizes, 
+        networkx.draw_networkx_nodes(G, pos=layout, label=None, node_size=sizes, 
                                         node_shape=node_shape, node_color=colors)
     else:
         for shape in shape_groups:
@@ -2286,7 +2286,7 @@ def showTree_networkx(tree, node_size=20, node_color='red', node_shape='o',
             nodesizes = [sizes[i] for i in shape_groups[shape]]
             nodecolors = [colors[i] for i in shape_groups[shape]]
             if not nodelist: continue
-            networkx.draw_networkx_nodes(G, pos=layout, withlabels=False, node_size=nodesizes, 
+            networkx.draw_networkx_nodes(G, pos=layout, label=None, node_size=nodesizes, 
                                         node_shape=shape, node_color=nodecolors, 
                                         nodelist=nodelist)
 


### PR DESCRIPTION
Running showTree_networkx with default parameters fails to label nodes with the following error:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Input In [7], in <cell line: 1>()
----> 1 showTree_networkx(seqid_tree)

File ~/software/scipion3/software/em/ProDy/prody/dynamics/plotting.py:2281, in showTree_networkx(tree, node_size, node_color, node_shape, withlabels, scale, iterations, k, **kwargs)
   2278 networkx.draw_networkx_edges(G, pos=layout)
   2280 if np.isscalar(node_shape):
-> 2281     networkx.draw_networkx_nodes(G, pos=layout, withlabels=False, node_size=sizes, 
   2282                                     node_shape=node_shape, node_color=colors)
   2283 else:
   2284     for shape in shape_groups:

TypeError: draw_networkx_nodes() got an unexpected keyword argument 'withlabels'
```

It looks like withlabels hasn't been part of this draw_networkx_nodes or draw_networkx_edges for a long time but there is a label keyword argument instead.