### PR TITLE
add nonstd nucleics

### DIFF
--- a/prody/atomic/__init__.py
+++ b/prody/atomic/__init__.py
@@ -163,6 +163,7 @@ from .selection import *
 
 from . import flags
 from . import atomic
+atomic.NAMAP = flags.NAMAP
 from . import select
 from . import atommap
 from . import pointer

--- a/prody/atomic/atomic.py
+++ b/prody/atomic/atomic.py
@@ -42,7 +42,7 @@ for aaa, a in AAMAP.items():
     _[a] = aaa
 AAMAP.update(_)
 
-# add modified AAs
+# add modified AAs and bases to AAMAP
 MODAAMAP = {}
 for mod, aa in MODMAP.items():
     if aa in AAMAP:

--- a/prody/atomic/flags.py
+++ b/prody/atomic/flags.py
@@ -40,10 +40,11 @@ from collections import defaultdict
 from numpy import array, ones, zeros
 
 from prody import SETTINGS, LOGGER
+from prody.utilities import openData
 from prody.utilities import joinLinks, joinTerms, wrapText
 
 __all__ = ['flagDefinition', 'listNonstdAAProps', 'getNonstdProperties',
-           'addNonstdAminoacid', 'delNonstdAminoacid']
+           'addNonstdAminoacid', 'delNonstdAminoacid', 'NAMAP']
 
 
 TIMESTAMP_KEY = 'flags_timestamp'
@@ -712,6 +713,25 @@ DEFINITIONS = None
 AMINOACIDS = None
 BACKBONE = None
 
+MODMAP = {}
+with openData('mod_res_map.dat') as f:
+    for line in f:
+        try:
+            mod, aa = line.strip().split(' ')
+            MODMAP[mod] = aa
+        except:
+            continue
+
+NAMAP = {'ADE': 'a', 'THY': 't', 'CYT': 'c',
+         'GUA': 'g', 'URA': 'u'}
+
+# add modified bases to NAMAP
+MODNAMAP = {}
+for mod, aa in MODMAP.items():
+    if aa in NAMAP:
+        MODNAMAP[mod] = NAMAP[aa]
+NAMAP.update(MODNAMAP)
+
 
 def updateDefinitions():
     """Update definitions and set some global variables.  This function must be
@@ -727,6 +747,8 @@ def updateDefinitions():
         aset = set(user.get(key, DEFAULTS[key]))
         nucleic.update(aset)
         DEFINITIONS[key] = aset
+    for key in NAMAP:
+        nucleic.update(set(NAMAP.keys()))
     DEFINITIONS['nucleic'] = nucleic
 
     # heteros


### PR DESCRIPTION
closes #2102 

As described, the current behaviour only outputs standard nucleics:
```
In [1]: import prody
   ...: 
   ...: struct = prody.parseMMCIF('1f7u', altloc="all")
@> CIF file is found in working directory (1f7u.cif).
@> 7126 atoms and 1 coordinate set(s) were parsed in 0.09s.

In [2]: set(struct.select('nucleic').getResnames())
Out[2]: {'A', 'C', 'G', 'U'}
```

With the fix, we can get other ones as defined in prody/utilities/datafiles/mod_res_map.dat like we do for amino acids:
```
In [2]: set(struct.select('nucleic').getResnames())
Out[2]: {'2MG', '5MC', '5MU', 'A', 'C', 'G', 'PSU', 'U'}
```
