### PR TITLE
End support for python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v2

--- a/prody/proteins/hpbmodule/README
+++ b/prody/proteins/hpbmodule/README
@@ -16,7 +16,7 @@ g++ -O3 -g -fPIC -c hpbmodule.cpp -o hpbmodule.o -I/usr/include/python3.X/
 instead
 
 If we ae using Anaconda we might have such pathway to python:
-g++ -O3 -g -fPIC -c hpbmodule.cpp -o hpbmodule.o -I/home/user_name/anaconda3/envs/name_of_environment/include/python3.9/
+g++ -O3 -g -fPIC -c hpbmodule.cpp -o hpbmodule.o -I/home/user_name/anaconda3/envs/name_of_environment/include/python3.10/
 
 user_name, name_of_environment - need to be replaced
 


### PR DESCRIPTION
The Python 3.9 tests are failing, while newer versions of Python are not. I removed the need to test 3.9 from the CI and I think going forward, we can support the most recent Python version plus the previous 2.