### PR TITLE
extract res if only 1 in extendAtoms

### DIFF
--- a/prody/atomic/functions.py
+++ b/prody/atomic/functions.py
@@ -346,7 +346,10 @@ def extendAtoms(nodes, atoms, is3d=False):
         if res is None:
             raise ValueError('atoms must contain a residue for all atoms')
         if isinstance(res, list):
-            raise ValueError('not enough data to get a single residue for all atoms')
+            if len(res) == 1:
+                res = res[0]
+            else:
+                raise ValueError('not enough data to get a single residue for all atoms')
 
         res_atom_indices = res._getIndices()
         if not fastin(res, residues):


### PR DESCRIPTION
fixes #1962 

for some reason HierView getResidue gets atoms from multiple residues for GLN 357 and it's fixed in the list comprehension of _getResidue so we only have one entry in the list. So, it throws an error that there's a list when really we can extract it, which we now do.