### PR TITLE
zero matrix with markersize

### DIFF
--- a/prody/utilities/catchall.py
+++ b/prody/utilities/catchall.py
@@ -739,6 +739,8 @@ def showMatrix(matrix, x_array=None, y_array=None, **kwargs):
         im = ax3.imshow(matrix, aspect=aspect, vmin=vmin, vmax=vmax,
                         norm=norm, cmap=cmap, origin=origin, **kwargs)
     else:
+        zeros_matrix = np.zeros(matrix.shape)
+        im = ax3.imshow(zeros_matrix, vmin=-1, vmax=1, cmap='seismic')
         plot_list = []
         for rows,cols in zip(np.where(matrix!=0)[0],np.where(matrix!=0)[1]):
             plot_list.append([cols,rows,matrix[rows,cols]])


### PR DESCRIPTION
This fixes the issue that showAtomicMatrix has the wrong size plot when markersize is set because of only applying pyplot scatter to nonzero elements

Bad matrix:
![bad_matrix](https://github.com/user-attachments/assets/ab36b10b-98d3-4796-81cc-355c432930b4)

Fixed matrix:
![fixed_matrix](https://github.com/user-attachments/assets/27c81d3d-c258-4719-a8d8-95f892442ee7)
