### PR TITLE
bug fix chainsHB no ligand

### DIFF
--- a/prody/proteins/interactions.py
+++ b/prody/proteins/interactions.py
@@ -710,9 +710,11 @@ def calcChHydrogenBonds(atoms, **kwargs):
     
         ChainsHBs = [ i for i in HBS_calculations if str(i[2]) != str(i[5]) ]
         if not ChainsHBs:
-            ligand_name = list(set(atoms.select('all not protein and not ion').getResnames()))[0]
-            ChainsHBs = [ ii for ii in HBS_calculations if ii[0][:3] == ligand_name or ii[3][:3] == ligand_name ]
-        
+            ligand_sel = atoms.select('all not protein and not ion')
+            if ligand_sel:
+                ligand_name = list(set(ligand_sel.getResnames()))[0]
+                ChainsHBs = [ ii for ii in HBS_calculations if ii[0][:3] == ligand_name or ii[3][:3] == ligand_name ]
+
         return ChainsHBs 
         
 


### PR DESCRIPTION
When there are no hydrogen bonds between chains with the current parameters, we can get this error if there's no ligand either, but it works if we loosen the criteria.
```
In [1]: from prody import *

In [2]: PDBfile = 'addH_9asd.pdb'

In [3]: atomsRL = parsePDB(PDBfile).select('protein and chain R L')

In [4]: chHB_RL = calcChHydrogenBonds(atomsRL)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[4], line 1
----> 1 chHB_RL = calcChHydrogenBonds(atomsRL)

File ~/software/scipion3/software/em/prody-github/ProDy/prody/proteins/interactions.py:713, in calcChHydrogenBonds(atoms, **kwargs)
    711 ChainsHBs = [ i for i in HBS_calculations if str(i[2]) != str(i[5]) ]
    712 if not ChainsHBs:
--> 713     ligand_name = list(set(atoms.select('all not protein and not ion').getResnames()))[0]
    714     ChainsHBs = [ ii for ii in HBS_calculations if ii[0][:3] == ligand_name or ii[3][:3] == ligand_name ]
    716 return ChainsHBs

AttributeError: 'NoneType' object has no attribute 'getResnames'

In [5]: chHB_RL = calcChHydrogenBonds(atomsRL, angle=90, distA=4)

In [6]: chHB_RL
Out[6]: 
[['ASN417', 'N_4667', 'R', 'TYR34', 'OH_2300', 'L', 2.7602, 49.0483],
 ['TYR93', 'OH_3186', 'L', 'THR415', 'OG1_4658', 'R', 3.0228, 69.6565],
 ['TYR34', 'OH_2300', 'L', 'GLN409', 'NE2_4576', 'R', 3.3524, 52.5221],
 ['GLN409', 'NE2_4576', 'R', 'TYR34', 'OH_2300', 'L', 3.3524, 63.639],
 ['ASN33', 'ND2_2278', 'L', 'ASN405', 'ND2_4517', 'R', 3.5242, 60.8902],
 ['ASN405', 'ND2_4517', 'R', 'ASN33', 'ND2_2278', 'L', 3.5242, 74.5393],
 ['LYS460', 'NZ_5388', 'R', 'TYR97', 'OH_3235', 'L', 3.5589, 52.5927],
 ['ASN33', 'ND2_2278', 'L', 'ASN405', 'OD1_4516', 'R', 3.83, 69.8678]]
```

With the fix, it will still try for a ligand if there is one but otherwise we just get an empty list without an error:
```
In [4]: chHB_RL = calcChHydrogenBonds(atomsRL)

In [5]: chHB_RL
Out[5]: []

In [6]: chHB_RL = calcChHydrogenBonds(atomsRL, angle=90, distA=4)

In [7]: chHB_RL
Out[7]: 
[['ASN417', 'N_4667', 'R', 'TYR34', 'OH_2300', 'L', 2.7602, 49.0483],
 ['TYR93', 'OH_3186', 'L', 'THR415', 'OG1_4658', 'R', 3.0228, 69.6565],
 ['TYR34', 'OH_2300', 'L', 'GLN409', 'NE2_4576', 'R', 3.3524, 52.5221],
 ['GLN409', 'NE2_4576', 'R', 'TYR34', 'OH_2300', 'L', 3.3524, 63.639],
 ['ASN33', 'ND2_2278', 'L', 'ASN405', 'ND2_4517', 'R', 3.5242, 60.8902],
 ['ASN405', 'ND2_4517', 'R', 'ASN33', 'ND2_2278', 'L', 3.5242, 74.5393],
 ['LYS460', 'NZ_5388', 'R', 'TYR97', 'OH_3235', 'L', 3.5589, 52.5927],
 ['ASN33', 'ND2_2278', 'L', 'ASN405', 'OD1_4516', 'R', 3.83, 69.8678]]
```