### PR TITLE
remove py27 from github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["2.7", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,11 +26,10 @@ jobs:
         echo $CONDA/bin >> $GITHUB_PATH
     - name: Install dependencies
       run: |
-        if [[ ${{ matrix.python-version }} != "2.7" ]]; then conda config --add channels conda-forge; fi
         conda create --yes -n test python=${{ matrix.python-version }}
         source activate test
         conda install --yes numpy scipy nose requests
-        if [[ ${{ matrix.python-version }} == "2.7" ]]; then conda install --yes unittest2; else conda install --yes pdbfixer mdtraj; fi
+        conda install --yes pdbfixer mdtraj
         pip install mmtf-python scikit-learn
         pip install .
         python setup.py build_ext --inplace --force

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         conda create --yes -n test python=${{ matrix.python-version }}
         source activate test
+        conda config --add channels conda-forge
         conda install --yes numpy scipy nose requests
         conda install --yes pdbfixer mdtraj
         pip install mmtf-python scikit-learn


### PR DESCRIPTION
Seeing as github actions doesn't build prody and biopython extensions anymore for python 2.7, let's remove it