### PR TITLE
Unpin numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,7 @@
 [build-system]
 requires = ["setuptools", "wheel", "numpy>=1.10", "pyparsing<=3.1.1", "scipy"]
+
+requires-python = ">=3.10"
+
+license = "MIT"
+license-files = ["LICENSE.rst"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy>=1.10,<2", "pyparsing<=3.1.1", "scipy"]
+requires = ["setuptools", "wheel", "numpy>=1.10", "pyparsing<=3.1.1", "scipy"]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.version_info[:2] < (2, 7):
 if sys.version_info[:2] == (2, 7) or sys.version_info[:2] <= (3, 5):
     INSTALL_REQUIRES=['numpy>=1.10', 'biopython<=1.76', 'pyparsing', 'scipy']
 else:
-    INSTALL_REQUIRES=['numpy>=1.10,<2', 'biopython', 'pyparsing<=3.1.1', 'scipy', 'setuptools']
+    INSTALL_REQUIRES=['numpy>=1.10', 'biopython', 'pyparsing<=3.1.1', 'scipy', 'setuptools']
 
 if sys.version_info[0] == 3 and sys.version_info[1] < 6:
     sys.stderr.write('Python 3.5 and older is not supported\n')

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ if sys.version_info[:2] == (2, 7) or sys.version_info[:2] <= (3, 5):
 else:
     INSTALL_REQUIRES=['numpy>=1.10', 'biopython', 'pyparsing<=3.1.1', 'scipy', 'setuptools']
 
-if sys.version_info[0] == 3 and sys.version_info[1] < 6:
-    sys.stderr.write('Python 3.5 and older is not supported\n')
+if sys.version_info[0] == 3 and sys.version_info[1] < 10:
+    sys.stderr.write('Python 3.9 and older is not supported\n')
     sys.exit()
 
 if os.name == 'java':


### PR DESCRIPTION
Fixes #2116 

Also, makes explicit the drop of support for python 3.9 and below