### PR TITLE
override GOOD_SEQID and GOOD_COVERAGE with seqid and coverage if higher

### DIFF
--- a/prody/proteins/compare.py
+++ b/prody/proteins/compare.py
@@ -997,8 +997,8 @@ def mapChainOntoChain(mobile, target, **kwargs):
         simple_target, simple_mobile)
     _seqid, _cover = calcScores(n_match, n_mapped, len(simple_target))
 
-    trivial_seqid = GOOD_SEQID if pwalign else seqid
-    trivial_cover = GOOD_COVERAGE if pwalign else coverage
+    trivial_seqid = max(GOOD_SEQID, seqid) if pwalign else seqid
+    trivial_cover = max(GOOD_COVERAGE, coverage) if pwalign else coverage
     if _seqid >= trivial_seqid and _cover >= trivial_cover:
         LOGGER.debug('\tMapped: {0} residues match with {1:.0f}% '
                 'sequence identity and {2:.0f}% overlap.'


### PR DESCRIPTION
Otherwise, the trivial mapping is accepted if seqid is >=90 % even if the user wants more stringency e.g. 96 %

Without the fix, the trivial mapping gets included in the ensemble:
```
@>   Comparing Chain B from 7wz1 (len=1027) with Chain A from 7dx1:
@>      Mapped: 961 residues match with 95% sequence identity and 99% overlap.
@> Trying to map atoms based on residue numbers and identities:
@>   Comparing Chain A from 7wz1 (len=1032) with Chain B from 7dx1:
@>      Mapped: 964 residues match with 95% sequence identity and 99% overlap.
@> Trying to map atoms based on residue numbers and identities:
@>   Comparing Chain C from 7wz1 (len=1033) with Chain C from 7dx1:
@>      Mapped: 964 residues match with 95% sequence identity and 99% overlap.
@> Finding the atommaps based on their coverages...
@> Identified that there exists 1 atommap(s) potentially.
```

With the fix, the trivial mapping is excluded and pwalign is used:
```
@> Trying to map atoms based on residue numbers and identities:
@>   Comparing Chain B from 7wz1 (len=1027) with Chain A from 7dx1:
@> Trying to map atoms based on local sequence alignment:
@>   Comparing Chain B from 7wz1 (len=1027) with Chain A from 7dx1:
@>      Mapped: 962 residues match with 97% sequence identity and 94% overlap.
@> Trying to map atoms based on residue numbers and identities:
@>   Comparing Chain A from 7wz1 (len=1032) with Chain B from 7dx1:
@> Trying to map atoms based on local sequence alignment:
@>   Comparing Chain A from 7wz1 (len=1032) with Chain B from 7dx1:
@>      Mapped: 963 residues match with 97% sequence identity and 93% overlap.
@> Trying to map atoms based on residue numbers and identities:
@>   Comparing Chain C from 7wz1 (len=1033) with Chain C from 7dx1:
@> Trying to map atoms based on local sequence alignment:
@>   Comparing Chain C from 7wz1 (len=1033) with Chain C from 7dx1:
@>      Mapped: 963 residues match with 97% sequence identity and 93% overlap.
@> Finding the atommaps based on their coverages...
@> Identified that there exists 1 atommap(s) potentially.
```