### PR TITLE
Fix frame update and allow non-parallel

### DIFF
--- a/prody/proteins/waterbridges.py
+++ b/prody/proteins/waterbridges.py
@@ -551,10 +551,10 @@ def calcWaterBridgesTrajectory(atoms, trajectory, **kwargs):
 
             j0 = start_frame
             while j0 < traj.numConfs():
-                frame0 = traj[j0]
 
                 processes = []
                 for i in range(max_proc):
+                    frame0 = traj[j0]
                     p = mp.Process(target=analyseFrame, args=(j0, start_frame,
                                                               frame0,
                                                               interactions_all))


### PR DESCRIPTION
Without this fix, we can see on the last pull request that we get the same number of water bridges for groups of frames.

Having the option to not use the parallel code when max_proc=1 is also a good thing to have.