### PR TITLE
add _bondOrder and _bondIndex to saveEnsemble and loadEnsemble

### DIFF
--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -66,8 +66,8 @@ def saveEnsemble(ensemble, filename=None, **kwargs):
 
     atoms = dict_['_atoms']
     if atoms is not None:
-        if not hasattr(atoms, '_bondOrder'):
-            atoms._bondOrder = None
+        if not hasattr(atoms, '_bondOrders'):
+            atoms._bondOrders = None
 
         if not hasattr(atoms, '_bondIndex'):
             atoms._bondIndex = None
@@ -193,8 +193,8 @@ def loadEnsemble(filename, **kwargs):
         else:
             ag = atoms._ag
 
-        if not hasattr(ag, '_bondOrder'):
-            ag._bondOrder = None
+        if not hasattr(ag, '_bondOrders'):
+            ag._bondOrders = None
 
         if not hasattr(ag, '_bondIndex'):
             ag._bondIndex = None

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -189,10 +189,18 @@ def loadEnsemble(filename, **kwargs):
         atoms = attr_dict['_atoms'][0]
 
         if isinstance(atoms, AtomGroup):
-            data = atoms._data
+            ag = atoms
         else:
-            data = atoms._ag._data
-        
+            ag = atoms._ag
+
+        if not hasattr(ag, '_bondOrder'):
+            ag._bondOrder = None
+
+        if not hasattr(ag, '_bondIndex'):
+            ag._bondIndex = None
+
+        data = ag._data
+
         for key in data:
             arr = data[key]
             char = arr.dtype.char

--- a/prody/ensemble/functions.py
+++ b/prody/ensemble/functions.py
@@ -66,6 +66,12 @@ def saveEnsemble(ensemble, filename=None, **kwargs):
 
     atoms = dict_['_atoms']
     if atoms is not None:
+        if not hasattr(atoms, '_bondOrder'):
+            atoms._bondOrder = None
+
+        if not hasattr(atoms, '_bondIndex'):
+            atoms._bondIndex = None
+
         attr_dict['_atoms'] = np.array([atoms, None], 
                                         dtype=object)
 


### PR DESCRIPTION
Otherwise, we get an error when they don't have it as exemplified in this Scipion protocol run from an old ensemble:
```
  File "/home/spa/scipion3/scipion-em-prody/prody2/protocols/protocol_cluster.py", line 140, in ensembleModificationStep
    ensFn = prody.saveEnsemble(self.ens, self.ensBaseName)
  File "/home/spa/scipion3/software/em/prody-github/ProDy/prody/ensemble/functions.py", line 100, in saveEnsemble
    np.savez(ostream, **attr_dict)
  File "<__array_function__ internals>", line 200, in savez
  File "/home/spa/anaconda3/envs/scipion3/lib/python3.8/site-packages/numpy/lib/npyio.py", line 615, in savez
    _savez(file, args, kwds, False)
  File "/home/spa/anaconda3/envs/scipion3/lib/python3.8/site-packages/numpy/lib/npyio.py", line 719, in _savez
    format.write_array(fid, val,
  File "/home/spa/anaconda3/envs/scipion3/lib/python3.8/site-packages/numpy/lib/format.py", line 711, in write_array
    pickle.dump(array, fp, protocol=3, **pickle_kwargs)
  File "/home/spa/scipion3/software/em/prody-github/ProDy/prody/atomic/atomic.py", line 133, in __getstate__
    return dict([(slot, getattr(self, slot))
  File "/home/spa/scipion3/software/em/prody-github/ProDy/prody/atomic/atomic.py", line 133, in <listcomp>
    return dict([(slot, getattr(self, slot))
  File "/home/spa/scipion3/software/em/prody-github/ProDy/prody/atomic/atomic.py", line 126, in __getattribute__
    raise AttributeError('{0} object has no attribute `{1}` and {2} '
AttributeError: AtomGroup object has no attribute `_bondOrders` and '_bondOrders' is not a valid selection string
```