### PR TITLE
add selstr and box selection to watfinder

### DIFF
--- a/prody/proteins/__init__.py
+++ b/prody/proteins/__init__.py
@@ -260,7 +260,7 @@ try:
 except SyntaxError:
     import logging
     logger = logging.getLogger()
-    logger.warn("Cannot import waterbridges in python 2")
+    logger.warn("Cannot import waterbridges")
 else:
     __all__.extend(waterbridges.__all__)
 

--- a/prody/proteins/waterbridges.py
+++ b/prody/proteins/waterbridges.py
@@ -7,6 +7,7 @@ __author__ = 'Karolina Mikulska-Ruminska'
 __credits__ = ['Frane Doljanin', 'Karolina Mikulska-Ruminska']
 __email__ = ['karolamik@fizyka.umk.pl', 'fdoljanin@pmfst.hr']
 
+from numbers import Number
 import numpy as np
 import os
 
@@ -30,7 +31,7 @@ __all__ = ['calcWaterBridges', 'calcWaterBridgesTrajectory', 'getWaterBridgesInf
            'calcBridgingResiduesHistogram', 'calcWaterBridgesDistribution',
            'savePDBWaterBridges', 'savePDBWaterBridgesTrajectory',
            'saveWaterBridges', 'parseWaterBridges', 'findClusterCenters',
-           'filterStructuresWithoutWater']
+           'filterStructuresWithoutWater', 'selectSurroundingsBox']
 
 
 class ResType(Enum):
@@ -366,6 +367,15 @@ def calcWaterBridges(atoms, **kwargs):
     :arg isInfoLog: should log information
         default is True
     :type output: bool
+
+    :arg selstr: selection string for focusing analysis
+        default of **None** focuses on everything
+    :type selstr: str
+
+    :arg expand_selection: whether to expand the selection with 
+        :func:`.selectSurroundingsBox`, selecting a box surrounding it.
+        Default is **False**
+    :type expand_selection: bool
     """
 
     method = kwargs.pop('method', 'chain')
@@ -386,6 +396,16 @@ def calcWaterBridges(atoms, **kwargs):
         raise TypeError('Method should be chain or cluster.')
     if outputType not in ['info', 'atomic', 'indices']:
         raise TypeError('Output can be info, atomic or indices.')
+
+    selstr = kwargs.pop('selstr', None)
+    if selstr is not None:
+        selection = atoms.select(selstr).copy()
+
+        expand_selection = kwargs.pop('expand_selection', False)
+        if expand_selection:
+            atoms = selectSurroundingsBox(atoms, selection).copy()
+        else:
+            atoms = selection.copy()
 
     water = atoms.select('water')
     if water is None:
@@ -508,6 +528,7 @@ def calcWaterBridgesTrajectory(atoms, trajectory, **kwargs):
         for j0, frame0 in enumerate(traj, start=start_frame):
             LOGGER.info('Frame: {0}'.format(j0))
             atoms_copy.setCoords(frame0.getCoords())
+
             interactions = calcWaterBridges(
                 atoms_copy, isInfoLog=False, **kwargs)
             interactions_all.append(interactions)
@@ -1215,3 +1236,36 @@ def filterStructuresWithoutWater(structures, min_water=0, filenames=None):
         new_structures.append(struct)
 
     return list(reversed(new_structures))
+
+
+def selectSurroundingsBox(atoms, select, padding=0, return_selstr=False):
+    """Select the surroundings of *select* within *atoms* using
+    a bounding box with optional *padding*."""
+
+    if not isinstance(atoms, Atomic):
+        raise TypeError('atoms should be an Atomic object')
+
+    if isinstance(select, str):
+        select = atoms.select(select)
+
+    if not isinstance(select, Atomic):
+        raise TypeError('select should be a valid selection or selection string')
+
+    if not isinstance(padding, Number):
+        raise TypeError('padding should be a number')
+    if padding < 0:
+        raise ValueError('padding should be a positive number')
+
+    minCoords = select.getCoords().min(axis=0)
+    maxCoords = select.getCoords().max(axis=0)
+
+    if padding > 0:
+        minCoords -= padding
+        maxCoords += padding
+
+    selstr = '(x `{0} to {1}`) and (y `{2} to {3}`) and (z `{4} to {5}`)'.format(
+        minCoords[0], maxCoords[0], minCoords[1], maxCoords[1], minCoords[2], maxCoords[2])
+
+    if return_selstr:
+        return selstr
+    return atoms.select(selstr)


### PR DESCRIPTION
New function selectSurroundingsBox selects the surroundings of a selection in a bounding box with the minimum and maximum x, y and z values, and an optional padding. There is an option to just return the x, y, z selection string.

calcWaterBridges and calcWaterBridgesTrajectory have new kwargs selstr and expand_selection to take the output of this function or any other user selstr.

By default, expand_selection is False to not have unexpected results for other selections. If set to True, then it uses the new function after applying the initial selstr.

```
In [1]: from prody import *
   ...: 
   ...: atoms = parsePDB('4a0v_all_sci.pdb')
   ...: traj = parseDCD('4a0v_all_sci_3frames.dcd')
@> 707044 atoms and 1 coordinate set(s) were parsed in 9.51s.
@> DCD file contains 4 coordinate sets for 707044 atoms.
@> DCD file was parsed in 0.06 seconds.
@> 32.37 MB parsed at input rate 563.60 MB/s.
@> 4 coordinate sets parsed at input rate 69 frame/s.

In [2]: x = calcWaterBridgesTrajectory(atoms, traj, start_frame=1, selstr='segname PROA', expand_selecti
   ...: on=True)
@> Frame: 1
@> 677 water bridges detected using method chain.
@> Frame: 2
@> 552 water bridges detected using method chain.
@> Frame: 3
@> 598 water bridges detected using method chain.

In [3]: x = calcWaterBridgesTrajectory(atoms, traj, start_frame=1)
@> Frame: 1
@> 6077 water bridges detected using method chain.
@> Frame: 2
@> 6011 water bridges detected using method chain.
@> Frame: 3
@> 6127 water bridges detected using method chain.
```


