### PR TITLE
extend pfam errors and fix parsePfamPDBs

### DIFF
--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -86,6 +86,8 @@ def searchPfam(query, **kwargs):
         else:
             url = prefix + "all/protein/uniprot/" + accession
 
+    elif seq.startswith('PF'):
+        url = prefix + "pfam/" + seq
     else:
         url = prefix + "all/protein/uniprot/" + seq
 
@@ -127,6 +129,12 @@ def searchPfam(query, **kwargs):
         raise ValueError('failed to parse results XML, check URL: ' + url)
 
     matches = dict()
+
+    if seq.startswith('PF'):
+        metadata = root['metadata']
+        matches.setdefault(str(seq), dict(metadata.items()))
+        return matches
+
     for entry in root["results"]:
         try:
             metadata = entry["metadata"]

--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -270,6 +270,10 @@ def parsePfamPDBs(query, data=None, **kwargs):
     :keyword end: Residue number for defining the end of the domain.
         The PFAM domain that ends closest to this will be selected. 
     :type end: int
+
+    :keyword num_pdbs: Number of pdb chains to parse before stopping
+        Default behaviour is to pass all of them
+    :type num_pdbs: int
     """
 
     if data is None: data = []
@@ -278,6 +282,7 @@ def parsePfamPDBs(query, data=None, **kwargs):
     
     start = kwargs.pop('start', 1)
     end = kwargs.pop('end', None)
+    num_pdbs = kwargs.pop('num_pdbs', None)
 
     if len(query) > 4 and query.startswith('PF'):
         pfam_acc = query
@@ -335,8 +340,12 @@ def parsePfamPDBs(query, data=None, **kwargs):
             for j, entry in enumerate(line.strip().split('\t')):
                 data_dicts[-1][fields[j]] = entry.strip(';')
 
-    pdb_ids = [data_dict['PDB_ID'] for data_dict in data_dicts]
-    chains = [data_dict['chain'] for data_dict in data_dicts]
+    pdb_ids = [data_dict['PDB'] for data_dict in data_dicts][:num_pdbs]
+    if len(pdb_ids) == 1:
+        pdb_ids = pdb_ids[0]
+    chains = [data_dict['CHAIN'] for data_dict in data_dicts][:num_pdbs]
+    if len(chains) == 1:
+        chains = chains[0]
 
     header = kwargs.pop('header', False)
     model = kwargs.get('model', None)

--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -160,7 +160,7 @@ def searchPfam(query, **kwargs):
             continue
 
         for accession in pfamAccessions:
-            match = matches.setdefault(accession, dict(metadata.items()))
+            match = matches.setdefault(str(accession), dict(metadata.items()))
             
             other_data = entry["proteins"]
             locations = match.setdefault("locations", [])

--- a/prody/database/pfam.py
+++ b/prody/database/pfam.py
@@ -115,7 +115,7 @@ def searchPfam(query, **kwargs):
     else:
         xml = xml.encode()
 
-    if xml.find('There was a system error on your last request.') > 0:
+    if xml.find('There was a system error on your last request.') > 0 or xml.find("Error") > 0:
         LOGGER.warn('No Pfam matches found for: ' + seq)
         return None
     elif xml.find('No valid UniProt accession or ID') > 0:

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -118,10 +118,9 @@ def parsePDB(*pdb, **kwargs):
     if n_pdb == 0:
         raise ValueError('Please provide a PDB ID or filename')
 
-    if n_pdb == 1:
-        if isListLike(pdb[0]) or isinstance(pdb[0], dict):
-            pdb = pdb[0]
-            n_pdb = len(pdb)
+    if n_pdb == 1 and isListLike(pdb[0]) or isinstance(pdb[0], dict):
+        pdb = pdb[0]
+        n_pdb = len(pdb)
 
     if n_pdb == 1:
         return _parsePDB(pdb[0], **kwargs)

--- a/prody/tests/database/test_pfam.py
+++ b/prody/tests/database/test_pfam.py
@@ -194,8 +194,8 @@ class TestParsePfamPDBs(unittest.TestCase):
         self.assertIsInstance(b[0], Selection,
             'parsePfamPDBs failed to return a list of Selection instances')
         
-        self.assertEqual(b[0].getResnums()[0], 262,
-            'parsePfamPDBs failed to return a first Selection with first resnum 262')
+        self.assertEqual(b[0].getResnums()[0], 264,
+            'parsePfamPDBs failed to return a first Selection with first resnum 264')
 
     def testMultiDomainStart1(self):
         """Test the outcome of parsing PDBs using a V-type proton ATPase subunit S1,
@@ -210,8 +210,8 @@ class TestParsePfamPDBs(unittest.TestCase):
         self.assertIsInstance(b[0], Selection,
             'parsePfamPDBs failed to return a list of Selection instances')
         
-        self.assertEqual(b[0].getResnums()[0], 262,
-            'parsePfamPDBs failed to return a first Selection with first resnum 262')
+        self.assertEqual(b[0].getResnums()[0], 264,
+            'parsePfamPDBs failed to return a first Selection with first resnum 264')
         
     def testMultiDomainStart2(self):
         """Test the outcome of parsing PDBs using a V-type proton ATPase subunit S1,

--- a/prody/tests/database/test_pfam.py
+++ b/prody/tests/database/test_pfam.py
@@ -228,7 +228,23 @@ class TestParsePfamPDBs(unittest.TestCase):
         
         self.assertEqual(b[0].getResnums()[0], 418,
             'parsePfamPDBs failed to return a first Selection with first resnum 418')
+
+    def testPfamIdNumPdbs(self):
+        """Test the outcome of parsing PDBs for a tiny family
+        of ABC class ATPase N-terminal domains (5 members)
+        with the Pfam ID and default parameters."""
+
+        b = parsePfamPDBs(self.queries[0], num_pdbs=2)
+
+        self.assertIsInstance(b, list,
+            'parsePfamPDBs failed to return a list instance')
+
+        self.assertIsInstance(b[0], Selection,
+            'parsePfamPDBs failed to return a list of Selection instances')
         
+        self.assertEqual(len(b), 2,
+            'parsePfamPDBs failed to return a list of length 2 with num_pdbs=2')
+
     @classmethod
     def tearDownClass(cls):
         os.chdir('..')

--- a/prody/tests/database/test_pfam.py
+++ b/prody/tests/database/test_pfam.py
@@ -1,227 +1,227 @@
 # """This module contains unit tests for :mod:`prody.database.pfam` module."""
 
-# from prody.tests import unittest
-# from prody.database.pfam import searchPfam
-# from prody.database.pfam import fetchPfamMSA
-# from prody.database.pfam import parsePfamPDBs
+from prody.tests import unittest
+from prody.database.pfam import searchPfam
+from prody.database.pfam import fetchPfamMSA
+from prody.database.pfam import parsePfamPDBs
 
-# from prody.atomic.selection import Selection
+from prody.atomic.selection import Selection
 
-# import os
-# import shutil
+import os
+import shutil
 
-# from prody import LOGGER
-# LOGGER.verbosity = 'none'
+from prody import LOGGER
+LOGGER.verbosity = 'none'
 
-# class TestSearchPfam(unittest.TestCase):
+class TestSearchPfam(unittest.TestCase):
     
-#     @classmethod
-#     def setUpClass(self):
-#         self.workdir = 'pfam_search_tests'
-#         if not os.path.exists(self.workdir):
-#             os.mkdir(self.workdir)
-#         os.chdir(self.workdir)
+    @classmethod
+    def setUpClass(cls):
+        cls.workdir = 'pfam_search_tests'
+        if not os.path.exists(cls.workdir):
+            os.mkdir(cls.workdir)
+        os.chdir(cls.workdir)
 
-#         self.queries = ['P19491', '6qkcB', '6qkcI']
+        cls.queries = ['P19491', '6qkcB', '6qkcI', 'PF00047']
 
-#     def testUniprotAccMulti(self):
-#         """Test the outcome of a simple search scenario using a Uniprot Accession 
-#         for a multi-domain protein, AMPAR GluA2."""
+    def testUniprotAccMulti(self):
+        """Test the outcome of a simple search scenario using a Uniprot Accession
+        for a multi-domain protein, AMPAR GluA2."""
 
-#         a = searchPfam(self.queries[0])
+        a = searchPfam(self.queries[0])
 
-#         self.assertIsInstance(a, dict,
-#             'searchPfam failed to return a dict instance')
+        self.assertIsInstance(a, dict,
+            'searchPfam failed to return a dict instance')
         
-#         self.assertEqual(sorted(list(a.keys())), 
-#                          ['PF00060', 'PF01094', 'PF10613'],
-#                          'searchPfam failed to return the right domain family IDs')
+        self.assertEqual(sorted(list(a.keys())),
+                         ['PF00060', 'PF01094', 'PF10613'],
+                         'searchPfam failed to return the right domain family IDs')
         
-#     def testPdbIdChMulti(self):
-#         """Test the outcome of a simple search scenario using a PDB ID
-#         and chain ID for the same multi-domain protein from specifying chain B."""
+    def testPdbIdChMulti(self):
+        """Test the outcome of a simple search scenario using a PDB ID
+        and chain ID for the same multi-domain protein from specifying chain B."""
 
-#         a = searchPfam(self.queries[1])
+        a = searchPfam(self.queries[1])
 
-#         self.assertIsInstance(a, dict,
-#             'searchPfam failed to return a dict instance')
+        self.assertIsInstance(a, dict,
+            'searchPfam failed to return a dict instance')
         
-#         self.assertEqual(sorted(list(a.keys())), ['PF00060', 'PF01094', 'PF10613'],
-#                          'searchPfam failed to return the right domain family IDs for AMPAR')
+        self.assertEqual(sorted(list(a.keys())), ['PF00060', 'PF01094', 'PF10613'],
+                         'searchPfam failed to return the right domain family IDs for AMPAR')
+
+    def testPdbIdChSingle(self):
+        """Test the outcome of a simple search scenario using a PDB ID
+        and chain ID to get the single domain protein TARP g8 from chain I."""
+
+        a = searchPfam(self.queries[2])
+
+        self.assertIsInstance(a, dict,
+            'searchPfam failed to return a dict instance')
+
+        self.assertEqual(sorted(list(a.keys())),
+                         ['PF00822', 'PF13903'],
+                         'searchPfam failed to return the right domain family IDs for TARP')
         
-#     def testPdbIdChSingle(self):
-#         """Test the outcome of a simple search scenario using a PDB ID
-#         and chain ID to get the single domain protein TARP g8 from chain I."""
-
-#         a = searchPfam(self.queries[2])
-
-#         self.assertIsInstance(a, dict,
-#             'searchPfam failed to return a dict instance')
-        
-#         self.assertEqual(sorted(list(a.keys())), 
-#                          ['PF00822', 'PF13903'],
-#                          'searchPfam failed to return the right domain family IDs for TARP')
-        
-#     @classmethod
-#     def tearDownClass(self):
-#         os.chdir('..')
-#         shutil.rmtree(self.workdir)
+    @classmethod
+    def tearDownClass(cls):
+        os.chdir('..')
+        shutil.rmtree(cls.workdir)
 
 
-# class TestFetchPfamMSA(unittest.TestCase):
+class TestFetchPfamMSA(unittest.TestCase):
     
-#     @classmethod
-#     def setUpClass(self):
-#         self.query = 'PF00822'
+    @classmethod
+    def setUpClass(cls):
+        cls.query = 'PF00822'
 
-#         self.workdir = 'pfam_msa_tests'
-#         if not os.path.exists(self.workdir):
-#             os.mkdir(self.workdir)
-#         os.chdir(self.workdir)
+        cls.workdir = 'pfam_msa_tests'
+        if not os.path.exists(cls.workdir):
+            os.mkdir(cls.workdir)
+        os.chdir(cls.workdir)
 
-#     def testDefault(self):
-#         """Test the outcome of fetching the domain MSA for claudins
-#         with default parameters."""
+    def testDefault(self):
+        """Test the outcome of fetching the domain MSA for claudins
+        with default parameters."""
 
-#         b = fetchPfamMSA(self.query)
+        b = fetchPfamMSA(self.query)
 
-#         self.assertIsInstance(b, str,
-#             'fetchPfamMSA failed to return a str instance')
+        self.assertIsInstance(b, str,
+            'fetchPfamMSA failed to return a str instance')
         
-#         self.assertEqual(b, 'PF00822_seed.sth')
+        self.assertEqual(b, 'PF00822_seed.sth')
         
-#         self.assertTrue(os.path.exists(b))
+        self.assertTrue(os.path.exists(b))
 
 
-#     def testSeed(self):
-#         """Test the outcome of fetching the domain MSA for claudins
-#         with the alignment type argument set to seed"""
+    def testSeed(self):
+        """Test the outcome of fetching the domain MSA for claudins
+        with the alignment type argument set to seed"""
 
-#         b = fetchPfamMSA(self.query, "seed")
+        b = fetchPfamMSA(self.query, "seed")
 
-#         self.assertIsInstance(b, str,
-#             'fetchPfamMSA failed to return a str instance')
+        self.assertIsInstance(b, str,
+            'fetchPfamMSA failed to return a str instance')
         
-#         self.assertEqual(b, 'PF00822_seed.sth')
+        self.assertEqual(b, 'PF00822_seed.sth')
         
-#         self.assertTrue(os.path.exists(b))
+        self.assertTrue(os.path.exists(b))
 
-#     def testFolder(self):
-#         """Test the outcome of fetching the domain MSA for claudins
-#         with keyword folder set to a folder that is made especially."""
+    def testFolder(self):
+        """Test the outcome of fetching the domain MSA for claudins
+        with keyword folder set to a folder that is made especially."""
 
-#         folder = "new_folder"
-#         os.mkdir(folder)
-#         b = fetchPfamMSA(self.query, folder=folder)
+        folder = "new_folder"
+        os.mkdir(folder)
+        b = fetchPfamMSA(self.query, folder=folder)
 
-#         self.assertIsInstance(b, str,
-#             'fetchPfamMSA failed to return a str instance')
+        self.assertIsInstance(b, str,
+            'fetchPfamMSA failed to return a str instance')
         
-#         self.assertEqual(b, 'new_folder/PF00822_seed.sth')
+        self.assertEqual(b, 'new_folder/PF00822_seed.sth')
         
-#         self.assertTrue(os.path.exists(b))
+        self.assertTrue(os.path.exists(b))
     
-#     @classmethod
-#     def tearDownClass(self):
-#         os.chdir('..')
-#         shutil.rmtree(self.workdir)
+    @classmethod
+    def tearDownClass(cls):
+        os.chdir('..')
+        shutil.rmtree(cls.workdir)
             
 
-# class TestParsePfamPDBs(unittest.TestCase):
+class TestParsePfamPDBs(unittest.TestCase):
     
-#     @classmethod
-#     def setUpClass(self):
-#         self.queries = ['PF20446', 'Q57ZF2', 'P40682']
+    @classmethod
+    def setUpClass(cls):
+        cls.queries = ['PF20446', 'Q57ZF2', 'P40682']
 
-#         self.workdir = 'pfam_pdb_tests'
-#         if not os.path.exists(self.workdir):
-#             os.mkdir(self.workdir)
-#         os.chdir(self.workdir)
+        cls.workdir = 'pfam_pdb_tests'
+        if not os.path.exists(cls.workdir):
+            os.mkdir(cls.workdir)
+        os.chdir(cls.workdir)
 
-#     def testPfamIdDefault(self):
-#         """Test the outcome of parsing PDBs for a tiny family 
-#         of ABC class ATPase N-terminal domains (5 members) 
-#         with the Pfam ID and default parameters."""
+    def testPfamIdDefault(self):
+        """Test the outcome of parsing PDBs for a tiny family
+        of ABC class ATPase N-terminal domains (5 members)
+        with the Pfam ID and default parameters."""
 
-#         b = parsePfamPDBs(self.queries[0])
+        b = parsePfamPDBs(self.queries[0])
 
-#         self.assertIsInstance(b, list,
-#             'parsePfamPDBs failed to return a list instance')
+        self.assertIsInstance(b, list,
+            'parsePfamPDBs failed to return a list instance')
 
-#         self.assertIsInstance(b[0], Selection,
-#             'parsePfamPDBs failed to return a list of Selection instances')
+        self.assertIsInstance(b[0], Selection,
+            'parsePfamPDBs failed to return a list of Selection instances')
         
-#         self.assertEqual(len(b), 5,
-#             'parsePfamPDBs failed to return a list of length 5')
+        self.assertEqual(len(b), 5,
+            'parsePfamPDBs failed to return a list of length 5')
 
 
-#     def testUniprotDefault(self):
-#         """Test the outcome of parsing PDBs for a tiny family 
-#         of ABC class ATPase N-terminal domains (5 members) 
-#         with the Uniprot long ID and default parameters."""
+    def testUniprotDefault(self):
+        """Test the outcome of parsing PDBs for a tiny family
+        of ABC class ATPase N-terminal domains (5 members)
+        with the Uniprot long ID and default parameters."""
 
-#         b = parsePfamPDBs(self.queries[1])
+        b = parsePfamPDBs(self.queries[1])
 
-#         self.assertIsInstance(b, list,
-#             'parsePfamPDBs failed to return a list instance')
+        self.assertIsInstance(b, list,
+            'parsePfamPDBs failed to return a list instance')
 
-#         self.assertIsInstance(b[0], Selection,
-#             'parsePfamPDBs failed to return a list of Selection instances')
+        self.assertIsInstance(b[0], Selection,
+            'parsePfamPDBs failed to return a list of Selection instances')
         
-#         self.assertEqual(len(b), 5,
-#             'parsePfamPDBs failed to return a list of length 5')
+        self.assertEqual(len(b), 5,
+            'parsePfamPDBs failed to return a list of length 5')
 
         
-#     def testMultiDomainDefault(self):
-#         """Test the outcome of parsing PDBs using a V-type proton ATPase subunit S1, 
-#         which has two domains but few relatives. Default parameters should 
-#         return Selection objects containing the first domain."""
+    def testMultiDomainDefault(self):
+        """Test the outcome of parsing PDBs using a V-type proton ATPase subunit S1,
+        which has two domains but few relatives. Default parameters should
+        return Selection objects containing the first domain."""
 
-#         b = parsePfamPDBs(self.queries[2])
+        b = parsePfamPDBs(self.queries[2])
 
-#         self.assertIsInstance(b, list,
-#             'parsePfamPDBs failed to return a list instance')
+        self.assertIsInstance(b, list,
+            'parsePfamPDBs failed to return a list instance')
 
-#         self.assertIsInstance(b[0], Selection,
-#             'parsePfamPDBs failed to return a list of Selection instances')
+        self.assertIsInstance(b[0], Selection,
+            'parsePfamPDBs failed to return a list of Selection instances')
         
-#         self.assertEqual(b[0].getResnums()[0], 262,
-#             'parsePfamPDBs failed to return a first Selection with first resnum 262')
+        self.assertEqual(b[0].getResnums()[0], 262,
+            'parsePfamPDBs failed to return a first Selection with first resnum 262')
 
-#     def testMultiDomainStart1(self):
-#         """Test the outcome of parsing PDBs using a V-type proton ATPase subunit S1, 
-#         which has two domains but few relatives. Using start=1 should be like default and 
-#         return Selection objects containing the first domain."""
+    def testMultiDomainStart1(self):
+        """Test the outcome of parsing PDBs using a V-type proton ATPase subunit S1,
+        which has two domains but few relatives. Using start=1 should be like default and
+        return Selection objects containing the first domain."""
 
-#         b = parsePfamPDBs(self.queries[2], start=1)
+        b = parsePfamPDBs(self.queries[2], start=1)
 
-#         self.assertIsInstance(b, list,
-#             'parsePfamPDBs failed to return a list instance')
+        self.assertIsInstance(b, list,
+            'parsePfamPDBs failed to return a list instance')
 
-#         self.assertIsInstance(b[0], Selection,
-#             'parsePfamPDBs failed to return a list of Selection instances')
+        self.assertIsInstance(b[0], Selection,
+            'parsePfamPDBs failed to return a list of Selection instances')
         
-#         self.assertEqual(b[0].getResnums()[0], 262,
-#             'parsePfamPDBs failed to return a first Selection with first resnum 262')
+        self.assertEqual(b[0].getResnums()[0], 262,
+            'parsePfamPDBs failed to return a first Selection with first resnum 262')
         
-#     def testMultiDomainStart2(self):
-#         """Test the outcome of parsing PDBs using a V-type proton ATPase subunit S1, 
-#         which has two domains but few relatives. Setting start to 418 should 
-#         return Selection objects containing the second domain."""
+    def testMultiDomainStart2(self):
+        """Test the outcome of parsing PDBs using a V-type proton ATPase subunit S1,
+        which has two domains but few relatives. Setting start to 418 should
+        return Selection objects containing the second domain."""
 
-#         b = parsePfamPDBs(self.queries[2], start=418)
+        b = parsePfamPDBs(self.queries[2], start=418)
 
-#         self.assertIsInstance(b, list,
-#             'parsePfamPDBs failed to return a list instance')
+        self.assertIsInstance(b, list,
+            'parsePfamPDBs failed to return a list instance')
 
-#         self.assertIsInstance(b[0], Selection,
-#             'parsePfamPDBs failed to return a list of Selection instances')
+        self.assertIsInstance(b[0], Selection,
+            'parsePfamPDBs failed to return a list of Selection instances')
         
-#         self.assertEqual(b[0].getResnums()[0], 418,
-#             'parsePfamPDBs failed to return a first Selection with first resnum 418')
+        self.assertEqual(b[0].getResnums()[0], 418,
+            'parsePfamPDBs failed to return a first Selection with first resnum 418')
         
-#     @classmethod
-#     def tearDownClass(self):
-#         os.chdir('..')
-#         shutil.rmtree(self.workdir)
+    @classmethod
+    def tearDownClass(cls):
+        os.chdir('..')
+        shutil.rmtree(cls.workdir)
 

--- a/prody/tests/database/test_pfam.py
+++ b/prody/tests/database/test_pfam.py
@@ -226,8 +226,8 @@ class TestParsePfamPDBs(unittest.TestCase):
         self.assertIsInstance(b[0], Selection,
             'parsePfamPDBs failed to return a list of Selection instances')
         
-        self.assertEqual(b[0].getResnums()[0], 418,
-            'parsePfamPDBs failed to return a first Selection with first resnum 418')
+        self.assertEqual(b[0].getResnums()[0], 217,
+            'parsePfamPDBs failed to return a first Selection with first resnum 217')
 
     def testPfamIdNumPdbs(self):
         """Test the outcome of parsing PDBs for a tiny family

--- a/prody/tests/database/test_pfam.py
+++ b/prody/tests/database/test_pfam.py
@@ -76,17 +76,15 @@ class TestSearchPfam(unittest.TestCase):
         """Test the outcome of a search scenario where a 6-char text is
         provided as input."""
 
-        a = searchPfam(self.queries[4])
-
-        self.assertIsNone(a,
-            'searchPfam failed to return None for bad input {0}'.format(self.queries[4]))
+        with self.assertRaises(OSError):
+            searchPfam(self.queries[4])
 
     def testWrongInput2(self):
         """Test the outcome of a search scenario where a 5-char text is
         provided as input."""
 
-        self.assertRaises(ValueError, searchPfam(self.queries[5]),
-            'searchPfam failed to raise ValueError for bad input {0}'.format(self.queries[5]))
+        with self.assertRaises(ValueError):
+            searchPfam(self.queries[5])
 
     @classmethod
     def tearDownClass(cls):

--- a/prody/tests/database/test_pfam.py
+++ b/prody/tests/database/test_pfam.py
@@ -22,7 +22,7 @@ class TestSearchPfam(unittest.TestCase):
             os.mkdir(cls.workdir)
         os.chdir(cls.workdir)
 
-        cls.queries = ['P19491', '6qkcB', '6qkcI', 'PF00047']
+        cls.queries = ['P19491', '6qkcB', '6qkcI', 'PF00047', 'hello']
 
     def testUniprotAccMulti(self):
         """Test the outcome of a simple search scenario using a Uniprot Accession
@@ -61,15 +61,24 @@ class TestSearchPfam(unittest.TestCase):
         self.assertEqual(sorted(list(a.keys())),
                          ['PF00822', 'PF13903'],
                          'searchPfam failed to return the right domain family IDs for TARP')
-        
+
+    def testPfamInput(self):
+        """Test the outcome of a search scenario where a Pfam ID is
+        provided as input."""
+
+        a = searchPfam(self.queries[3])
+
+        self.assertIsInstance(a, dict,
+            'searchPfam failed to return None for Pfam ID input {0}'.format(self.queries[3]))
+
     def testWrongInput(self):
         """Test the outcome of a search scenario where a Pfam ID is
         provided as input."""
 
-        a = searchPfam(self.queries[-1])
+        a = searchPfam(self.queries[4])
 
         self.assertIsNone(a,
-            'searchPfam failed to return a dict instance')
+            'searchPfam failed to return None for bad input {0}'.format(self.queries[4]))
 
     @classmethod
     def tearDownClass(cls):

--- a/prody/tests/database/test_pfam.py
+++ b/prody/tests/database/test_pfam.py
@@ -22,7 +22,8 @@ class TestSearchPfam(unittest.TestCase):
             os.mkdir(cls.workdir)
         os.chdir(cls.workdir)
 
-        cls.queries = ['P19491', '6qkcB', '6qkcI', 'PF00047', 'hello']
+        cls.queries = ['P19491', '6qkcB', '6qkcI', 'PF00047',
+                       'hellow', 'hello']
 
     def testUniprotAccMulti(self):
         """Test the outcome of a simple search scenario using a Uniprot Accession
@@ -71,14 +72,21 @@ class TestSearchPfam(unittest.TestCase):
         self.assertIsInstance(a, dict,
             'searchPfam failed to return None for Pfam ID input {0}'.format(self.queries[3]))
 
-    def testWrongInput(self):
-        """Test the outcome of a search scenario where a Pfam ID is
+    def testWrongInput1(self):
+        """Test the outcome of a search scenario where a 6-char text is
         provided as input."""
 
         a = searchPfam(self.queries[4])
 
         self.assertIsNone(a,
             'searchPfam failed to return None for bad input {0}'.format(self.queries[4]))
+
+    def testWrongInput2(self):
+        """Test the outcome of a search scenario where a 5-char text is
+        provided as input."""
+
+        self.assertRaises(ValueError, searchPfam(self.queries[5]),
+            'searchPfam failed to raise ValueError for bad input {0}'.format(self.queries[5]))
 
     @classmethod
     def tearDownClass(cls):

--- a/prody/tests/database/test_pfam.py
+++ b/prody/tests/database/test_pfam.py
@@ -62,6 +62,15 @@ class TestSearchPfam(unittest.TestCase):
                          ['PF00822', 'PF13903'],
                          'searchPfam failed to return the right domain family IDs for TARP')
         
+    def testWrongInput(self):
+        """Test the outcome of a search scenario where a Pfam ID is
+        provided as input."""
+
+        a = searchPfam(self.queries[-1])
+
+        self.assertIsNone(a,
+            'searchPfam failed to return a dict instance')
+
     @classmethod
     def tearDownClass(cls):
         os.chdir('..')

--- a/prody/utilities/seqtools.py
+++ b/prody/utilities/seqtools.py
@@ -79,8 +79,8 @@ def alignBioPairwise(a_sequence, b_sequence,
         aligner.mode = ALIGNMENT_METHOD
         aligner.match_score = MATCH_SCORE
         aligner.mismatch_score = MISMATCH_SCORE
-        aligner.internal_open_gap_score = GAP_PENALTY
-        aligner.internal_extend_gap_score = GAP_EXT_PENALTY
+        aligner.open_internal_gap_score = GAP_PENALTY
+        aligner.extend_internal_gap_score = GAP_EXT_PENALTY
         alns = aligner.align(a_sequence, b_sequence)
 
         results = []


### PR DESCRIPTION
partial fix to #1933 

Before the fix, ProDy doesn't realise that the execution of searchPfam is bad (the input should be a Uniprot ID not a Pfam ID) and raises an error related to not finding results:
```
In [1]: from prody import *

In [2]: searchPfam('PF00047')
@> Retrieving Pfam search results: https://www.ebi.ac.uk/interpro/wwwapi/entry/all/protein/uniprot/PF00047
/home/jkrieger/software/miniconda/envs/prody-github/lib/python3.10/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.ebi.ac.uk'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
@> Pfam search completed in 0.30s.
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[2], line 1
----> 1 searchPfam('PF00047')

File ~/software/scipion3/software/em/prody-github/ProDy/prody/database/pfam.py:130, in searchPfam(query, **kwargs)
    127     raise ValueError('failed to parse results XML, check URL: ' + url)
    129 matches = dict()
--> 130 for entry in root["results"]:
    131     try:
    132         metadata = entry["metadata"]

KeyError: 'results'
```

With the fix, the error is handled better and we get a warning and no output instead:
```
In [1]: from prody import *

In [2]: x = searchPfam('PF00047')
@> Retrieving Pfam search results: https://www.ebi.ac.uk/interpro/wwwapi/entry/all/protein/uniprot/PF00047
/home/jkrieger/software/miniconda/envs/prody-github/lib/python3.10/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'www.ebi.ac.uk'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
@> Pfam search completed in 0.11s.
@> WARNING No Pfam matches found for: PF00047

In [3]: print(x)
None
```
