### PR TITLE
clustenm fixes

### DIFF
--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -1076,7 +1076,7 @@ class ClustENM(Ensemble):
         self._sparse = kwargs.get('sparse', False)
         self._kdtree = kwargs.get('kdtree', False)
         self._turbo = kwargs.get('turbo', False)
-        self._nproc = kwargs.pop('nproc', None)
+        self._nproc = kwargs.pop('nproc', 0)
         if kwargs.get('zeros', False):
             LOGGER.warn('ClustENM cannot use zero modes so ignoring this kwarg')
 


### PR DESCRIPTION
The 1st fix is regardless of openmm version. Other fixes can be towards accommodating the new openmm (#1971) in the same pull request.

The default value of nproc for passing on to solvEig couldn't be None because there's a numeric comparison happening and should be 0 instead.
```
clustenm.run(n_modes=2, n_confs=5, n_gens=2, maxclust=2, sim=False, rmsd=2)
@> Kirchhoff was built in 0.04s.
@> Generation 0 ...
@> Minimization in generation 0 ...
@> Completed in 17.70s.
@> #-------------------/*\-------------------#
@> Generation 1 ...
@> Sampling conformers in generation 1 ...
@> Hessian was built in 0.13s.
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[7], line 1
----> 1 clustenm.run(n_modes=2, n_confs=5, n_gens=2, maxclust=2, sim=False, rmsd=2)

File ~/software/scipion3/software/em/prody-github/ProDy/prody/dynamics/clustenm.py:1208, in ClustENM.run(self, cutoff, n_modes, gamma, n_confs, rmsd, n_gens, maxclust, threshold, solvent, sim, force_field, temp, t_steps_i, t_steps_g, outlier, mzscore, **kwargs)
   1206 self._cycle += 1
   1207 LOGGER.info('Generation %d ...' % i)
-> 1208 confs, weights = self._generate(start_confs)
   1209 if self._sim:
   1210     if self._t_steps[i] != 0:

File ~/software/scipion3/software/em/prody-github/ProDy/prody/dynamics/clustenm.py:678, in ClustENM._generate(self, confs, **kwargs)
    676         tmp = p.map(sample_method, [conf for conf in confs])
    677 else:
--> 678     tmp = [sample_method(conf) for conf in confs]
    680 tmp = [r for r in tmp if r is not None]
    682 confs_ex = np.concatenate(tmp)

File ~/software/scipion3/software/em/prody-github/ProDy/prody/dynamics/clustenm.py:678, in <listcomp>(.0)
    676         tmp = p.map(sample_method, [conf for conf in confs])
    677 else:
--> 678     tmp = [sample_method(conf) for conf in confs]
    680 tmp = [r for r in tmp if r is not None]
    682 confs_ex = np.concatenate(tmp)

File ~/software/scipion3/software/em/prody-github/ProDy/prody/dynamics/clustenm.py:529, in ClustENM._sample(self, conf)
    526 if not self._checkANM(anm_cg):
    527     return None
--> 529 anm_cg.calcModes(self._n_modes, turbo=self._turbo,
    530                  nproc=self._nproc)
    532 anm_ex = self._extendModel(anm_cg, cg, tmp)
    533 ens_ex = sampleModes(anm_ex, atoms=tmp,
    534                      n_confs=self._n_confs,
    535                      rmsd=self._rmsd[self._cycle])

File ~/software/scipion3/software/em/prody-github/ProDy/prody/dynamics/anm.py:230, in ANMBase.calcModes(self, n_modes, zeros, turbo, **kwargs)
    228 self._clear()
    229 LOGGER.timeit('_anm_calc_modes')
--> 230 values, vectors, vars = solveEig(self._hessian, n_modes=n_modes, zeros=zeros, 
    231                                  turbo=turbo, expct_n_zeros=6, **kwargs)
    232 self._eigvals = values
    233 self._array = vectors

File ~/software/scipion3/software/em/prody-github/ProDy/prody/utilities/eigtools.py:96, in solveEig(M, n_modes, zeros, turbo, expct_n_zeros, reverse, **kwargs)
     93     n_zeros = sum(w < ZERO)
     94     return n_zeros
---> 96 if nproc > 0:
     97     try:
     98         from threadpoolctl import threadpool_limits

TypeError: '>' not supported between instances of 'NoneType' and 'int'
```