### PR TITLE
eigh evd when no turbo

### DIFF
--- a/prody/utilities/eigtools.py
+++ b/prody/utilities/eigtools.py
@@ -40,9 +40,9 @@ def solveEig(M, n_modes=None, zeros=False, turbo=True, expct_n_zeros=None, rever
             if eigvals:
                 turbo = False
             if not issparse(M):
-                if hasattr('linalg.eigh', 'turbo'):
+                try:
                     values, vectors = linalg.eigh(M, turbo=turbo, eigvals=eigvals)
-                else:
+                except AttributeError:
                     if turbo:
                         values, vectors = linalg.eigh(M, driver='evd', eigvals=eigvals)
                     else:

--- a/prody/utilities/eigtools.py
+++ b/prody/utilities/eigtools.py
@@ -40,7 +40,13 @@ def solveEig(M, n_modes=None, zeros=False, turbo=True, expct_n_zeros=None, rever
             if eigvals:
                 turbo = False
             if not issparse(M):
-                values, vectors = linalg.eigh(M, turbo=turbo, eigvals=eigvals)
+                if hasattr('linalg.eigh', 'turbo'):
+                    values, vectors = linalg.eigh(M, turbo=turbo, eigvals=eigvals)
+                else:
+                    if turbo:
+                        values, vectors = linalg.eigh(M, driver='evd', eigvals=eigvals)
+                    else:
+                        values, vectors = linalg.eigh(M, eigvals=eigvals)
             else:
                 try:
                     from scipy.sparse import linalg as scipy_sparse_la

--- a/prody/utilities/eigtools.py
+++ b/prody/utilities/eigtools.py
@@ -42,11 +42,11 @@ def solveEig(M, n_modes=None, zeros=False, turbo=True, expct_n_zeros=None, rever
             if not issparse(M):
                 try:
                     values, vectors = linalg.eigh(M, turbo=turbo, eigvals=eigvals)
-                except AttributeError:
+                except TypeError:
                     if turbo:
-                        values, vectors = linalg.eigh(M, driver='evd', eigvals=eigvals)
+                        values, vectors = linalg.eigh(M, driver='evd', subset_by_index=eigvals)
                     else:
-                        values, vectors = linalg.eigh(M, eigvals=eigvals)
+                        values, vectors = linalg.eigh(M, subset_by_index=eigvals)
             else:
                 try:
                     from scipy.sparse import linalg as scipy_sparse_la

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=1.10,<1.25", "pyparsing<=3.1.1", "scipy<=1.13.1"]
+requires = ["setuptools", "wheel", "numpy>=1.10,<1.24", "pyparsing<=3.1.1", "scipy"]

--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,9 @@ if sys.version_info[:2] < (2, 7):
     sys.exit()
 
 if sys.version_info[:2] == (2, 7) or sys.version_info[:2] <= (3, 5):
-    INSTALL_REQUIRES=['numpy>=1.10,<1.25', 'biopython<=1.76', 'pyparsing', 'scipy']
+    INSTALL_REQUIRES=['numpy>=1.10', 'biopython<=1.76', 'pyparsing', 'scipy']
 else:
-    INSTALL_REQUIRES=['numpy>=1.10,<1.24', 'biopython', 'pyparsing<=3.1.1', 'scipy<=1.13.1', 'setuptools']
+    INSTALL_REQUIRES=['numpy>=1.10,<1.24', 'biopython', 'pyparsing<=3.1.1', 'scipy', 'setuptools']
 
 if sys.version_info[0] == 3 and sys.version_info[1] < 6:
     sys.stderr.write('Python 3.5 and older is not supported\n')


### PR DESCRIPTION
fixes #1955 

later scipy uses the driver argument instead of turbo. The default value is 'evr' for standard problems and driver='evd' can be faster at the expense of memory so matches turbo. The deprecation warning says 'gvd' but actually we don't have a generalised problem as we don't provide a second matrix b.