### PR TITLE
Create a template for new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/prody-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/prody-bug-report.md
@@ -1,0 +1,31 @@
+---
+name: ProDy Bug Report
+about: Please let us know about a bug you encountered when using ProDy.
+title: ''
+labels: ''
+assignees: AnthonyBogetti
+
+---
+
+**Note: *Our GitHub Issues are for bug reports ONLY*. Please post any feature requests and other topics to the Discussions tab. Thank you.**
+
+**Please read the following before posting an issue.**
+Hello, we are sorry that you have run into a problem while using ProDy. We will do our best to address your issues in a timely and comprehensive manner. In return, we ask that you completely fill out this bug report. Do not leave any section blank. Filling this form out ensures that we can help you most efficiently and saves us (and you) time and energy. Also, please search old issues and discussions before opening a new Issue. Chances are, someone in the past had your issue and the solution was described there.
+
+## Description of the bug.
+Below, please describe the error you encountered and what you were trying to do with ProDy.
+
+## Do you have any error messages or logs?
+Below, please post the error you got and text from any relevant log files.
+
+## What is your setup?
+Below, please describe your setup. What operating system are you using (MacOS, Linux, etc.).
+
+## How did you install ProDy?
+Below, please say whether you installed from source, with conda or with pip. Please also add what version of ProDy you are using.
+
+## What did your code look like?
+Below, if possible, please post the exact code you ran that led to the error you received. Please also attach any relevant input files. This will help us more quickly respond you your issue.
+
+## Anything else?
+Below, please write any other details you would like us to know about.


### PR DESCRIPTION
This adds a template for Bug Reports going to the Issues tab. This should help ensure more productive questions and responses and reduce back-and-forth gathering information about version, OS etc.