### PR TITLE
SignInt - change in the title name of 

### DIFF
--- a/prody/proteins/interactions.py
+++ b/prody/proteins/interactions.py
@@ -526,7 +526,7 @@ def plot_barh(result, bond_type, **kwargs):
         plt.ylim(-1, result_chunk.shape[0])
         plt.ylabel('{} Pairs of Residue Numbers'.format(bond_type))
         plt.xlabel('Percentage')
-        plt.title('Persistence of {} Bonds (entries {}-{})'.format(bond_type, start_idx + 1, end_idx))
+        plt.title('Persistence of {} (entries {}-{})'.format(bond_type, start_idx + 1, end_idx))
         # Save each plot with an incremented filename for multiple plots
         output_plot_file = '{}_plot_part{}.png'.format(bond_type, plot_idx + 1)
         log_message("Saving plot to: {}".format(output_plot_file))


### PR DESCRIPTION
I removed "Bond" word from the title of the plot created by calcSignatureInteractions('struc_homologs', mapping_file='shortlisted_resind.msa')
Otherwise, we would have Pi-Cation Bond, HPh Bond in the title.

I did that a week ago or so, but I forgot to pull request.

Now we have:
![foldseek_hbs_plot1](https://github.com/user-attachments/assets/c1b514cc-7c1d-4940-b39c-9c636574788b)
