### PR TITLE
extended header parsing

### DIFF
--- a/prody/proteins/header.py
+++ b/prody/proteins/header.py
@@ -950,7 +950,7 @@ def _missingResidues(lines):
             resnum = int(w[2][:-1])
         else:
             resnum = int(w[2])
-        mr.append((w[1],w[0],resnum, icode, modelNumStr))
+        mr.append((w[1], w[0], resnum, icode, modelNumStr))
     return mr
     
 def _missingAtoms(lines):
@@ -961,24 +961,20 @@ def _missingAtoms(lines):
     header['missing_atoms'] = [(chid, resname, resnum, icode, modelNum, [atom names])]
     """
     ma = []
-    seen = {}
+    res_repr_to_ma_index = {} # {residue_string_repr: index of this residue in ma list}
     header = True
     for i, line in lines['REMARK 470']:
         #skip header records
         if line.startswith("REMARK 470   M RES CSSEQI  ATOMS"):
             header=False
             continue
-        if header: continue
+        if header:
+            continue
         modelNumStr = line[10:14].strip()
-        if modelNumStr: modelNum = int(modelNumStr)
-        else: modelNum = None
-        #w = line[15:].split()
-        #if w[2][-1].isalpha():
-        #    icode = w[2][-1]
-        #    resnum = int(w[2][:-1])
-        #else:
-        #    resnum = int(w[2])
-        #ma.append((w[1], w[0], resnum, icode, w[3:]))
+        if modelNumStr:
+            modelNum = int(modelNumStr)
+        else:
+            modelNum = None
         resname = line[15:18]
         chid = line[19]
         resnum = int(line[20:24])
@@ -986,10 +982,10 @@ def _missingAtoms(lines):
         if icode == ' ':
             icode = ''
         key = '%s:%s%d%s'%(chid,resname,resnum,icode)
-        if key in seen: # missing atoms record for a residue can span multiple lines 1vzq.pdb
-            ma[seen[key]][-1].extend(line[25:].split())
+        if key in res_repr_to_ma_index: # missing atoms record for a residue can span multiple lines 1vzq.pdb
+            ma[res_repr_to_ma_index[key]][-1].extend(line[25:].split())
         else:
-            seen[key] = len(ma)
+            res_repr_to_ma_index[key] = len(ma)
             ma.append((chid, resname, resnum, icode, line[25:].split()))
     return ma
     

--- a/prody/proteins/header.py
+++ b/prody/proteins/header.py
@@ -385,6 +385,38 @@ def _getResolution(lines):
             except:
                 return None
 
+def _getSCALE(lines):
+    ctof = np.identity(4)
+    if len(lines['SCALE1']) == 0: return {}
+    ctof[0] = lines['SCALE1'][0][1].split()[1:5]
+    ctof[1] = lines['SCALE2'][0][1].split()[1:5]
+    ctof[2] = lines['SCALE3'][0][1].split()[1:5]
+    ftoc = np.linalg.inv(ctof)
+    return {'ctof':ctof, 'ftoc':ftoc}
+
+def _getSpaceGroup(lines):
+    rowct = 0
+    mat = []
+    xform = []
+    sg = None
+    for i, line in lines['REMARK 290']:
+        if 'SYMMETRY OPERATORS FOR SPACE GROUP:' in line:
+            try:
+                sg = line.split('GROUP:')[1].strip()
+            except:
+                pass
+        if line[13:18] == 'SMTRY':
+            w = line.split()
+            mat.append([float(x) for x in w[4:]])
+            rowct += 1
+            if rowct==3:
+                mat.append( (0,0,0,1) )
+                matnp = np.array(mat)
+                #if np.sum(matnp-np.identity(4))!=0.0:
+                xform.append(np.array(mat))
+                rowct = 0
+                mat = []
+    return {'spaceGroup':sg, 'symMats': xform}
 
 def _getRelatedEntries(lines):
 
@@ -876,6 +908,91 @@ def _getNumModels(lines):
         except:
             pass
 
+def _getCRYST1(lines):
+    line = lines['CRYST1']
+    if line:
+       i, line = line[0]
+       try:
+           return {'cellLength': (float(line[6:15]),
+                                  float(line[15:24]),
+                                  float(line[24:33])),
+                   'cellAngles': (float(line[33:40]),
+                                  float(line[40:47]),
+                                  float(line[47:54])),
+                   'spaceGroup': line[55:66].strip(),
+                   'Z value' : int(line[66:70])
+                   }
+       except:
+           pass
+
+def _missingResidues(lines):
+    """
+    Parse REMARK 465, Missing residues records
+    REMARK 465   M RES C SSSEQI
+    REMARK 465     GLU B   448
+    header['missing_residues'] = [(chid, resname, resnum, icode, modelNum)]
+    """
+    mr = []
+    header = True
+    for i, line in lines['REMARK 465']:
+        #skip header records
+        if line.startswith("REMARK 465   M RES C SSSEQI"):
+            header=False
+            continue
+        if header: continue
+        modelNumStr = line[10:14].strip()
+        if modelNumStr: modelNum = int(modelNumStr)
+        else: modelNum = None
+        w = line[15:].split()
+        icode = ''
+        if w[2][-1].isalpha():
+            icode = w[2][-1]
+            resnum = int(w[2][:-1])
+        else:
+            resnum = int(w[2])
+        mr.append((w[1],w[0],resnum, icode, modelNumStr))
+    return mr
+    
+def _missingAtoms(lines):
+    """
+    Parse REMARK 470,  Missing Atom records
+    REMARK 470   M RES CSSEQI  ATOMS
+    REMARK 470     ARG A 412    CG   CD   NE   CZ   NH1  NH2  
+    header['missing_atoms'] = [(chid, resname, resnum, icode, modelNum, [atom names])]
+    """
+    ma = []
+    seen = {}
+    header = True
+    for i, line in lines['REMARK 470']:
+        #skip header records
+        if line.startswith("REMARK 470   M RES CSSEQI  ATOMS"):
+            header=False
+            continue
+        if header: continue
+        modelNumStr = line[10:14].strip()
+        if modelNumStr: modelNum = int(modelNumStr)
+        else: modelNum = None
+        #w = line[15:].split()
+        #if w[2][-1].isalpha():
+        #    icode = w[2][-1]
+        #    resnum = int(w[2][:-1])
+        #else:
+        #    resnum = int(w[2])
+        #ma.append((w[1], w[0], resnum, icode, w[3:]))
+        resname = line[15:18]
+        chid = line[19]
+        resnum = int(line[20:24])
+        icode = line[24]
+        if icode == ' ':
+            icode = ''
+        key = '%s:%s%d%s'%(chid,resname,resnum,icode)
+        if key in seen: # missing atoms record for a residue can span multiple lines 1vzq.pdb
+            ma[seen[key]][-1].extend(line[25:].split())
+        else:
+            seen[key] = len(ma)
+            ma.append((chid, resname, resnum, icode, line[25:].split()))
+    return ma
+    
 # Make sure that lambda functions defined below won't raise exceptions
 _PDB_HEADER_MAP = {
     'helix': _getHelix,
@@ -912,6 +1029,10 @@ _PDB_HEADER_MAP = {
     'n_models': _getNumModels,
     'space_group': _getSpaceGroup,
     'related_entries': _getRelatedEntries,
+    'CRYST1': _getCRYST1,
+    'SCALE': _getSCALE,
+    'missing_residues': _missingResidues,
+    'missing_atoms': _missingAtoms,
 }
 
 mapHelix = {

--- a/prody/tests/proteins/test_header.py
+++ b/prody/tests/proteins/test_header.py
@@ -108,7 +108,7 @@ class TestParsePDBHeaderCRYST1andSCALE(unittest.TestCase):
 
         self.header = None
 
-class TestParsePDBHeaderCRYST1andSCALE(unittest.TestCase):
+class TestParsePDBHeaderMissingAtoms(unittest.TestCase):
 
     def setUp(self):
         self.header = parsePDB(pathDatafile('pdb3hsy.pdb'),

--- a/prody/tests/proteins/test_header.py
+++ b/prody/tests/proteins/test_header.py
@@ -1,5 +1,5 @@
 """This module contains unit tests for :mod:`~prody.proteins`."""
-
+import numpy as np
 from numpy.testing import *
 
 from prody import *
@@ -39,8 +39,112 @@ class TestParsePDBHeaderOnly(unittest.TestCase):
 
         self.header = None
 
+class TestParsePDBHeaderCRYST1andSCALE(unittest.TestCase):
 
+    def setUp(self):
+        self.header = parsePDB(pathDatafile('1pwc.pdb'),
+                               header=True, model=0)
 
+    def testHeaderType(self):
+        self.assertIsInstance(self.header, dict,
+            'header type is incorrect')
+
+    def testHeaderContent(self):
+        # CRYST1
+        cryst1 = self.header.get('CRYST1', None)
+        self.assertIsInstance(cryst1, dict,
+            'CRYST1 type is incorrect in the header')
+        self.assertEqual(cryst1.get('Z value'), 4,
+            'failed to get expected value for Z value')
+        self.assertEqual(cryst1.get('spaceGroup'), 'P 21 21 21',
+            'failed to get expected value for spaceGroup from header')
+        self.assertEqual(cryst1.get('cellAngles', None), (90.0, 90.0, 90.0),
+            'failed to get expected value for cellAngles from header')
+        self.assertEqual(cryst1.get('cellLength'), (50.9, 66.7, 99.6),
+            'failed to get expected value for cellLength from header')
+
+        # SCALE
+        scale = self.header.get('SCALE', None)
+        self.assertIsInstance(scale, dict,
+            'SCALE type is incorrect in the header')
+        self.assertIsInstance(scale.get('ctof', None), np.ndarray)
+        self.assertEqual(scale.get('ctof').shape, (4,4), 
+            'failed to get expected value for scale.ctof value')
+        _ctof = np.array([[0.019646, 0.      , 0.      , 0.      ],
+                          [0.      , 0.014993, 0.      , 0.      ],
+                          [0.      , 0.      , 0.01004 , 0.      ],
+                          [0.      , 0.      , 0.      , 1.      ]])
+              
+        assert_array_equal(scale.get('ctof'), _ctof, 
+            'failed to get expected value for sacle.ctof value')
+
+        self.assertIsInstance(scale.get('ftoc', None), np.ndarray)
+        self.assertEqual(scale.get('ftoc').shape, (4,4), 
+            'failed to get expected value for scale.ftoc value')
+        _ftoc = np.array([[50.90094676,  0.        ,  0.        ,  0.        ],
+                          [ 0.        , 66.6977923 ,  0.        ,  0.        ],
+                          [ 0.        ,  0.        , 99.60159363,  0.        ],
+                          [ 0.        ,  0.        ,  0.        ,  1.        ]])
+        assert_array_almost_equal(scale.get('ftoc'), _ftoc, decimal=7,
+            err_msg='failed to get expected value for scale.ftoc value')
+
+        # REMARK 365
+        self.assertIsInstance(self.header.get('missing_residues', None), list,
+            'missing_residues type is incorrect in the header')
+        mis_res = self.header.get('missing_residues')
+        
+        self.assertEqual(len(mis_res), 4, 
+                         'failed to get expected value for missing_residues value')        
+        self.assertEqual( mis_res[0], ('A', 'ALA', 1, '', ''),
+            'failed to get expected value for missing_residues[0]')
+        self.assertEqual( mis_res[1], ('A', 'ASP', 2, '', ''),
+            'failed to get expected value for missing_residues[1]')
+        self.assertEqual( mis_res[2], ('A', 'THR', 348, '', ''),
+            'failed to get expected value for missing_residues[2]')
+        self.assertEqual( mis_res[3], ('A', 'THR', 349, '', ''),
+            'failed to get expected value for missing_residues[3]')
+        
+    def tearDown(self):
+
+        self.header = None
+
+class TestParsePDBHeaderCRYST1andSCALE(unittest.TestCase):
+
+    def setUp(self):
+        self.header = parsePDB(pathDatafile('pdb3hsy.pdb'),
+                               header=True, model=0)
+
+    def testHeaderType(self):
+        self.assertIsInstance(self.header, dict,
+            'header type is incorrect')
+
+    def testHeaderContent(self):
+        # CRYST1
+        self.assertIsInstance(self.header.get('missing_atoms', None), list,
+            'missing_atoms type is incorrect in the header')
+        mis_atoms = self.header.get('missing_atoms')
+        
+        self.assertEqual(len(mis_atoms), 5, 
+                         'failed to get expected value for missing_atoms value')
+        self.assertEqual( mis_atoms[0],
+            ('A', 'ASN', 305, '', ['CG', 'OD1', 'ND2']), 
+            'failed to get expected value for missing_atoms[0]')
+        self.assertEqual( mis_atoms[1],
+            ('B', 'GLN', 296, '', ['CG', 'CD', 'OE1', 'NE2']),
+            'failed to get expected value for missing_atoms[1]')
+        self.assertEqual( mis_atoms[2],
+            ('B', 'ARG', 297, '', ['CG', 'CD', 'NE', 'CZ', 'NH1', 'NH2']),
+            'failed to get expected value for missing_atoms[2]')
+        self.assertEqual( mis_atoms[3],
+            ('B', 'ILE', 298, '', ['CG1', 'CG2', 'CD1']),
+            'failed to get expected value for missing_atoms[3]')
+        self.assertEqual( mis_atoms[4],
+            ('B', 'GLU', 299, '', ['CG', 'CD', 'OE1', 'OE2']),
+            'failed to get expected value for missing_atoms[4]')
+        
+    def tearDown(self):
+
+        self.header = None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The is the new and cleaned up PR for extending prody/protein/header.py to parse CRYST',  SCALE, REMARK 465 (missing_residues), and REMARK 470 (missing_atoms). I also extended prody/tests/protein/test_header.py to test these new parsers.

I am using these records to complete structures and find crystal packing contacts.

NOTE: the code is unchanged from the previous PR (that I withdrew), but this time I branched from from version 2.5.0 for cleaner commit history. Sorry for the inconvenience.