### PR TITLE
add chain bar to showCumulativeInteractionTypes energy

### DIFF
--- a/prody/proteins/interactions.py
+++ b/prody/proteins/interactions.py
@@ -3798,9 +3798,13 @@ class Interactions(object):
             fig, ax = plt.subplots(num=None, figsize=(20,6), facecolor='w')
             matplotlib.rcParams['font.size'] = '24'
 
-            ax.bar(ResNumb, matrix_en_sum, width, color='blue')
+            zeros_row = np.zeros(matrix_en_sum.shape)
+            pplot(zeros_row, atoms=atoms.ca)
+
+            ax.bar(ResList, matrix_en_sum, width, color='blue')
             
-            plt.xlim([ResNumb[0]-0.5, ResNumb[-1]+0.5])
+            #plt.xlim([ResList[0]-0.5, ResList[-1]+0.5])
+            plt.ylim([min(matrix_en_sum)-1,0])
             plt.tight_layout()    
             plt.xlabel('Residue')
             plt.ylabel('Cumulative Energy [kcal/mol]')


### PR DESCRIPTION
Previously, we didn't have any chain bars and the residue labels aren't that sensible for multi chain cases (here they have different numbers in the two chains so it's ok but usually that may not happen):
![interactions_cum_energy_old_9atm_RL](https://github.com/user-attachments/assets/2fe2421e-c47a-4c26-91ac-28fbd15d33c3)


Now, we have chain bars and good residue+chain labels
![interactions_cum_energy_chains_9atm_RL](https://github.com/user-attachments/assets/9721e345-1519-407d-b59b-87383c210924)
