### PR TITLE
Readme fix: remove double back tick

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ ProDy has a modular structure with modules inside various subpackages.
 
 The main ones are:
 
-- :mod:`~prody.atomic`` handles all :class:`~prody.atomic.Atomic` objects including :class:`~prody.atomic.AtomGroup` and :class:`.Selection`
+- :mod:`~prody.atomic` handles all :class:`~prody.atomic.Atomic` objects including :class:`~prody.atomic.AtomGroup` and :class:`.Selection`
 
 - :mod:`~prody.database` interfaces with databases such as CATH, DALI, UniProt and Pfam
 


### PR DESCRIPTION
We probably have more to fix because I'm getting complaints about the readme using twine to push to the test PyPI, but this one is needed either way