### PR TITLE
fix showAtomicLines gaps

### DIFF
--- a/prody/dynamics/plotting.py
+++ b/prody/dynamics/plotting.py
@@ -1997,7 +1997,7 @@ def showAtomicLines(*args, **kwargs):
                         last += len(resnums)
                     else:
                         x.extend(resnums + last)
-                        last = resnums[-1]
+                        last += resnums[-1]
                     
         if gap:
             if overlay:


### PR DESCRIPTION
Without the fix, we get overlapping of chains after the second one onto the second one:
```
In [1]: import matplotlib.pyplot as plt; plt.ion()
Out[1]: <matplotlib.pyplot._IonContext at 0x7fa8eb592940>

In [2]: from prody import *

In [3]: ag = parsePDB('7kec')

In [4]: atoms = ag.ca

In [5]: showAtomicLines(atoms.getBetas(), atoms=atoms, gap=True)
```
![Figure_2](https://github.com/prody/ProDy/assets/13259162/392bedab-b0e2-4373-8d2b-cf02566cb7ac)

With the fix, everything is as it should be:
![Figure_3](https://github.com/prody/ProDy/assets/13259162/76852e55-7f06-40f7-a00d-ed9614f16719)
