### PR TITLE
add build and overwrite to showCumulativeInteractionTypes energy

### DIFF
--- a/prody/proteins/interactions.py
+++ b/prody/proteins/interactions.py
@@ -3847,6 +3847,9 @@ class Interactions(object):
                 self.buildInteractionMatrixEnergy(energy_list_type=energy_list_type)
                 matrix_en = self._interactions_matrix_en
 
+            elif self._energy_type != energy_list_type:
+                LOGGER.warn('The energy type is {0}, not {1}'.format(self._energy_type, energy_list_type))
+
             matrix_en_sum = np.sum(matrix_en, axis=0)
 
             width = 0.8


### PR DESCRIPTION
Otherwise, we get an error if the matrix isn't calculated. Now there's it will build the matrix if it's not there and the option to overwrite it if it is.