### PR TITLE
update toBioPythonStructure init_model

### DIFF
--- a/prody/atomic/atomic.py
+++ b/prody/atomic/atomic.py
@@ -318,7 +318,7 @@ class Atomic(object):
         
         for i in csets:
             self.setACSIndex(i)
-            structure_builder.init_model(i)
+            structure_builder.init_model(i, i+1)
 
             current_segid = None
             current_chain_id = None

--- a/prody/atomic/atomic.py
+++ b/prody/atomic/atomic.py
@@ -292,9 +292,7 @@ class Atomic(object):
         :arg csets: coordinate set indices, default is all coordinate sets
         """ 
         try:
-            from Bio.PDB.Structure import Structure
             from Bio.PDB.StructureBuilder import StructureBuilder
-            from Bio.PDB.PDBParser import PDBParser
             from Bio.PDB.PDBExceptions import PDBConstructionException
         except ImportError:
             raise ImportError('Bio StructureBuilder could not be imported. '


### PR DESCRIPTION
alternative fix to #2111 

This bypasses the biopython issue of changing model 0 to 1 by starting at 1 instead of fixing it. That seems like the recommended behaviour anyway.