### PR TITLE
add biomt oper range handling

### DIFF
--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -191,7 +191,15 @@ def _getBiomoltrans(lines):
 
         biomt = biomolecule[currentBiomolecule]
 
-        operators = item1["_pdbx_struct_assembly_gen.oper_expression"].split(',')
+        oper_expression = item1["_pdbx_struct_assembly_gen.oper_expression"]
+        if oper_expression[0].isnumeric() and oper_expression.find(',') != -1:
+            operators = oper_expression.split(',')
+        elif (oper_expression.startswith('(')
+              and oper_expression.find('-') != -1
+              and oper_expression.endswith(')')):
+            firstOperator = int(oper_expression.split('(')[1].split('-')[0])-1
+            lastOperator = int(oper_expression.split('-')[1].split(')')[0])
+            operators = range(firstOperator, lastOperator)
         for oper in operators:
             biomt.append(applyToChains)
 


### PR DESCRIPTION
fixes #2119 

This recognises a new format of biomolecular assembly transformation operations as a range e.g. (1-60) in 7bth.

We now get the following:
```
In [1]: import prody

In [2]: pdb_id = "7cth"
   ...: struct, header = prody.parseMMCIF(pdb_id, header=True)
@> CIF file is found in working directory (7cth.cif).
@> 16647 atoms and 1 coordinate set(s) were parsed in 0.36s.

In [3]: struct.numChains()
Out[3]: 14

In [4]: biomols = prody.parseMMCIF(pdb_id, biomol=True)
@> CIF file is found in working directory (7cth.cif).
@> 16647 atoms and 1 coordinate set(s) were parsed in 0.36s.
@> Biomolecular transformations were applied, 5 biomolecule(s) are returned.

In [5]: ag = biomols[0]

In [6]: ag.numChains()
Out[6]: 840

In [7]: ag.numChains()/14
Out[7]: 60.0
```