### PR TITLE
fix localpdb gz check

### DIFF
--- a/prody/proteins/localpdb.py
+++ b/prody/proteins/localpdb.py
@@ -485,8 +485,8 @@ def findPDBFiles(path, case=None, **kwargs):
     for fn in iterPDBFilenames(path, sort=True, reverse=True, **kwargs):
         fn = normpath(fn)
         pdb = splitext(split(fn)[1])[0]
-        ending = splitext(splitext(split(fn)[1])[0])[1]
-        if ending == 'gz':
+        ending = splitext(split(fn)[1])[1]
+        if ending == '.gz':
             pdb = splitext(pdb)[0]
         if len(pdb) == 7 and pdb.startswith('pdb'):
             pdb = pdb[3:]


### PR DESCRIPTION
Otherwise, prody keeps downloading pdb files again and again if we don't say compressed=False:
```
(prody-github) jkrieger@whipple ~/software/scipion3/software/em/prody-github/ProDy (main) $ rm 8c2*
(prody-github) jkrieger@whipple ~/software/scipion3/software/em/prody-github/ProDy (main) $ ipython
Python 3.9.19 (main, May  6 2024, 19:43:03) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.15.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: protein = prody.parsePDB('8C2H')
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 8c2h downloaded (8c2h.pdb.gz)
@> PDB download via FTP completed (1 downloaded, 0 failed).
@> 9912 atoms and 1 coordinate set(s) were parsed in 0.08s.

In [3]: protein = prody.parsePDB('8C2H')
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 8c2h downloaded (8c2h.pdb.gz)
@> PDB download via FTP completed (1 downloaded, 0 failed).
@> 9912 atoms and 1 coordinate set(s) were parsed in 0.08s.

In [4]: exit
(prody-github) jkrieger@whipple ~/software/scipion3/software/em/prody-github/ProDy (main) $ rm 8c2*
(prody-github) jkrieger@whipple ~/software/scipion3/software/em/prody-github/ProDy (main) $ git checkout localpdb_fix 
Switched to branch 'localpdb_fix'
Your branch is up to date with 'origin/localpdb_fix'.
(prody-github) jkrieger@whipple ~/software/scipion3/software/em/prody-github/ProDy (localpdb_fix) $ ipython
Python 3.9.19 (main, May  6 2024, 19:43:03) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.15.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: protein = prody.parsePDB('8C2H')
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 8c2h downloaded (8c2h.pdb.gz)
@> PDB download via FTP completed (1 downloaded, 0 failed).
@> 9912 atoms and 1 coordinate set(s) were parsed in 0.08s.

In [3]: protein = prody.parsePDB('8C2H')
@> PDB file is found in working directory (8c2h.pdb.gz).
@> 9912 atoms and 1 coordinate set(s) were parsed in 0.08s.
```

With compressed=False, we also had the same problem that is now fixed. With the .gz file in the directory, the current prody still downloads again, but this branch is fine.
```
(prody-github) jkrieger@whipple ~/software/scipion3/software/em/prody-github/ProDy (main) $ rm 8c2h.pdb
(prody-github) jkrieger@whipple ~/software/scipion3/software/em/prody-github/ProDy (main) $ ipython
Python 3.9.19 (main, May  6 2024, 19:43:03) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.15.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: protein = prody.parsePDB('8C2H', compressed=False)
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> 8c2h downloaded (8c2h.pdb)
@> PDB download via FTP completed (1 downloaded, 0 failed).
@> 9912 atoms and 1 coordinate set(s) were parsed in 0.07s.

In [3]: exit
(prody-github) jkrieger@whipple ~/software/scipion3/software/em/prody-github/ProDy (main) $ rm 8c2h.pdb
(prody-github) jkrieger@whipple ~/software/scipion3/software/em/prody-github/ProDy (main) $ git checkout localpdb_fix 
Switched to branch 'localpdb_fix'
Your branch is up to date with 'origin/localpdb_fix'.
(prody-github) jkrieger@whipple ~/software/scipion3/software/em/prody-github/ProDy (localpdb_fix) $ ipython
Python 3.9.19 (main, May  6 2024, 19:43:03) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.15.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from prody import *

In [2]: protein = prody.parsePDB('8C2H', compressed=False)
@> 9912 atoms and 1 coordinate set(s) were parsed in 0.08s.
```