### PR TITLE
Handle chimerax cif (missing fields)

### DIFF
--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -95,8 +95,6 @@ def parseMMCIF(pdb, **kwargs):
             else:
                 raise ValueError('Please provide chain as a keyword argument '
                                  'or part of the PDB ID, not both')
-        else:
-            chain = chain
 
         if len(pdb) == 4 and pdb.isalnum():
             if title is None:

--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -773,9 +773,9 @@ def _getPolymers(lines):
     items1 = parseSTARSection(lines, '_entity_poly', report=False)
 
     for item in items1:
-        chains = item['_entity_poly.pdbx_strand_id'].replace(';','').replace(' ', '')
-        entity = item['_entity_poly.entity_id']
-        
+        chains = item.get('_entity_poly.pdbx_strand_id', '').replace(';','').replace(' ', '')
+        entity = item.get('_entity_poly.entity_id', '')
+
         for ch in chains.split(","):
             entities[entity].append(ch)
             poly = polymers.get(ch, Polymer(ch))
@@ -1106,8 +1106,8 @@ def _getChemicals(lines):
             synonym = synonym[1:-1]
         chem_synonyms[resname] += synonym
         
-        chem_formulas[resname] += data["_chem_comp.formula"]
-
+        if "_chem_comp.formula" in data.keys():
+            chem_formulas[resname] += data["_chem_comp.formula"]
 
     for key, name in chem_names.items():  # PY3K: OK
         name = cleanString(name)

--- a/prody/proteins/starfile.py
+++ b/prody/proteins/starfile.py
@@ -1073,8 +1073,8 @@ def parseSTARSection(lines, key, report=True):
 
         i += 1
 
-    if i < len(lines):
-        star_dict, _ = parseSTARLines(lines[:2] + lines[start-1: stop], shlex=True)
+    if start > 0:
+        star_dict, _ = parseSTARLines(lines[:5] + lines[start-1: stop], shlex=True)
         loop_dict = list(star_dict.values())[0]
 
         if lines[start - 1].strip() == "loop_":

--- a/prody/tests/datafiles/__init__.py
+++ b/prody/tests/datafiles/__init__.py
@@ -254,6 +254,12 @@ DATA_FILES = {
         'atoms': 165175,
         'segment_SX0_atoms': 1089,
     },
+    'chimerax_cif': {
+        'pdb': '1ake',
+        'file': 'mmcif_1ake_chimerax.cif',
+        'biomols': 2,
+        'bm0_atoms': 1954
+    },
     '6zu5_sel': {
         'pdb': '6zu5',
         'file': '6zu5_sel_SE0_SF0_10-20.pdb',

--- a/prody/tests/datafiles/mmcif_1ake_chimerax.cif
+++ b/prody/tests/datafiles/mmcif_1ake_chimerax.cif
@@ -1,0 +1,4804 @@
+#\#CIF_1.1
+# mmCIF
+data_1ake.cif
+#
+_entry.id 1AKE
+#
+_audit_conform.dict_name mmcif_pdbx.dic
+_audit_conform.dict_version 4.007
+_audit_conform.dict_location http://mmcif.pdb.org/dictionaries/ascii/mmcif_pdbx.dic
+#
+_audit_syntax.case_sensitive_flag Y
+_audit_syntax.fixed_width "atom_site atom_site_anisotrop"
+#
+loop_
+_citation.id
+_citation.title
+_citation.journal_abbrev
+_citation.journal_volume
+_citation.page_first
+_citation.page_last
+_citation.year
+_citation.journal_id_ASTM
+_citation.country
+_citation.journal_id_ISSN
+_citation.journal_id_CSD
+_citation.book_publisher
+_citation.pdbx_database_id_PubMed
+_citation.pdbx_database_id_DOI
+_citation.journal_issue
+primary
+
+;Structure of the complex between adenylate kinase from Escherichia coli and the inhibitor Ap5A refined at 1.9 A resolution. A model for a catalytic transition state.
+;
+ J.Mol.Biol. 224 159 177 1992 JMOBAK UK 0022-2836 0070 ? 1548697 10.1016/0022-2836(92)90582-5 ?
+1 "Induced-Fit Movements in Adenylate Kinases" J.Mol.Biol. 213 627 ? 1990 JMOBAK UK 0022-2836 0070 ? ? ? ?
+2 
+;Structure of the Complex of Adenylate Kinase from Escherichia Coli with the Inhibitor P1, P5-Bis (Adenosine-5'-) Pentaphosphate
+;
+ J.Mol.Biol. 202 909 ? 1988 JMOBAK UK 0022-2836 0070 ? ? ? ?
+chimerax 
+;UCSF ChimeraX: Structure visualization for researchers, educators, and developers
+;
+ "Protein Sci." 30 70 82 2021 ? ? ? ? ? 28710774 10.1002/pro.3943 1
+#
+loop_
+_citation_author.citation_id
+_citation_author.name
+_citation_author.ordinal
+_citation_author.identifier_ORCID
+primary  "Muller, C.W."   1 ? 
+primary  "Schulz, G.E."   2 ? 
+1        "Schulz, G.E."   3 ? 
+1        "Mueller, C.W."  4 ? 
+1        "Diederichs, K." 5 ? 
+2        "Mueller, C.W."  6 ? 
+2        "Schulz, G.E."   7 ? 
+chimerax "Pettersen EF"   1 ? 
+chimerax "Goddard TD"     2 ? 
+chimerax "Huang CC"       3 ? 
+chimerax "Meng EC"        4 ? 
+chimerax "Couch GS"       5 ? 
+chimerax "Croll TI"       6 ? 
+chimerax "Morris JH"      7 ? 
+chimerax "Ferrin TE"      8 ? 
+#
+loop_
+_software.name
+_software.classification
+_software.version
+_software.citation_id
+_software.pdbx_ordinal
+_software.location
+_software.os
+_software.type
+X-PLOR          "model building" .      ?        1 ?                                   ?     ?       
+X-PLOR          refinement       .      ?        2 ?                                   ?     ?       
+X-PLOR          phasing          .      ?        3 ?                                   ?     ?       
+"UCSF ChimeraX" "model building" 1.4/v9 chimerax 4 https://www.rbvi.ucsf.edu/chimerax/ Linux package 
+#
+loop_
+_chem_comp.id
+_chem_comp.type
+_chem_comp.name
+MET "L-peptide linking" METHIONINE                         
+ARG "L-peptide linking" ARGININE                           
+ILE "L-peptide linking" ISOLEUCINE                         
+LEU "L-peptide linking" LEUCINE                            
+GLY "peptide linking"   GLYCINE                            
+ALA "L-peptide linking" ALANINE                            
+PRO "L-peptide linking" PROLINE                            
+LYS "L-peptide linking" LYSINE                             
+THR "L-peptide linking" THREONINE                          
+GLN "L-peptide linking" GLUTAMINE                          
+PHE "L-peptide linking" PHENYLALANINE                      
+GLU "L-peptide linking" "GLUTAMIC ACID"                    
+TYR "L-peptide linking" TYROSINE                           
+SER "L-peptide linking" SERINE                             
+ASP "L-peptide linking" "ASPARTIC ACID"                    
+VAL "L-peptide linking" VALINE                             
+CYS "L-peptide linking" CYSTEINE                           
+ASN "L-peptide linking" ASPARAGINE                         
+HIS "L-peptide linking" HISTIDINE                          
+AP5 non-polymer         "BIS(ADENOSINE)-5'-PENTAPHOSPHATE" 
+HOH non-polymer         WATER                              
+#
+_exptl.entry_id 1AKE
+_exptl.method "X-RAY DIFFRACTION"
+_exptl.crystals_number ?
+#
+loop_
+_entity.id
+_entity.type
+_entity.pdbx_description
+1 polymer     "ADENYLATE KINASE"                 
+2 non-polymer "BIS(ADENOSINE)-5'-PENTAPHOSPHATE" 
+3 water       water                              
+#
+_entity_poly.entity_id 1
+_entity_poly.nstd_monomer no
+_entity_poly.type polypeptide(L)
+_entity_poly.pdbx_seq_one_letter_code_can 
+;MRIILLGAPGAGKGTQAQFIMEKYGIPQISTGDMLRAAVKSGSELGKQAKDIMDAGKLVTDELVIALVKERIAQEDCRNGFLLDGFPRTIPQADAMKEAGINVDYVLEFDVPDELIVDRIVGRRVHAPSGRVYHVKFNPPKVEGKDDVTGEELTTRKDDQEETVRKRLVEYHQMTAPLIGYYSKEAEAGNTKYAKVDGTKPVAEVRADLEKILG
+;
+
+#
+loop_
+_entity_poly_seq.entity_id
+_entity_poly_seq.num
+_entity_poly_seq.mon_id
+1 1   MET 
+1 2   ARG 
+1 3   ILE 
+1 4   ILE 
+1 5   LEU 
+1 6   LEU 
+1 7   GLY 
+1 8   ALA 
+1 9   PRO 
+1 10  GLY 
+1 11  ALA 
+1 12  GLY 
+1 13  LYS 
+1 14  GLY 
+1 15  THR 
+1 16  GLN 
+1 17  ALA 
+1 18  GLN 
+1 19  PHE 
+1 20  ILE 
+1 21  MET 
+1 22  GLU 
+1 23  LYS 
+1 24  TYR 
+1 25  GLY 
+1 26  ILE 
+1 27  PRO 
+1 28  GLN 
+1 29  ILE 
+1 30  SER 
+1 31  THR 
+1 32  GLY 
+1 33  ASP 
+1 34  MET 
+1 35  LEU 
+1 36  ARG 
+1 37  ALA 
+1 38  ALA 
+1 39  VAL 
+1 40  LYS 
+1 41  SER 
+1 42  GLY 
+1 43  SER 
+1 44  GLU 
+1 45  LEU 
+1 46  GLY 
+1 47  LYS 
+1 48  GLN 
+1 49  ALA 
+1 50  LYS 
+1 51  ASP 
+1 52  ILE 
+1 53  MET 
+1 54  ASP 
+1 55  ALA 
+1 56  GLY 
+1 57  LYS 
+1 58  LEU 
+1 59  VAL 
+1 60  THR 
+1 61  ASP 
+1 62  GLU 
+1 63  LEU 
+1 64  VAL 
+1 65  ILE 
+1 66  ALA 
+1 67  LEU 
+1 68  VAL 
+1 69  LYS 
+1 70  GLU 
+1 71  ARG 
+1 72  ILE 
+1 73  ALA 
+1 74  GLN 
+1 75  GLU 
+1 76  ASP 
+1 77  CYS 
+1 78  ARG 
+1 79  ASN 
+1 80  GLY 
+1 81  PHE 
+1 82  LEU 
+1 83  LEU 
+1 84  ASP 
+1 85  GLY 
+1 86  PHE 
+1 87  PRO 
+1 88  ARG 
+1 89  THR 
+1 90  ILE 
+1 91  PRO 
+1 92  GLN 
+1 93  ALA 
+1 94  ASP 
+1 95  ALA 
+1 96  MET 
+1 97  LYS 
+1 98  GLU 
+1 99  ALA 
+1 100 GLY 
+1 101 ILE 
+1 102 ASN 
+1 103 VAL 
+1 104 ASP 
+1 105 TYR 
+1 106 VAL 
+1 107 LEU 
+1 108 GLU 
+1 109 PHE 
+1 110 ASP 
+1 111 VAL 
+1 112 PRO 
+1 113 ASP 
+1 114 GLU 
+1 115 LEU 
+1 116 ILE 
+1 117 VAL 
+1 118 ASP 
+1 119 ARG 
+1 120 ILE 
+1 121 VAL 
+1 122 GLY 
+1 123 ARG 
+1 124 ARG 
+1 125 VAL 
+1 126 HIS 
+1 127 ALA 
+1 128 PRO 
+1 129 SER 
+1 130 GLY 
+1 131 ARG 
+1 132 VAL 
+1 133 TYR 
+1 134 HIS 
+1 135 VAL 
+1 136 LYS 
+1 137 PHE 
+1 138 ASN 
+1 139 PRO 
+1 140 PRO 
+1 141 LYS 
+1 142 VAL 
+1 143 GLU 
+1 144 GLY 
+1 145 LYS 
+1 146 ASP 
+1 147 ASP 
+1 148 VAL 
+1 149 THR 
+1 150 GLY 
+1 151 GLU 
+1 152 GLU 
+1 153 LEU 
+1 154 THR 
+1 155 THR 
+1 156 ARG 
+1 157 LYS 
+1 158 ASP 
+1 159 ASP 
+1 160 GLN 
+1 161 GLU 
+1 162 GLU 
+1 163 THR 
+1 164 VAL 
+1 165 ARG 
+1 166 LYS 
+1 167 ARG 
+1 168 LEU 
+1 169 VAL 
+1 170 GLU 
+1 171 TYR 
+1 172 HIS 
+1 173 GLN 
+1 174 MET 
+1 175 THR 
+1 176 ALA 
+1 177 PRO 
+1 178 LEU 
+1 179 ILE 
+1 180 GLY 
+1 181 TYR 
+1 182 TYR 
+1 183 SER 
+1 184 LYS 
+1 185 GLU 
+1 186 ALA 
+1 187 GLU 
+1 188 ALA 
+1 189 GLY 
+1 190 ASN 
+1 191 THR 
+1 192 LYS 
+1 193 TYR 
+1 194 ALA 
+1 195 LYS 
+1 196 VAL 
+1 197 ASP 
+1 198 GLY 
+1 199 THR 
+1 200 LYS 
+1 201 PRO 
+1 202 VAL 
+1 203 ALA 
+1 204 GLU 
+1 205 VAL 
+1 206 ARG 
+1 207 ALA 
+1 208 ASP 
+1 209 LEU 
+1 210 GLU 
+1 211 LYS 
+1 212 ILE 
+1 213 LEU 
+1 214 GLY 
+#
+loop_
+_struct_asym.id
+_struct_asym.entity_id
+A 1 
+B 1 
+C 2 
+D 2 
+E 3 
+F 3 
+#
+loop_
+_pdbx_poly_seq_scheme.entity_id
+_pdbx_poly_seq_scheme.asym_id
+_pdbx_poly_seq_scheme.mon_id
+_pdbx_poly_seq_scheme.seq_id
+_pdbx_poly_seq_scheme.pdb_strand_id
+_pdbx_poly_seq_scheme.pdb_seq_num
+_pdbx_poly_seq_scheme.pdb_ins_code
+1 A MET 1   A 1   . 
+1 A ARG 2   A 2   . 
+1 A ILE 3   A 3   . 
+1 A ILE 4   A 4   . 
+1 A LEU 5   A 5   . 
+1 A LEU 6   A 6   . 
+1 A GLY 7   A 7   . 
+1 A ALA 8   A 8   . 
+1 A PRO 9   A 9   . 
+1 A GLY 10  A 10  . 
+1 A ALA 11  A 11  . 
+1 A GLY 12  A 12  . 
+1 A LYS 13  A 13  . 
+1 A GLY 14  A 14  . 
+1 A THR 15  A 15  . 
+1 A GLN 16  A 16  . 
+1 A ALA 17  A 17  . 
+1 A GLN 18  A 18  . 
+1 A PHE 19  A 19  . 
+1 A ILE 20  A 20  . 
+1 A MET 21  A 21  . 
+1 A GLU 22  A 22  . 
+1 A LYS 23  A 23  . 
+1 A TYR 24  A 24  . 
+1 A GLY 25  A 25  . 
+1 A ILE 26  A 26  . 
+1 A PRO 27  A 27  . 
+1 A GLN 28  A 28  . 
+1 A ILE 29  A 29  . 
+1 A SER 30  A 30  . 
+1 A THR 31  A 31  . 
+1 A GLY 32  A 32  . 
+1 A ASP 33  A 33  . 
+1 A MET 34  A 34  . 
+1 A LEU 35  A 35  . 
+1 A ARG 36  A 36  . 
+1 A ALA 37  A 37  . 
+1 A ALA 38  A 38  . 
+1 A VAL 39  A 39  . 
+1 A LYS 40  A 40  . 
+1 A SER 41  A 41  . 
+1 A GLY 42  A 42  . 
+1 A SER 43  A 43  . 
+1 A GLU 44  A 44  . 
+1 A LEU 45  A 45  . 
+1 A GLY 46  A 46  . 
+1 A LYS 47  A 47  . 
+1 A GLN 48  A 48  . 
+1 A ALA 49  A 49  . 
+1 A LYS 50  A 50  . 
+1 A ASP 51  A 51  . 
+1 A ILE 52  A 52  . 
+1 A MET 53  A 53  . 
+1 A ASP 54  A 54  . 
+1 A ALA 55  A 55  . 
+1 A GLY 56  A 56  . 
+1 A LYS 57  A 57  . 
+1 A LEU 58  A 58  . 
+1 A VAL 59  A 59  . 
+1 A THR 60  A 60  . 
+1 A ASP 61  A 61  . 
+1 A GLU 62  A 62  . 
+1 A LEU 63  A 63  . 
+1 A VAL 64  A 64  . 
+1 A ILE 65  A 65  . 
+1 A ALA 66  A 66  . 
+1 A LEU 67  A 67  . 
+1 A VAL 68  A 68  . 
+1 A LYS 69  A 69  . 
+1 A GLU 70  A 70  . 
+1 A ARG 71  A 71  . 
+1 A ILE 72  A 72  . 
+1 A ALA 73  A 73  . 
+1 A GLN 74  A 74  . 
+1 A GLU 75  A 75  . 
+1 A ASP 76  A 76  . 
+1 A CYS 77  A 77  . 
+1 A ARG 78  A 78  . 
+1 A ASN 79  A 79  . 
+1 A GLY 80  A 80  . 
+1 A PHE 81  A 81  . 
+1 A LEU 82  A 82  . 
+1 A LEU 83  A 83  . 
+1 A ASP 84  A 84  . 
+1 A GLY 85  A 85  . 
+1 A PHE 86  A 86  . 
+1 A PRO 87  A 87  . 
+1 A ARG 88  A 88  . 
+1 A THR 89  A 89  . 
+1 A ILE 90  A 90  . 
+1 A PRO 91  A 91  . 
+1 A GLN 92  A 92  . 
+1 A ALA 93  A 93  . 
+1 A ASP 94  A 94  . 
+1 A ALA 95  A 95  . 
+1 A MET 96  A 96  . 
+1 A LYS 97  A 97  . 
+1 A GLU 98  A 98  . 
+1 A ALA 99  A 99  . 
+1 A GLY 100 A 100 . 
+1 A ILE 101 A 101 . 
+1 A ASN 102 A 102 . 
+1 A VAL 103 A 103 . 
+1 A ASP 104 A 104 . 
+1 A TYR 105 A 105 . 
+1 A VAL 106 A 106 . 
+1 A LEU 107 A 107 . 
+1 A GLU 108 A 108 . 
+1 A PHE 109 A 109 . 
+1 A ASP 110 A 110 . 
+1 A VAL 111 A 111 . 
+1 A PRO 112 A 112 . 
+1 A ASP 113 A 113 . 
+1 A GLU 114 A 114 . 
+1 A LEU 115 A 115 . 
+1 A ILE 116 A 116 . 
+1 A VAL 117 A 117 . 
+1 A ASP 118 A 118 . 
+1 A ARG 119 A 119 . 
+1 A ILE 120 A 120 . 
+1 A VAL 121 A 121 . 
+1 A GLY 122 A 122 . 
+1 A ARG 123 A 123 . 
+1 A ARG 124 A 124 . 
+1 A VAL 125 A 125 . 
+1 A HIS 126 A 126 . 
+1 A ALA 127 A 127 . 
+1 A PRO 128 A 128 . 
+1 A SER 129 A 129 . 
+1 A GLY 130 A 130 . 
+1 A ARG 131 A 131 . 
+1 A VAL 132 A 132 . 
+1 A TYR 133 A 133 . 
+1 A HIS 134 A 134 . 
+1 A VAL 135 A 135 . 
+1 A LYS 136 A 136 . 
+1 A PHE 137 A 137 . 
+1 A ASN 138 A 138 . 
+1 A PRO 139 A 139 . 
+1 A PRO 140 A 140 . 
+1 A LYS 141 A 141 . 
+1 A VAL 142 A 142 . 
+1 A GLU 143 A 143 . 
+1 A GLY 144 A 144 . 
+1 A LYS 145 A 145 . 
+1 A ASP 146 A 146 . 
+1 A ASP 147 A 147 . 
+1 A VAL 148 A 148 . 
+1 A THR 149 A 149 . 
+1 A GLY 150 A 150 . 
+1 A GLU 151 A 151 . 
+1 A GLU 152 A 152 . 
+1 A LEU 153 A 153 . 
+1 A THR 154 A 154 . 
+1 A THR 155 A 155 . 
+1 A ARG 156 A 156 . 
+1 A LYS 157 A 157 . 
+1 A ASP 158 A 158 . 
+1 A ASP 159 A 159 . 
+1 A GLN 160 A 160 . 
+1 A GLU 161 A 161 . 
+1 A GLU 162 A 162 . 
+1 A THR 163 A 163 . 
+1 A VAL 164 A 164 . 
+1 A ARG 165 A 165 . 
+1 A LYS 166 A 166 . 
+1 A ARG 167 A 167 . 
+1 A LEU 168 A 168 . 
+1 A VAL 169 A 169 . 
+1 A GLU 170 A 170 . 
+1 A TYR 171 A 171 . 
+1 A HIS 172 A 172 . 
+1 A GLN 173 A 173 . 
+1 A MET 174 A 174 . 
+1 A THR 175 A 175 . 
+1 A ALA 176 A 176 . 
+1 A PRO 177 A 177 . 
+1 A LEU 178 A 178 . 
+1 A ILE 179 A 179 . 
+1 A GLY 180 A 180 . 
+1 A TYR 181 A 181 . 
+1 A TYR 182 A 182 . 
+1 A SER 183 A 183 . 
+1 A LYS 184 A 184 . 
+1 A GLU 185 A 185 . 
+1 A ALA 186 A 186 . 
+1 A GLU 187 A 187 . 
+1 A ALA 188 A 188 . 
+1 A GLY 189 A 189 . 
+1 A ASN 190 A 190 . 
+1 A THR 191 A 191 . 
+1 A LYS 192 A 192 . 
+1 A TYR 193 A 193 . 
+1 A ALA 194 A 194 . 
+1 A LYS 195 A 195 . 
+1 A VAL 196 A 196 . 
+1 A ASP 197 A 197 . 
+1 A GLY 198 A 198 . 
+1 A THR 199 A 199 . 
+1 A LYS 200 A 200 . 
+1 A PRO 201 A 201 . 
+1 A VAL 202 A 202 . 
+1 A ALA 203 A 203 . 
+1 A GLU 204 A 204 . 
+1 A VAL 205 A 205 . 
+1 A ARG 206 A 206 . 
+1 A ALA 207 A 207 . 
+1 A ASP 208 A 208 . 
+1 A LEU 209 A 209 . 
+1 A GLU 210 A 210 . 
+1 A LYS 211 A 211 . 
+1 A ILE 212 A 212 . 
+1 A LEU 213 A 213 . 
+1 A GLY 214 A 214 . 
+1 B MET 1   B 1   . 
+1 B ARG 2   B 2   . 
+1 B ILE 3   B 3   . 
+1 B ILE 4   B 4   . 
+1 B LEU 5   B 5   . 
+1 B LEU 6   B 6   . 
+1 B GLY 7   B 7   . 
+1 B ALA 8   B 8   . 
+1 B PRO 9   B 9   . 
+1 B GLY 10  B 10  . 
+1 B ALA 11  B 11  . 
+1 B GLY 12  B 12  . 
+1 B LYS 13  B 13  . 
+1 B GLY 14  B 14  . 
+1 B THR 15  B 15  . 
+1 B GLN 16  B 16  . 
+1 B ALA 17  B 17  . 
+1 B GLN 18  B 18  . 
+1 B PHE 19  B 19  . 
+1 B ILE 20  B 20  . 
+1 B MET 21  B 21  . 
+1 B GLU 22  B 22  . 
+1 B LYS 23  B 23  . 
+1 B TYR 24  B 24  . 
+1 B GLY 25  B 25  . 
+1 B ILE 26  B 26  . 
+1 B PRO 27  B 27  . 
+1 B GLN 28  B 28  . 
+1 B ILE 29  B 29  . 
+1 B SER 30  B 30  . 
+1 B THR 31  B 31  . 
+1 B GLY 32  B 32  . 
+1 B ASP 33  B 33  . 
+1 B MET 34  B 34  . 
+1 B LEU 35  B 35  . 
+1 B ARG 36  B 36  . 
+1 B ALA 37  B 37  . 
+1 B ALA 38  B 38  . 
+1 B VAL 39  B 39  . 
+1 B LYS 40  B 40  . 
+1 B SER 41  B 41  . 
+1 B GLY 42  B 42  . 
+1 B SER 43  B 43  . 
+1 B GLU 44  B 44  . 
+1 B LEU 45  B 45  . 
+1 B GLY 46  B 46  . 
+1 B LYS 47  B 47  . 
+1 B GLN 48  B 48  . 
+1 B ALA 49  B 49  . 
+1 B LYS 50  B 50  . 
+1 B ASP 51  B 51  . 
+1 B ILE 52  B 52  . 
+1 B MET 53  B 53  . 
+1 B ASP 54  B 54  . 
+1 B ALA 55  B 55  . 
+1 B GLY 56  B 56  . 
+1 B LYS 57  B 57  . 
+1 B LEU 58  B 58  . 
+1 B VAL 59  B 59  . 
+1 B THR 60  B 60  . 
+1 B ASP 61  B 61  . 
+1 B GLU 62  B 62  . 
+1 B LEU 63  B 63  . 
+1 B VAL 64  B 64  . 
+1 B ILE 65  B 65  . 
+1 B ALA 66  B 66  . 
+1 B LEU 67  B 67  . 
+1 B VAL 68  B 68  . 
+1 B LYS 69  B 69  . 
+1 B GLU 70  B 70  . 
+1 B ARG 71  B 71  . 
+1 B ILE 72  B 72  . 
+1 B ALA 73  B 73  . 
+1 B GLN 74  B 74  . 
+1 B GLU 75  B 75  . 
+1 B ASP 76  B 76  . 
+1 B CYS 77  B 77  . 
+1 B ARG 78  B 78  . 
+1 B ASN 79  B 79  . 
+1 B GLY 80  B 80  . 
+1 B PHE 81  B 81  . 
+1 B LEU 82  B 82  . 
+1 B LEU 83  B 83  . 
+1 B ASP 84  B 84  . 
+1 B GLY 85  B 85  . 
+1 B PHE 86  B 86  . 
+1 B PRO 87  B 87  . 
+1 B ARG 88  B 88  . 
+1 B THR 89  B 89  . 
+1 B ILE 90  B 90  . 
+1 B PRO 91  B 91  . 
+1 B GLN 92  B 92  . 
+1 B ALA 93  B 93  . 
+1 B ASP 94  B 94  . 
+1 B ALA 95  B 95  . 
+1 B MET 96  B 96  . 
+1 B LYS 97  B 97  . 
+1 B GLU 98  B 98  . 
+1 B ALA 99  B 99  . 
+1 B GLY 100 B 100 . 
+1 B ILE 101 B 101 . 
+1 B ASN 102 B 102 . 
+1 B VAL 103 B 103 . 
+1 B ASP 104 B 104 . 
+1 B TYR 105 B 105 . 
+1 B VAL 106 B 106 . 
+1 B LEU 107 B 107 . 
+1 B GLU 108 B 108 . 
+1 B PHE 109 B 109 . 
+1 B ASP 110 B 110 . 
+1 B VAL 111 B 111 . 
+1 B PRO 112 B 112 . 
+1 B ASP 113 B 113 . 
+1 B GLU 114 B 114 . 
+1 B LEU 115 B 115 . 
+1 B ILE 116 B 116 . 
+1 B VAL 117 B 117 . 
+1 B ASP 118 B 118 . 
+1 B ARG 119 B 119 . 
+1 B ILE 120 B 120 . 
+1 B VAL 121 B 121 . 
+1 B GLY 122 B 122 . 
+1 B ARG 123 B 123 . 
+1 B ARG 124 B 124 . 
+1 B VAL 125 B 125 . 
+1 B HIS 126 B 126 . 
+1 B ALA 127 B 127 . 
+1 B PRO 128 B 128 . 
+1 B SER 129 B 129 . 
+1 B GLY 130 B 130 . 
+1 B ARG 131 B 131 . 
+1 B VAL 132 B 132 . 
+1 B TYR 133 B 133 . 
+1 B HIS 134 B 134 . 
+1 B VAL 135 B 135 . 
+1 B LYS 136 B 136 . 
+1 B PHE 137 B 137 . 
+1 B ASN 138 B 138 . 
+1 B PRO 139 B 139 . 
+1 B PRO 140 B 140 . 
+1 B LYS 141 B 141 . 
+1 B VAL 142 B 142 . 
+1 B GLU 143 B 143 . 
+1 B GLY 144 B 144 . 
+1 B LYS 145 B 145 . 
+1 B ASP 146 B 146 . 
+1 B ASP 147 B 147 . 
+1 B VAL 148 B 148 . 
+1 B THR 149 B 149 . 
+1 B GLY 150 B 150 . 
+1 B GLU 151 B 151 . 
+1 B GLU 152 B 152 . 
+1 B LEU 153 B 153 . 
+1 B THR 154 B 154 . 
+1 B THR 155 B 155 . 
+1 B ARG 156 B 156 . 
+1 B LYS 157 B 157 . 
+1 B ASP 158 B 158 . 
+1 B ASP 159 B 159 . 
+1 B GLN 160 B 160 . 
+1 B GLU 161 B 161 . 
+1 B GLU 162 B 162 . 
+1 B THR 163 B 163 . 
+1 B VAL 164 B 164 . 
+1 B ARG 165 B 165 . 
+1 B LYS 166 B 166 . 
+1 B ARG 167 B 167 . 
+1 B LEU 168 B 168 . 
+1 B VAL 169 B 169 . 
+1 B GLU 170 B 170 . 
+1 B TYR 171 B 171 . 
+1 B HIS 172 B 172 . 
+1 B GLN 173 B 173 . 
+1 B MET 174 B 174 . 
+1 B THR 175 B 175 . 
+1 B ALA 176 B 176 . 
+1 B PRO 177 B 177 . 
+1 B LEU 178 B 178 . 
+1 B ILE 179 B 179 . 
+1 B GLY 180 B 180 . 
+1 B TYR 181 B 181 . 
+1 B TYR 182 B 182 . 
+1 B SER 183 B 183 . 
+1 B LYS 184 B 184 . 
+1 B GLU 185 B 185 . 
+1 B ALA 186 B 186 . 
+1 B GLU 187 B 187 . 
+1 B ALA 188 B 188 . 
+1 B GLY 189 B 189 . 
+1 B ASN 190 B 190 . 
+1 B THR 191 B 191 . 
+1 B LYS 192 B 192 . 
+1 B TYR 193 B 193 . 
+1 B ALA 194 B 194 . 
+1 B LYS 195 B 195 . 
+1 B VAL 196 B 196 . 
+1 B ASP 197 B 197 . 
+1 B GLY 198 B 198 . 
+1 B THR 199 B 199 . 
+1 B LYS 200 B 200 . 
+1 B PRO 201 B 201 . 
+1 B VAL 202 B 202 . 
+1 B ALA 203 B 203 . 
+1 B GLU 204 B 204 . 
+1 B VAL 205 B 205 . 
+1 B ARG 206 B 206 . 
+1 B ALA 207 B 207 . 
+1 B ASP 208 B 208 . 
+1 B LEU 209 B 209 . 
+1 B GLU 210 B 210 . 
+1 B LYS 211 B 211 . 
+1 B ILE 212 B 212 . 
+1 B LEU 213 B 213 . 
+1 B GLY 214 B 214 . 
+#
+loop_
+_atom_type.symbol
+C 
+N 
+O 
+P 
+S 
+#
+loop_
+_atom_site.group_PDB
+_atom_site.id
+_atom_site.type_symbol
+_atom_site.label_atom_id
+_atom_site.label_alt_id
+_atom_site.label_comp_id
+_atom_site.label_asym_id
+_atom_site.label_entity_id
+_atom_site.label_seq_id
+_atom_site.Cartn_x
+_atom_site.Cartn_y
+_atom_site.Cartn_z
+_atom_site.auth_asym_id
+_atom_site.auth_seq_id
+_atom_site.pdbx_PDB_ins_code
+_atom_site.occupancy
+_atom_site.B_iso_or_equiv
+_atom_site.pdbx_PDB_model_num
+ATOM   1    N N   . MET A 1 1   26.981 53.977  40.085 A 1   ? 1.00 40.83  1 
+ATOM   2    C CA  . MET A 1 1   26.091 52.849  39.889 A 1   ? 1.00 37.14  1 
+ATOM   3    C C   . MET A 1 1   26.679 52.163  38.675 A 1   ? 1.00 30.15  1 
+ATOM   4    O O   . MET A 1 1   27.020 52.865  37.715 A 1   ? 1.00 27.59  1 
+ATOM   5    C CB  . MET A 1 1   24.677 53.310  39.580 A 1   ? 1.00 38.06  1 
+ATOM   6    C CG  . MET A 1 1   23.624 52.189  39.442 A 1   ? 1.00 46.67  1 
+ATOM   7    S SD  . MET A 1 1   21.917 52.816  39.301 A 1   ? 1.00 61.54  1 
+ATOM   8    C CE  . MET A 1 1   21.930 53.926  37.910 A 1   ? 1.00 51.17  1 
+ATOM   9    N N   . ARG A 1 2   26.861 50.841  38.803 A 2   ? 1.00 28.23  1 
+ATOM   10   C CA  . ARG A 1 2   27.437 49.969  37.786 A 2   ? 1.00 25.76  1 
+ATOM   11   C C   . ARG A 1 2   26.336 48.959  37.429 A 2   ? 1.00 25.85  1 
+ATOM   12   O O   . ARG A 1 2   25.745 48.313  38.312 A 2   ? 1.00 25.74  1 
+ATOM   13   C CB  . ARG A 1 2   28.653 49.266  38.349 A 2   ? 1.00 21.92  1 
+ATOM   14   C CG  . ARG A 1 2   29.870 50.188  38.416 A 2   ? 1.00 39.05  1 
+ATOM   15   C CD  . ARG A 1 2   31.033 49.532  39.173 A 2   ? 1.00 51.33  1 
+ATOM   16   N NE  . ARG A 1 2   32.318 50.244  39.125 A 2   ? 1.00 59.73  1 
+ATOM   17   C CZ  . ARG A 1 2   33.462 49.750  39.679 A 2   ? 1.00 58.78  1 
+ATOM   18   N NH1 . ARG A 1 2   33.522 48.572  40.308 A 2   ? 1.00 58.56  1 
+ATOM   19   N NH2 . ARG A 1 2   34.610 50.427  39.597 A 2   ? 1.00 59.20  1 
+ATOM   20   N N   . ILE A 1 3   26.039 48.836  36.139 A 3   ? 1.00 21.59  1 
+ATOM   21   C CA  . ILE A 1 3   24.961 47.988  35.671 A 3   ? 1.00 23.90  1 
+ATOM   22   C C   . ILE A 1 3   25.374 47.080  34.537 A 3   ? 1.00 21.12  1 
+ATOM   23   O O   . ILE A 1 3   26.029 47.614  33.642 A 3   ? 1.00 24.59  1 
+ATOM   24   C CB  . ILE A 1 3   23.802 48.880  35.202 A 3   ? 1.00 23.84  1 
+ATOM   25   C CG1 . ILE A 1 3   23.317 49.724  36.378 A 3   ? 1.00 26.14  1 
+ATOM   26   C CG2 . ILE A 1 3   22.660 48.010  34.642 A 3   ? 1.00 19.29  1 
+ATOM   27   C CD1 . ILE A 1 3   22.436 50.890  35.992 A 3   ? 1.00 24.97  1 
+ATOM   28   N N   . ILE A 1 4   25.062 45.774  34.541 A 4   ? 1.00 20.44  1 
+ATOM   29   C CA  . ILE A 1 4   25.194 44.925  33.360 A 4   ? 1.00 17.83  1 
+ATOM   30   C C   . ILE A 1 4   23.804 44.715  32.751 A 4   ? 1.00 18.42  1 
+ATOM   31   O O   . ILE A 1 4   22.824 44.536  33.484 A 4   ? 1.00 16.35  1 
+ATOM   32   C CB  . ILE A 1 4   25.789 43.561  33.720 A 4   ? 1.00 16.64  1 
+ATOM   33   C CG1 . ILE A 1 4   27.206 43.753  34.233 A 4   ? 1.00 17.27  1 
+ATOM   34   C CG2 . ILE A 1 4   25.829 42.650  32.463 A 4   ? 1.00 21.39  1 
+ATOM   35   C CD1 . ILE A 1 4   27.967 42.486  34.621 A 4   ? 1.00 15.61  1 
+ATOM   36   N N   . LEU A 1 5   23.655 44.874  31.424 A 5   ? 1.00 19.74  1 
+ATOM   37   C CA  . LEU A 1 5   22.428 44.503  30.712 A 5   ? 1.00 19.86  1 
+ATOM   38   C C   . LEU A 1 5   22.668 43.134  30.012 A 5   ? 1.00 18.50  1 
+ATOM   39   O O   . LEU A 1 5   23.614 42.932  29.232 A 5   ? 1.00 17.64  1 
+ATOM   40   C CB  . LEU A 1 5   22.088 45.547  29.675 A 5   ? 1.00 22.23  1 
+ATOM   41   C CG  . LEU A 1 5   22.076 47.021  30.069 A 5   ? 1.00 27.37  1 
+ATOM   42   C CD1 . LEU A 1 5   21.735 47.848  28.817 A 5   ? 1.00 19.28  1 
+ATOM   43   C CD2 . LEU A 1 5   21.088 47.249  31.193 A 5   ? 1.00 24.82  1 
+ATOM   44   N N   . LEU A 1 6   21.787 42.178  30.248 A 6   ? 1.00 14.28  1 
+ATOM   45   C CA  . LEU A 1 6   21.933 40.811  29.752 A 6   ? 1.00 21.75  1 
+ATOM   46   C C   . LEU A 1 6   20.711 40.529  28.870 A 6   ? 1.00 23.97  1 
+ATOM   47   O O   . LEU A 1 6   19.602 40.977  29.220 A 6   ? 1.00 19.19  1 
+ATOM   48   C CB  . LEU A 1 6   21.919 39.891  30.945 A 6   ? 1.00 27.49  1 
+ATOM   49   C CG  . LEU A 1 6   22.847 38.789  31.103 A 6   ? 1.00 31.51  1 
+ATOM   50   C CD1 . LEU A 1 6   24.254 39.345  31.210 A 6   ? 1.00 34.32  1 
+ATOM   51   C CD2 . LEU A 1 6   22.465 38.042  32.355 A 6   ? 1.00 24.54  1 
+ATOM   52   N N   . GLY A 1 7   20.800 39.799  27.764 A 7   ? 1.00 18.09  1 
+ATOM   53   C CA  . GLY A 1 7   19.604 39.512  26.973 A 7   ? 1.00 20.21  1 
+ATOM   54   C C   . GLY A 1 7   19.959 39.035  25.585 A 7   ? 1.00 14.48  1 
+ATOM   55   O O   . GLY A 1 7   21.049 39.324  25.122 A 7   ? 1.00 15.84  1 
+ATOM   56   N N   . ALA A 1 8   19.117 38.232  24.936 A 8   ? 1.00 19.71  1 
+ATOM   57   C CA  . ALA A 1 8   19.324 37.742  23.567 A 8   ? 1.00 16.92  1 
+ATOM   58   C C   . ALA A 1 8   19.530 38.886  22.568 A 8   ? 1.00 17.35  1 
+ATOM   59   O O   . ALA A 1 8   19.158 40.013  22.889 A 8   ? 1.00 15.41  1 
+ATOM   60   C CB  . ALA A 1 8   18.092 36.960  23.169 A 8   ? 1.00 15.12  1 
+ATOM   61   N N   . PRO A 1 9   20.069 38.660  21.359 A 9   ? 1.00 20.54  1 
+ATOM   62   C CA  . PRO A 1 9   20.108 39.651  20.294 A 9   ? 1.00 17.47  1 
+ATOM   63   C C   . PRO A 1 9   18.750 40.300  20.095 A 9   ? 1.00 21.25  1 
+ATOM   64   O O   . PRO A 1 9   17.760 39.552  20.084 A 9   ? 1.00 17.47  1 
+ATOM   65   C CB  . PRO A 1 9   20.574 38.908  19.047 A 9   ? 1.00 19.04  1 
+ATOM   66   C CG  . PRO A 1 9   20.687 37.425  19.450 A 9   ? 1.00 25.54  1 
+ATOM   67   C CD  . PRO A 1 9   20.695 37.403  20.958 A 9   ? 1.00 17.37  1 
+ATOM   68   N N   . GLY A 1 10  18.697 41.656  20.019 A 10  ? 1.00 21.90  1 
+ATOM   69   C CA  . GLY A 1 10  17.487 42.426  19.756 A 10  ? 1.00 18.35  1 
+ATOM   70   C C   . GLY A 1 10  16.476 42.449  20.905 A 10  ? 1.00 19.36  1 
+ATOM   71   O O   . GLY A 1 10  15.311 42.745  20.642 A 10  ? 1.00 18.88  1 
+ATOM   72   N N   . ALA A 1 11  16.899 42.259  22.187 A 11  ? 1.00 16.83  1 
+ATOM   73   C CA  . ALA A 1 11  15.960 42.201  23.284 A 11  ? 1.00 18.31  1 
+ATOM   74   C C   . ALA A 1 11  15.625 43.630  23.738 A 11  ? 1.00 17.96  1 
+ATOM   75   O O   . ALA A 1 11  14.821 43.804  24.675 A 11  ? 1.00 22.53  1 
+ATOM   76   C CB  . ALA A 1 11  16.528 41.416  24.561 A 11  ? 1.00 15.72  1 
+ATOM   77   N N   . GLY A 1 12  16.317 44.646  23.192 A 12  ? 1.00 15.75  1 
+ATOM   78   C CA  . GLY A 1 12  16.082 46.035  23.547 A 12  ? 1.00 20.57  1 
+ATOM   79   C C   . GLY A 1 12  17.115 46.628  24.499 A 12  ? 1.00 19.31  1 
+ATOM   80   O O   . GLY A 1 12  16.847 47.654  25.139 A 12  ? 1.00 18.99  1 
+ATOM   81   N N   . LYS A 1 13  18.320 46.036  24.586 A 13  ? 1.00 15.72  1 
+ATOM   82   C CA  . LYS A 1 13  19.303 46.427  25.595 A 13  ? 1.00 14.56  1 
+ATOM   83   C C   . LYS A 1 13  19.811 47.802  25.236 A 13  ? 1.00 23.49  1 
+ATOM   84   O O   . LYS A 1 13  19.666 48.712  26.068 A 13  ? 1.00 17.44  1 
+ATOM   85   C CB  . LYS A 1 13  20.485 45.442  25.661 A 13  ? 1.00 14.39  1 
+ATOM   86   C CG  . LYS A 1 13  20.219 44.133  26.392 A 13  ? 1.00 16.06  1 
+ATOM   87   C CD  . LYS A 1 13  21.297 43.055  26.321 A 13  ? 1.00 14.28  1 
+ATOM   88   C CE  . LYS A 1 13  21.965 42.761  24.960 A 13  ? 1.00 16.79  1 
+ATOM   89   N NZ  . LYS A 1 13  21.056 42.207  23.991 A 13  ? 1.00 14.14  1 
+ATOM   90   N N   . GLY A 1 14  20.270 47.997  23.985 A 14  ? 1.00 17.69  1 
+ATOM   91   C CA  . GLY A 1 14  20.816 49.254  23.528 A 14  ? 1.00 17.87  1 
+ATOM   92   C C   . GLY A 1 14  19.793 50.385  23.631 A 14  ? 1.00 22.90  1 
+ATOM   93   O O   . GLY A 1 14  20.196 51.500  24.037 A 14  ? 1.00 23.43  1 
+ATOM   94   N N   . THR A 1 15  18.498 50.132  23.306 A 15  ? 1.00 17.68  1 
+ATOM   95   C CA  . THR A 1 15  17.421 51.124  23.373 A 15  ? 1.00 11.87  1 
+ATOM   96   C C   . THR A 1 15  17.273 51.590  24.830 A 15  ? 1.00 21.09  1 
+ATOM   97   O O   . THR A 1 15  17.270 52.795  25.123 A 15  ? 1.00 17.30  1 
+ATOM   98   C CB  . THR A 1 15  16.120 50.501  22.872 A 15  ? 1.00 15.41  1 
+ATOM   99   O OG1 . THR A 1 15  16.372 50.206  21.494 A 15  ? 1.00 17.67  1 
+ATOM   100  C CG2 . THR A 1 15  14.890 51.418  22.995 A 15  ? 1.00 16.41  1 
+ATOM   101  N N   . GLN A 1 16  17.226 50.671  25.798 A 16  ? 1.00 18.86  1 
+ATOM   102  C CA  . GLN A 1 16  17.135 51.071  27.210 A 16  ? 1.00 24.63  1 
+ATOM   103  C C   . GLN A 1 16  18.402 51.664  27.843 A 16  ? 1.00 28.08  1 
+ATOM   104  O O   . GLN A 1 16  18.310 52.464  28.793 A 16  ? 1.00 21.17  1 
+ATOM   105  C CB  . GLN A 1 16  16.681 49.884  28.037 A 16  ? 1.00 22.62  1 
+ATOM   106  C CG  . GLN A 1 16  15.323 49.406  27.525 A 16  ? 1.00 28.34  1 
+ATOM   107  C CD  . GLN A 1 16  14.227 50.459  27.630 A 16  ? 1.00 26.24  1 
+ATOM   108  O OE1 . GLN A 1 16  13.285 50.464  26.849 A 16  ? 1.00 28.75  1 
+ATOM   109  N NE2 . GLN A 1 16  14.220 51.378  28.575 A 16  ? 1.00 21.97  1 
+ATOM   110  N N   . ALA A 1 17  19.571 51.282  27.302 A 17  ? 1.00 21.47  1 
+ATOM   111  C CA  . ALA A 1 17  20.821 51.825  27.722 A 17  ? 1.00 21.29  1 
+ATOM   112  C C   . ALA A 1 17  20.827 53.331  27.452 A 17  ? 1.00 24.27  1 
+ATOM   113  O O   . ALA A 1 17  21.287 54.060  28.335 A 17  ? 1.00 21.39  1 
+ATOM   114  C CB  . ALA A 1 17  21.915 51.150  26.941 A 17  ? 1.00 19.10  1 
+ATOM   115  N N   . GLN A 1 18  20.335 53.865  26.299 A 18  ? 1.00 23.09  1 
+ATOM   116  C CA  . GLN A 1 18  20.249 55.314  26.080 A 18  ? 1.00 35.13  1 
+ATOM   117  C C   . GLN A 1 18  19.380 55.998  27.161 A 18  ? 1.00 30.93  1 
+ATOM   118  O O   . GLN A 1 18  19.805 57.033  27.660 A 18  ? 1.00 29.17  1 
+ATOM   119  C CB  . GLN A 1 18  19.663 55.642  24.704 A 18  ? 1.00 39.96  1 
+ATOM   120  C CG  . GLN A 1 18  20.470 55.251  23.446 A 18  ? 1.00 56.33  1 
+ATOM   121  C CD  . GLN A 1 18  19.589 55.276  22.173 A 18  ? 1.00 66.12  1 
+ATOM   122  O OE1 . GLN A 1 18  19.597 54.383  21.297 A 18  ? 1.00 60.71  1 
+ATOM   123  N NE2 . GLN A 1 18  18.775 56.322  22.023 A 18  ? 1.00 58.49  1 
+ATOM   124  N N   . PHE A 1 19  18.249 55.451  27.639 A 19  ? 1.00 30.18  1 
+ATOM   125  C CA  . PHE A 1 19  17.474 56.050  28.712 A 19  ? 1.00 29.68  1 
+ATOM   126  C C   . PHE A 1 19  18.238 56.003  30.023 A 19  ? 1.00 28.43  1 
+ATOM   127  O O   . PHE A 1 19  18.209 56.994  30.747 A 19  ? 1.00 30.45  1 
+ATOM   128  C CB  . PHE A 1 19  16.077 55.343  28.905 A 19  ? 1.00 29.03  1 
+ATOM   129  C CG  . PHE A 1 19  15.536 55.268  30.366 A 19  ? 1.00 42.14  1 
+ATOM   130  C CD1 . PHE A 1 19  15.100 56.407  31.053 A 19  ? 1.00 42.90  1 
+ATOM   131  C CD2 . PHE A 1 19  15.580 54.062  31.054 A 19  ? 1.00 44.87  1 
+ATOM   132  C CE1 . PHE A 1 19  14.735 56.359  32.386 A 19  ? 1.00 37.82  1 
+ATOM   133  C CE2 . PHE A 1 19  15.213 54.022  32.386 A 19  ? 1.00 42.62  1 
+ATOM   134  C CZ  . PHE A 1 19  14.799 55.160  33.050 A 19  ? 1.00 43.84  1 
+ATOM   135  N N   . ILE A 1 20  18.869 54.909  30.422 A 20  ? 1.00 23.09  1 
+ATOM   136  C CA  . ILE A 1 20  19.532 54.877  31.696 A 20  ? 1.00 23.96  1 
+ATOM   137  C C   . ILE A 1 20  20.645 55.887  31.681 A 20  ? 1.00 29.63  1 
+ATOM   138  O O   . ILE A 1 20  20.846 56.617  32.663 A 20  ? 1.00 32.83  1 
+ATOM   139  C CB  . ILE A 1 20  20.070 53.459  31.980 A 20  ? 1.00 27.73  1 
+ATOM   140  C CG1 . ILE A 1 20  18.829 52.589  32.155 A 20  ? 1.00 24.67  1 
+ATOM   141  C CG2 . ILE A 1 20  20.994 53.376  33.235 A 20  ? 1.00 26.89  1 
+ATOM   142  C CD1 . ILE A 1 20  19.248 51.106  32.066 A 20  ? 1.00 25.96  1 
+ATOM   143  N N   . MET A 1 21  21.352 55.962  30.577 A 21  ? 1.00 22.68  1 
+ATOM   144  C CA  . MET A 1 21  22.441 56.903  30.479 A 21  ? 1.00 32.34  1 
+ATOM   145  C C   . MET A 1 21  21.963 58.344  30.645 A 21  ? 1.00 36.61  1 
+ATOM   146  O O   . MET A 1 21  22.537 59.094  31.451 A 21  ? 1.00 35.98  1 
+ATOM   147  C CB  . MET A 1 21  23.126 56.713  29.136 A 21  ? 1.00 34.45  1 
+ATOM   148  C CG  . MET A 1 21  23.987 57.889  28.770 A 21  ? 1.00 47.17  1 
+ATOM   149  S SD  . MET A 1 21  24.666 57.634  27.140 A 21  ? 1.00 58.05  1 
+ATOM   150  C CE  . MET A 1 21  26.316 57.426  27.691 A 21  ? 1.00 46.92  1 
+ATOM   151  N N   . GLU A 1 22  20.892 58.740  29.957 A 22  ? 1.00 35.15  1 
+ATOM   152  C CA  . GLU A 1 22  20.467 60.117  30.020 A 22  ? 1.00 35.34  1 
+ATOM   153  C C   . GLU A 1 22  19.853 60.448  31.354 A 22  ? 1.00 41.37  1 
+ATOM   154  O O   . GLU A 1 22  20.085 61.541  31.858 A 22  ? 1.00 49.63  1 
+ATOM   155  C CB  . GLU A 1 22  19.479 60.433  28.914 A 22  ? 1.00 42.27  1 
+ATOM   156  C CG  . GLU A 1 22  18.092 59.796  28.979 A 22  ? 1.00 68.08  1 
+ATOM   157  C CD  . GLU A 1 22  17.103 60.339  27.946 A 22  ? 1.00 82.33  1 
+ATOM   158  O OE1 . GLU A 1 22  17.363 60.191  26.740 A 22  ? 1.00 86.19  1 
+ATOM   159  O OE2 . GLU A 1 22  16.077 60.905  28.360 A 22  ? 1.00 89.10  1 
+ATOM   160  N N   . LYS A 1 23  19.160 59.507  31.983 A 23  ? 1.00 40.77  1 
+ATOM   161  C CA  . LYS A 1 23  18.497 59.710  33.252 A 23  ? 1.00 35.64  1 
+ATOM   162  C C   . LYS A 1 23  19.376 59.568  34.467 A 23  ? 1.00 42.07  1 
+ATOM   163  O O   . LYS A 1 23  19.054 60.110  35.524 A 23  ? 1.00 51.32  1 
+ATOM   164  C CB  . LYS A 1 23  17.349 58.727  33.381 A 23  ? 1.00 39.75  1 
+ATOM   165  C CG  . LYS A 1 23  16.112 59.315  34.008 A 23  ? 1.00 41.63  1 
+ATOM   166  C CD  . LYS A 1 23  15.916 58.649  35.332 A 23  ? 1.00 47.22  1 
+ATOM   167  C CE  . LYS A 1 23  14.562 59.056  35.858 A 23  ? 1.00 50.81  1 
+ATOM   168  N NZ  . LYS A 1 23  14.238 58.262  37.026 A 23  ? 1.00 52.24  1 
+ATOM   169  N N   . TYR A 1 24  20.432 58.765  34.406 A 24  ? 1.00 46.00  1 
+ATOM   170  C CA  . TYR A 1 24  21.269 58.502  35.566 A 24  ? 1.00 38.91  1 
+ATOM   171  C C   . TYR A 1 24  22.706 58.970  35.378 A 24  ? 1.00 39.17  1 
+ATOM   172  O O   . TYR A 1 24  23.565 58.695  36.216 A 24  ? 1.00 40.96  1 
+ATOM   173  C CB  . TYR A 1 24  21.239 57.011  35.866 A 24  ? 1.00 41.58  1 
+ATOM   174  C CG  . TYR A 1 24  19.834 56.522  36.193 A 24  ? 1.00 45.68  1 
+ATOM   175  C CD1 . TYR A 1 24  19.324 56.640  37.474 A 24  ? 1.00 43.85  1 
+ATOM   176  C CD2 . TYR A 1 24  19.065 55.950  35.192 A 24  ? 1.00 51.33  1 
+ATOM   177  C CE1 . TYR A 1 24  18.047 56.180  37.751 A 24  ? 1.00 53.35  1 
+ATOM   178  C CE2 . TYR A 1 24  17.787 55.490  35.459 A 24  ? 1.00 52.15  1 
+ATOM   179  C CZ  . TYR A 1 24  17.283 55.607  36.743 A 24  ? 1.00 54.96  1 
+ATOM   180  O OH  . TYR A 1 24  16.010 55.128  36.994 A 24  ? 1.00 56.26  1 
+ATOM   181  N N   . GLY A 1 25  22.969 59.641  34.252 A 25  ? 1.00 34.82  1 
+ATOM   182  C CA  . GLY A 1 25  24.253 60.217  33.938 A 25  ? 1.00 29.00  1 
+ATOM   183  C C   . GLY A 1 25  25.410 59.236  33.969 A 25  ? 1.00 43.54  1 
+ATOM   184  O O   . GLY A 1 25  26.527 59.669  34.253 A 25  ? 1.00 44.35  1 
+ATOM   185  N N   . ILE A 1 26  25.220 57.924  33.751 A 26  ? 1.00 47.69  1 
+ATOM   186  C CA  . ILE A 1 26  26.346 56.989  33.707 A 26  ? 1.00 36.55  1 
+ATOM   187  C C   . ILE A 1 26  26.607 56.614  32.249 A 26  ? 1.00 35.98  1 
+ATOM   188  O O   . ILE A 1 26  25.682 56.499  31.427 A 26  ? 1.00 30.67  1 
+ATOM   189  C CB  . ILE A 1 26  26.052 55.747  34.560 A 26  ? 1.00 36.41  1 
+ATOM   190  C CG1 . ILE A 1 26  24.746 55.087  34.229 A 26  ? 1.00 41.45  1 
+ATOM   191  C CG2 . ILE A 1 26  26.001 56.219  36.017 A 26  ? 1.00 39.77  1 
+ATOM   192  C CD1 . ILE A 1 26  24.439 53.923  35.198 A 26  ? 1.00 48.36  1 
+ATOM   193  N N   . PRO A 1 27  27.875 56.500  31.841 A 27  ? 1.00 34.73  1 
+ATOM   194  C CA  . PRO A 1 27  28.231 56.198  30.472 A 27  ? 1.00 28.83  1 
+ATOM   195  C C   . PRO A 1 27  27.891 54.763  30.180 A 27  ? 1.00 23.60  1 
+ATOM   196  O O   . PRO A 1 27  28.027 53.875  31.033 A 27  ? 1.00 27.00  1 
+ATOM   197  C CB  . PRO A 1 27  29.693 56.494  30.393 A 27  ? 1.00 28.89  1 
+ATOM   198  C CG  . PRO A 1 27  30.135 56.089  31.760 A 27  ? 1.00 35.46  1 
+ATOM   199  C CD  . PRO A 1 27  29.069 56.668  32.663 A 27  ? 1.00 33.80  1 
+ATOM   200  N N   . GLN A 1 28  27.439 54.643  28.939 A 28  ? 1.00 27.50  1 
+ATOM   201  C CA  . GLN A 1 28  27.118 53.394  28.303 A 28  ? 1.00 27.15  1 
+ATOM   202  C C   . GLN A 1 28  28.433 52.911  27.659 A 28  ? 1.00 30.41  1 
+ATOM   203  O O   . GLN A 1 28  28.996 53.606  26.809 A 28  ? 1.00 31.73  1 
+ATOM   204  C CB  . GLN A 1 28  26.069 53.601  27.214 A 28  ? 1.00 27.04  1 
+ATOM   205  C CG  . GLN A 1 28  25.883 52.370  26.246 A 28  ? 1.00 33.40  1 
+ATOM   206  C CD  . GLN A 1 28  24.954 52.485  25.024 A 28  ? 1.00 35.82  1 
+ATOM   207  O OE1 . GLN A 1 28  24.659 53.643  24.452 A 28  ? 1.00 40.26  1 
+ATOM   208  N NE2 . GLN A 1 28  24.463 51.483  24.505 A 28  ? 1.00 36.86  1 
+ATOM   209  N N   . ILE A 1 29  28.954 51.735  28.010 A 29  ? 1.00 28.81  1 
+ATOM   210  C CA  . ILE A 1 29  30.122 51.105  27.381 A 29  ? 1.00 30.28  1 
+ATOM   211  C C   . ILE A 1 29  29.558 49.951  26.533 A 29  ? 1.00 27.89  1 
+ATOM   212  O O   . ILE A 1 29  29.160 48.912  27.052 A 29  ? 1.00 25.04  1 
+ATOM   213  C CB  . ILE A 1 29  31.060 50.660  28.537 A 29  ? 1.00 26.02  1 
+ATOM   214  C CG1 . ILE A 1 29  31.505 51.927  29.291 A 29  ? 1.00 20.27  1 
+ATOM   215  C CG2 . ILE A 1 29  32.195 49.761  27.969 A 29  ? 1.00 23.69  1 
+ATOM   216  C CD1 . ILE A 1 29  32.357 51.636  30.507 A 29  ? 1.00 32.49  1 
+ATOM   217  N N   . SER A 1 30  29.386 50.098  25.234 A 30  ? 1.00 24.91  1 
+ATOM   218  C CA  . SER A 1 30  28.780 49.070  24.408 A 30  ? 1.00 28.13  1 
+ATOM   219  C C   . SER A 1 30  29.856 48.513  23.484 A 30  ? 1.00 27.39  1 
+ATOM   220  O O   . SER A 1 30  30.450 49.195  22.628 A 30  ? 1.00 21.34  1 
+ATOM   221  C CB  . SER A 1 30  27.641 49.674  23.614 A 30  ? 1.00 21.93  1 
+ATOM   222  O OG  . SER A 1 30  27.393 49.012  22.382 A 30  ? 1.00 29.69  1 
+ATOM   223  N N   . THR A 1 31  30.102 47.225  23.695 A 31  ? 1.00 23.11  1 
+ATOM   224  C CA  . THR A 1 31  31.156 46.587  22.987 A 31  ? 1.00 19.90  1 
+ATOM   225  C C   . THR A 1 31  30.787 46.464  21.542 A 31  ? 1.00 18.73  1 
+ATOM   226  O O   . THR A 1 31  31.720 46.622  20.766 A 31  ? 1.00 19.30  1 
+ATOM   227  C CB  . THR A 1 31  31.489 45.205  23.617 A 31  ? 1.00 20.48  1 
+ATOM   228  O OG1 . THR A 1 31  30.313 44.530  23.975 A 31  ? 1.00 21.10  1 
+ATOM   229  C CG2 . THR A 1 31  32.316 45.409  24.879 A 31  ? 1.00 20.87  1 
+ATOM   230  N N   . GLY A 1 32  29.544 46.231  21.122 A 32  ? 1.00 16.33  1 
+ATOM   231  C CA  . GLY A 1 32  29.191 46.253  19.704 A 32  ? 1.00 21.95  1 
+ATOM   232  C C   . GLY A 1 32  29.525 47.627  19.099 A 32  ? 1.00 22.83  1 
+ATOM   233  O O   . GLY A 1 32  30.121 47.705  18.019 A 32  ? 1.00 17.51  1 
+ATOM   234  N N   . ASP A 1 33  29.237 48.726  19.826 A 33  ? 1.00 23.46  1 
+ATOM   235  C CA  . ASP A 1 33  29.487 50.042  19.273 A 33  ? 1.00 25.07  1 
+ATOM   236  C C   . ASP A 1 33  30.983 50.250  19.161 A 33  ? 1.00 22.43  1 
+ATOM   237  O O   . ASP A 1 33  31.454 50.638  18.077 A 33  ? 1.00 25.43  1 
+ATOM   238  C CB  . ASP A 1 33  28.914 51.173  20.141 A 33  ? 1.00 20.81  1 
+ATOM   239  C CG  . ASP A 1 33  27.419 51.446  19.994 A 33  ? 1.00 34.20  1 
+ATOM   240  O OD1 . ASP A 1 33  26.816 50.961  19.027 A 33  ? 1.00 28.19  1 
+ATOM   241  O OD2 . ASP A 1 33  26.880 52.176  20.852 A 33  ? 1.00 37.34  1 
+ATOM   242  N N   . MET A 1 34  31.738 49.947  20.223 A 34  ? 1.00 16.91  1 
+ATOM   243  C CA  . MET A 1 34  33.184 50.074  20.161 A 34  ? 1.00 16.15  1 
+ATOM   244  C C   . MET A 1 34  33.787 49.222  19.073 A 34  ? 1.00 17.63  1 
+ATOM   245  O O   . MET A 1 34  34.703 49.685  18.386 A 34  ? 1.00 23.65  1 
+ATOM   246  C CB  . MET A 1 34  33.832 49.679  21.452 A 34  ? 1.00 17.88  1 
+ATOM   247  C CG  . MET A 1 34  33.464 50.634  22.545 A 34  ? 1.00 28.29  1 
+ATOM   248  S SD  . MET A 1 34  34.415 50.284  24.035 A 34  ? 1.00 37.95  1 
+ATOM   249  C CE  . MET A 1 34  33.371 49.008  24.702 A 34  ? 1.00 31.80  1 
+ATOM   250  N N   . LEU A 1 35  33.336 48.008  18.816 A 35  ? 1.00 14.18  1 
+ATOM   251  C CA  . LEU A 1 35  33.940 47.195  17.763 A 35  ? 1.00 18.35  1 
+ATOM   252  C C   . LEU A 1 35  33.532 47.687  16.374 A 35  ? 1.00 22.21  1 
+ATOM   253  O O   . LEU A 1 35  34.397 47.686  15.499 A 35  ? 1.00 23.14  1 
+ATOM   254  C CB  . LEU A 1 35  33.538 45.702  17.921 A 35  ? 1.00 14.38  1 
+ATOM   255  C CG  . LEU A 1 35  34.178 44.933  19.144 A 35  ? 1.00 22.42  1 
+ATOM   256  C CD1 . LEU A 1 35  33.426 43.634  19.487 A 35  ? 1.00 22.66  1 
+ATOM   257  C CD2 . LEU A 1 35  35.633 44.683  18.796 A 35  ? 1.00 21.21  1 
+ATOM   258  N N   . ARG A 1 36  32.291 48.095  16.040 A 36  ? 1.00 25.04  1 
+ATOM   259  C CA  . ARG A 1 36  31.961 48.619  14.693 A 36  ? 1.00 21.19  1 
+ATOM   260  C C   . ARG A 1 36  32.777 49.890  14.437 A 36  ? 1.00 20.98  1 
+ATOM   261  O O   . ARG A 1 36  33.328 50.113  13.362 A 36  ? 1.00 22.82  1 
+ATOM   262  C CB  . ARG A 1 36  30.469 48.931  14.605 A 36  ? 1.00 15.77  1 
+ATOM   263  C CG  . ARG A 1 36  29.578 47.699  14.429 A 36  ? 1.00 19.41  1 
+ATOM   264  C CD  . ARG A 1 36  28.058 47.971  14.453 A 36  ? 1.00 15.24  1 
+ATOM   265  N NE  . ARG A 1 36  27.555 48.398  15.764 A 36  ? 1.00 17.70  1 
+ATOM   266  C CZ  . ARG A 1 36  27.064 47.570  16.706 A 36  ? 1.00 14.08  1 
+ATOM   267  N NH1 . ARG A 1 36  27.106 46.256  16.575 A 36  ? 1.00 20.01  1 
+ATOM   268  N NH2 . ARG A 1 36  26.547 48.043  17.839 A 36  ? 1.00 15.42  1 
+ATOM   269  N N   . ALA A 1 37  32.963 50.707  15.460 A 37  ? 1.00 17.17  1 
+ATOM   270  C CA  . ALA A 1 37  33.778 51.895  15.373 A 37  ? 1.00 27.13  1 
+ATOM   271  C C   . ALA A 1 37  35.212 51.490  15.060 A 37  ? 1.00 28.62  1 
+ATOM   272  O O   . ALA A 1 37  35.775 51.983  14.083 A 37  ? 1.00 27.31  1 
+ATOM   273  C CB  . ALA A 1 37  33.764 52.668  16.691 A 37  ? 1.00 24.59  1 
+ATOM   274  N N   . ALA A 1 38  35.832 50.581  15.801 A 38  ? 1.00 23.95  1 
+ATOM   275  C CA  . ALA A 1 38  37.207 50.146  15.498 A 38  ? 1.00 28.55  1 
+ATOM   276  C C   . ALA A 1 38  37.350 49.607  14.071 A 38  ? 1.00 23.97  1 
+ATOM   277  O O   . ALA A 1 38  38.315 49.935  13.355 A 38  ? 1.00 26.96  1 
+ATOM   278  C CB  . ALA A 1 38  37.658 49.037  16.499 A 38  ? 1.00 23.72  1 
+ATOM   279  N N   . VAL A 1 39  36.370 48.833  13.594 A 39  ? 1.00 20.08  1 
+ATOM   280  C CA  . VAL A 1 39  36.426 48.279  12.266 A 39  ? 1.00 21.10  1 
+ATOM   281  C C   . VAL A 1 39  36.378 49.421  11.306 A 39  ? 1.00 33.75  1 
+ATOM   282  O O   . VAL A 1 39  37.180 49.428  10.380 A 39  ? 1.00 40.93  1 
+ATOM   283  C CB  . VAL A 1 39  35.264 47.365  12.049 A 39  ? 1.00 22.86  1 
+ATOM   284  C CG1 . VAL A 1 39  35.016 47.117  10.563 A 39  ? 1.00 26.70  1 
+ATOM   285  C CG2 . VAL A 1 39  35.625 46.029  12.675 A 39  ? 1.00 19.03  1 
+ATOM   286  N N   . LYS A 1 40  35.526 50.417  11.553 A 40  ? 1.00 36.34  1 
+ATOM   287  C CA  . LYS A 1 40  35.384 51.553  10.650 A 40  ? 1.00 38.88  1 
+ATOM   288  C C   . LYS A 1 40  36.590 52.492  10.671 A 40  ? 1.00 39.37  1 
+ATOM   289  O O   . LYS A 1 40  36.908 53.028  9.605  A 40  ? 1.00 39.37  1 
+ATOM   290  C CB  . LYS A 1 40  34.110 52.246  11.044 A 40  ? 1.00 46.46  1 
+ATOM   291  C CG  . LYS A 1 40  33.417 53.311  10.207 A 40  ? 1.00 55.86  1 
+ATOM   292  C CD  . LYS A 1 40  32.105 53.543  10.986 A 40  ? 1.00 68.28  1 
+ATOM   293  C CE  . LYS A 1 40  32.307 53.985  12.477 A 40  ? 1.00 76.27  1 
+ATOM   294  N NZ  . LYS A 1 40  31.158 53.781  13.360 A 40  ? 1.00 74.69  1 
+ATOM   295  N N   . SER A 1 41  37.272 52.721  11.806 A 41  ? 1.00 30.04  1 
+ATOM   296  C CA  . SER A 1 41  38.507 53.491  11.905 A 41  ? 1.00 33.63  1 
+ATOM   297  C C   . SER A 1 41  39.777 52.736  11.541 A 41  ? 1.00 34.75  1 
+ATOM   298  O O   . SER A 1 41  40.837 53.367  11.412 A 41  ? 1.00 43.02  1 
+ATOM   299  C CB  . SER A 1 41  38.784 53.990  13.294 A 41  ? 1.00 31.94  1 
+ATOM   300  O OG  . SER A 1 41  37.700 54.780  13.703 A 41  ? 1.00 53.72  1 
+ATOM   301  N N   . GLY A 1 42  39.746 51.404  11.382 A 42  ? 1.00 39.50  1 
+ATOM   302  C CA  . GLY A 1 42  40.955 50.617  11.185 A 42  ? 1.00 29.51  1 
+ATOM   303  C C   . GLY A 1 42  41.822 50.731  12.450 A 42  ? 1.00 28.13  1 
+ATOM   304  O O   . GLY A 1 42  43.052 50.709  12.332 A 42  ? 1.00 31.99  1 
+ATOM   305  N N   . SER A 1 43  41.232 50.910  13.656 A 43  ? 1.00 24.66  1 
+ATOM   306  C CA  . SER A 1 43  41.976 50.997  14.916 A 43  ? 1.00 29.21  1 
+ATOM   307  C C   . SER A 1 43  42.661 49.644  15.134 A 43  ? 1.00 31.46  1 
+ATOM   308  O O   . SER A 1 43  42.039 48.580  14.922 A 43  ? 1.00 25.60  1 
+ATOM   309  C CB  . SER A 1 43  41.035 51.263  16.084 A 43  ? 1.00 29.99  1 
+ATOM   310  O OG  . SER A 1 43  40.232 52.405  15.825 A 43  ? 1.00 44.89  1 
+ATOM   311  N N   . GLU A 1 44  43.932 49.643  15.550 A 44  ? 1.00 31.16  1 
+ATOM   312  C CA  . GLU A 1 44  44.618 48.368  15.772 A 44  ? 1.00 33.01  1 
+ATOM   313  C C   . GLU A 1 44  43.907 47.521  16.842 A 44  ? 1.00 28.72  1 
+ATOM   314  O O   . GLU A 1 44  43.847 46.298  16.691 A 44  ? 1.00 30.36  1 
+ATOM   315  C CB  . GLU A 1 44  46.104 48.609  16.173 A 44  ? 1.00 33.07  1 
+ATOM   316  C CG  . GLU A 1 44  46.901 47.312  16.527 A 44  ? 1.00 49.76  1 
+ATOM   317  C CD  . GLU A 1 44  46.976 46.124  15.533 A 44  ? 1.00 56.05  1 
+ATOM   318  O OE1 . GLU A 1 44  46.829 46.355  14.334 A 44  ? 1.00 64.47  1 
+ATOM   319  O OE2 . GLU A 1 44  47.197 44.971  15.941 A 44  ? 1.00 42.68  1 
+ATOM   320  N N   . LEU A 1 45  43.369 48.073  17.935 A 45  ? 1.00 21.36  1 
+ATOM   321  C CA  . LEU A 1 45  42.604 47.255  18.836 A 45  ? 1.00 20.92  1 
+ATOM   322  C C   . LEU A 1 45  41.154 47.218  18.387 A 45  ? 1.00 22.01  1 
+ATOM   323  O O   . LEU A 1 45  40.358 48.129  18.639 A 45  ? 1.00 25.70  1 
+ATOM   324  C CB  . LEU A 1 45  42.682 47.763  20.285 A 45  ? 1.00 21.03  1 
+ATOM   325  C CG  . LEU A 1 45  42.073 46.942  21.452 A 45  ? 1.00 23.72  1 
+ATOM   326  C CD1 . LEU A 1 45  42.721 45.578  21.647 A 45  ? 1.00 21.19  1 
+ATOM   327  C CD2 . LEU A 1 45  42.367 47.680  22.716 A 45  ? 1.00 29.45  1 
+ATOM   328  N N   . GLY A 1 46  40.826 46.179  17.622 A 46  ? 1.00 18.13  1 
+ATOM   329  C CA  . GLY A 1 46  39.438 45.942  17.303 A 46  ? 1.00 17.17  1 
+ATOM   330  C C   . GLY A 1 46  39.168 45.842  15.824 A 46  ? 1.00 23.73  1 
+ATOM   331  O O   . GLY A 1 46  38.144 45.232  15.468 A 46  ? 1.00 24.40  1 
+ATOM   332  N N   . LYS A 1 47  39.996 46.362  14.895 A 47  ? 1.00 23.50  1 
+ATOM   333  C CA  . LYS A 1 47  39.679 46.226  13.467 A 47  ? 1.00 25.84  1 
+ATOM   334  C C   . LYS A 1 47  39.573 44.757  13.054 A 47  ? 1.00 22.74  1 
+ATOM   335  O O   . LYS A 1 47  38.879 44.398  12.105 A 47  ? 1.00 24.12  1 
+ATOM   336  C CB  . LYS A 1 47  40.745 46.915  12.592 A 47  ? 1.00 27.57  1 
+ATOM   337  C CG  . LYS A 1 47  42.100 46.284  12.693 A 47  ? 1.00 29.81  1 
+ATOM   338  C CD  . LYS A 1 47  43.176 46.843  11.807 A 47  ? 1.00 39.67  1 
+ATOM   339  C CE  . LYS A 1 47  44.309 45.903  12.225 A 47  ? 1.00 49.23  1 
+ATOM   340  N NZ  . LYS A 1 47  45.613 46.363  11.795 A 47  ? 1.00 59.26  1 
+ATOM   341  N N   . GLN A 1 48  40.174 43.863  13.838 A 48  ? 1.00 23.23  1 
+ATOM   342  C CA  . GLN A 1 48  40.193 42.426  13.556 A 48  ? 1.00 29.80  1 
+ATOM   343  C C   . GLN A 1 48  38.799 41.803  13.641 A 48  ? 1.00 28.52  1 
+ATOM   344  O O   . GLN A 1 48  38.628 40.680  13.160 A 48  ? 1.00 24.52  1 
+ATOM   345  C CB  . GLN A 1 48  41.091 41.651  14.550 A 48  ? 1.00 28.39  1 
+ATOM   346  C CG  . GLN A 1 48  42.545 42.077  14.615 A 48  ? 1.00 16.98  1 
+ATOM   347  C CD  . GLN A 1 48  42.764 43.318  15.409 A 48  ? 1.00 21.22  1 
+ATOM   348  O OE1 . GLN A 1 48  41.872 43.870  16.081 A 48  ? 1.00 26.23  1 
+ATOM   349  N NE2 . GLN A 1 48  43.995 43.740  15.370 A 48  ? 1.00 23.03  1 
+ATOM   350  N N   . ALA A 1 49  37.806 42.475  14.253 A 49  ? 1.00 21.21  1 
+ATOM   351  C CA  . ALA A 1 49  36.488 41.903  14.418 A 49  ? 1.00 16.89  1 
+ATOM   352  C C   . ALA A 1 49  35.659 41.895  13.161 A 49  ? 1.00 19.52  1 
+ATOM   353  O O   . ALA A 1 49  34.709 41.109  13.072 A 49  ? 1.00 23.10  1 
+ATOM   354  C CB  . ALA A 1 49  35.759 42.659  15.487 A 49  ? 1.00 22.58  1 
+ATOM   355  N N   . LYS A 1 50  36.097 42.602  12.125 A 50  ? 1.00 17.73  1 
+ATOM   356  C CA  . LYS A 1 50  35.308 42.759  10.917 A 50  ? 1.00 24.66  1 
+ATOM   357  C C   . LYS A 1 50  34.650 41.524  10.384 A 50  ? 1.00 30.87  1 
+ATOM   358  O O   . LYS A 1 50  33.426 41.471  10.278 A 50  ? 1.00 36.65  1 
+ATOM   359  C CB  . LYS A 1 50  36.143 43.316  9.800  A 50  ? 1.00 34.17  1 
+ATOM   360  C CG  . LYS A 1 50  35.224 43.799  8.664  A 50  ? 1.00 45.95  1 
+ATOM   361  C CD  . LYS A 1 50  36.154 44.209  7.561  A 50  ? 1.00 56.17  1 
+ATOM   362  C CE  . LYS A 1 50  35.425 44.373  6.250  A 50  ? 1.00 66.66  1 
+ATOM   363  N NZ  . LYS A 1 50  36.415 44.386  5.180  A 50  ? 1.00 79.68  1 
+ATOM   364  N N   . ASP A 1 51  35.416 40.493  10.111 A 51  ? 1.00 28.37  1 
+ATOM   365  C CA  . ASP A 1 51  34.849 39.271  9.552  A 51  ? 1.00 35.62  1 
+ATOM   366  C C   . ASP A 1 51  34.045 38.338  10.448 A 51  ? 1.00 25.22  1 
+ATOM   367  O O   . ASP A 1 51  33.120 37.663  10.011 A 51  ? 1.00 30.31  1 
+ATOM   368  C CB  . ASP A 1 51  35.989 38.504  8.921  A 51  ? 1.00 43.20  1 
+ATOM   369  C CG  . ASP A 1 51  36.454 39.059  7.573  A 51  ? 1.00 50.07  1 
+ATOM   370  O OD1 . ASP A 1 51  35.853 40.016  7.050  A 51  ? 1.00 46.59  1 
+ATOM   371  O OD2 . ASP A 1 51  37.423 38.492  7.051  A 51  ? 1.00 57.73  1 
+ATOM   372  N N   . ILE A 1 52  34.418 38.333  11.713 A 52  ? 1.00 22.79  1 
+ATOM   373  C CA  . ILE A 1 52  33.759 37.591  12.753 A 52  ? 1.00 23.52  1 
+ATOM   374  C C   . ILE A 1 52  32.335 38.163  12.892 A 52  ? 1.00 20.34  1 
+ATOM   375  O O   . ILE A 1 52  31.372 37.397  12.769 A 52  ? 1.00 22.10  1 
+ATOM   376  C CB  . ILE A 1 52  34.522 37.749  14.102 A 52  ? 1.00 22.08  1 
+ATOM   377  C CG1 . ILE A 1 52  36.035 37.435  13.963 A 52  ? 1.00 26.19  1 
+ATOM   378  C CG2 . ILE A 1 52  33.881 36.769  15.110 A 52  ? 1.00 21.64  1 
+ATOM   379  C CD1 . ILE A 1 52  36.841 37.512  15.303 A 52  ? 1.00 33.11  1 
+ATOM   380  N N   . MET A 1 53  32.175 39.479  13.080 A 53  ? 1.00 19.44  1 
+ATOM   381  C CA  . MET A 1 53  30.854 40.075  13.253 A 53  ? 1.00 23.37  1 
+ATOM   382  C C   . MET A 1 53  29.979 39.860  12.019 A 53  ? 1.00 24.24  1 
+ATOM   383  O O   . MET A 1 53  28.783 39.588  12.107 A 53  ? 1.00 26.60  1 
+ATOM   384  C CB  . MET A 1 53  30.924 41.555  13.495 A 53  ? 1.00 15.23  1 
+ATOM   385  C CG  . MET A 1 53  31.597 41.967  14.781 A 53  ? 1.00 17.79  1 
+ATOM   386  S SD  . MET A 1 53  31.472 43.709  15.259 A 53  ? 1.00 23.09  1 
+ATOM   387  C CE  . MET A 1 53  32.499 44.502  14.091 A 53  ? 1.00 24.41  1 
+ATOM   388  N N   . ASP A 1 54  30.589 39.897  10.843 A 54  ? 1.00 29.99  1 
+ATOM   389  C CA  . ASP A 1 54  29.903 39.620  9.595  A 54  ? 1.00 34.41  1 
+ATOM   390  C C   . ASP A 1 54  29.341 38.234  9.548  A 54  ? 1.00 34.53  1 
+ATOM   391  O O   . ASP A 1 54  28.271 38.002  8.980  A 54  ? 1.00 27.93  1 
+ATOM   392  C CB  . ASP A 1 54  30.846 39.759  8.427  A 54  ? 1.00 53.31  1 
+ATOM   393  C CG  . ASP A 1 54  30.564 41.029  7.641  A 54  ? 1.00 70.87  1 
+ATOM   394  O OD1 . ASP A 1 54  29.567 41.055  6.910  A 54  ? 1.00 79.36  1 
+ATOM   395  O OD2 . ASP A 1 54  31.337 41.984  7.762  A 54  ? 1.00 76.90  1 
+ATOM   396  N N   . ALA A 1 55  30.099 37.277  10.090 A 55  ? 1.00 34.64  1 
+ATOM   397  C CA  . ALA A 1 55  29.654 35.907  10.111 A 55  ? 1.00 25.96  1 
+ATOM   398  C C   . ALA A 1 55  28.643 35.688  11.231 A 55  ? 1.00 30.04  1 
+ATOM   399  O O   . ALA A 1 55  27.968 34.667  11.178 A 55  ? 1.00 28.03  1 
+ATOM   400  C CB  . ALA A 1 55  30.846 34.979  10.311 A 55  ? 1.00 30.79  1 
+ATOM   401  N N   . GLY A 1 56  28.424 36.586  12.210 A 56  ? 1.00 27.41  1 
+ATOM   402  C CA  . GLY A 1 56  27.438 36.396  13.278 A 56  ? 1.00 16.79  1 
+ATOM   403  C C   . GLY A 1 56  28.029 35.715  14.500 A 56  ? 1.00 19.84  1 
+ATOM   404  O O   . GLY A 1 56  27.354 35.184  15.394 A 56  ? 1.00 20.05  1 
+ATOM   405  N N   . LYS A 1 57  29.353 35.725  14.527 A 57  ? 1.00 19.78  1 
+ATOM   406  C CA  . LYS A 1 57  30.045 35.011  15.563 A 57  ? 1.00 20.20  1 
+ATOM   407  C C   . LYS A 1 57  30.554 35.895  16.685 A 57  ? 1.00 16.98  1 
+ATOM   408  O O   . LYS A 1 57  30.776 37.065  16.459 A 57  ? 1.00 15.79  1 
+ATOM   409  C CB  . LYS A 1 57  31.199 34.244  14.906 A 57  ? 1.00 29.82  1 
+ATOM   410  C CG  . LYS A 1 57  30.657 32.925  14.399 A 57  ? 1.00 40.46  1 
+ATOM   411  C CD  . LYS A 1 57  31.789 32.009  13.997 A 57  ? 1.00 62.41  1 
+ATOM   412  C CE  . LYS A 1 57  31.195 30.661  13.561 A 57  ? 1.00 79.19  1 
+ATOM   413  N NZ  . LYS A 1 57  32.082 29.917  12.671 A 57  ? 1.00 88.79  1 
+ATOM   414  N N   . LEU A 1 58  30.876 35.344  17.855 A 58  ? 1.00 20.88  1 
+ATOM   415  C CA  . LEU A 1 58  31.439 36.126  18.922 A 58  ? 1.00 23.72  1 
+ATOM   416  C C   . LEU A 1 58  32.927 36.378  18.633 A 58  ? 1.00 31.20  1 
+ATOM   417  O O   . LEU A 1 58  33.598 35.546  18.015 A 58  ? 1.00 18.63  1 
+ATOM   418  C CB  . LEU A 1 58  31.221 35.381  20.215 A 58  ? 1.00 16.70  1 
+ATOM   419  C CG  . LEU A 1 58  29.766 35.311  20.615 A 58  ? 1.00 21.10  1 
+ATOM   420  C CD1 . LEU A 1 58  29.660 34.685  22.003 A 58  ? 1.00 21.80  1 
+ATOM   421  C CD2 . LEU A 1 58  29.175 36.702  20.724 A 58  ? 1.00 19.30  1 
+ATOM   422  N N   . VAL A 1 59  33.396 37.616  18.899 A 59  ? 1.00 30.29  1 
+ATOM   423  C CA  . VAL A 1 59  34.805 38.036  18.787 A 59  ? 1.00 23.29  1 
+ATOM   424  C C   . VAL A 1 59  35.544 37.378  20.008 A 59  ? 1.00 21.99  1 
+ATOM   425  O O   . VAL A 1 59  34.935 37.144  21.071 A 59  ? 1.00 21.43  1 
+ATOM   426  C CB  . VAL A 1 59  34.761 39.591  18.806 A 59  ? 1.00 19.93  1 
+ATOM   427  C CG1 . VAL A 1 59  36.142 40.223  18.968 A 59  ? 1.00 18.47  1 
+ATOM   428  C CG2 . VAL A 1 59  34.130 40.031  17.478 A 59  ? 1.00 20.27  1 
+ATOM   429  N N   . THR A 1 60  36.865 37.120  19.939 A 60  ? 1.00 21.24  1 
+ATOM   430  C CA  . THR A 1 60  37.608 36.412  20.972 A 60  ? 1.00 25.23  1 
+ATOM   431  C C   . THR A 1 60  37.527 37.208  22.258 A 60  ? 1.00 18.79  1 
+ATOM   432  O O   . THR A 1 60  37.609 38.459  22.254 A 60  ? 1.00 21.05  1 
+ATOM   433  C CB  . THR A 1 60  39.117 36.197  20.509 A 60  ? 1.00 33.74  1 
+ATOM   434  O OG1 . THR A 1 60  39.753 37.453  20.343 A 60  ? 1.00 39.83  1 
+ATOM   435  C CG2 . THR A 1 60  39.207 35.549  19.155 A 60  ? 1.00 33.28  1 
+ATOM   436  N N   . ASP A 1 61  37.436 36.473  23.370 A 61  ? 1.00 17.01  1 
+ATOM   437  C CA  . ASP A 1 61  37.300 37.089  24.665 A 61  ? 1.00 19.81  1 
+ATOM   438  C C   . ASP A 1 61  38.471 37.991  24.925 A 61  ? 1.00 17.79  1 
+ATOM   439  O O   . ASP A 1 61  38.270 39.110  25.380 A 61  ? 1.00 20.11  1 
+ATOM   440  C CB  . ASP A 1 61  37.283 36.074  25.778 A 61  ? 1.00 24.12  1 
+ATOM   441  C CG  . ASP A 1 61  36.119 35.113  25.728 A 61  ? 1.00 23.83  1 
+ATOM   442  O OD1 . ASP A 1 61  35.028 35.471  25.285 A 61  ? 1.00 23.79  1 
+ATOM   443  O OD2 . ASP A 1 61  36.303 34.003  26.173 A 61  ? 1.00 28.74  1 
+ATOM   444  N N   . GLU A 1 62  39.673 37.506  24.610 A 62  ? 1.00 20.66  1 
+ATOM   445  C CA  . GLU A 1 62  40.905 38.219  24.879 A 62  ? 1.00 19.00  1 
+ATOM   446  C C   . GLU A 1 62  40.846 39.627  24.225 A 62  ? 1.00 19.84  1 
+ATOM   447  O O   . GLU A 1 62  41.185 40.658  24.843 A 62  ? 1.00 19.50  1 
+ATOM   448  C CB  . GLU A 1 62  41.978 37.216  24.370 A 62  ? 1.00 23.93  1 
+ATOM   449  C CG  . GLU A 1 62  43.314 37.871  24.232 A 62  ? 1.00 32.16  1 
+ATOM   450  C CD  . GLU A 1 62  44.432 37.171  23.444 A 62  ? 1.00 24.91  1 
+ATOM   451  O OE1 . GLU A 1 62  44.232 36.601  22.375 A 62  ? 1.00 22.63  1 
+ATOM   452  O OE2 . GLU A 1 62  45.550 37.294  23.917 A 62  ? 1.00 24.05  1 
+ATOM   453  N N   . LEU A 1 63  40.288 39.759  23.018 A 63  ? 1.00 20.30  1 
+ATOM   454  C CA  . LEU A 1 63  40.206 41.060  22.376 A 63  ? 1.00 20.21  1 
+ATOM   455  C C   . LEU A 1 63  39.236 42.029  23.037 A 63  ? 1.00 24.42  1 
+ATOM   456  O O   . LEU A 1 63  39.556 43.177  23.403 A 63  ? 1.00 26.47  1 
+ATOM   457  C CB  . LEU A 1 63  39.820 40.866  20.937 A 63  ? 1.00 22.40  1 
+ATOM   458  C CG  . LEU A 1 63  39.963 41.979  19.870 A 63  ? 1.00 31.71  1 
+ATOM   459  C CD1 . LEU A 1 63  41.386 42.539  19.788 A 63  ? 1.00 29.21  1 
+ATOM   460  C CD2 . LEU A 1 63  39.567 41.359  18.551 A 63  ? 1.00 28.31  1 
+ATOM   461  N N   . VAL A 1 64  38.042 41.515  23.278 A 64  ? 1.00 19.19  1 
+ATOM   462  C CA  . VAL A 1 64  36.989 42.314  23.858 A 64  ? 1.00 22.62  1 
+ATOM   463  C C   . VAL A 1 64  37.317 42.711  25.310 A 64  ? 1.00 18.33  1 
+ATOM   464  O O   . VAL A 1 64  37.064 43.855  25.724 A 64  ? 1.00 18.42  1 
+ATOM   465  C CB  . VAL A 1 64  35.727 41.422  23.626 A 64  ? 1.00 27.94  1 
+ATOM   466  C CG1 . VAL A 1 64  34.666 41.782  24.563 A 64  ? 1.00 28.09  1 
+ATOM   467  C CG2 . VAL A 1 64  35.186 41.635  22.200 A 64  ? 1.00 21.84  1 
+ATOM   468  N N   . ILE A 1 65  37.932 41.831  26.118 A 65  ? 1.00 15.64  1 
+ATOM   469  C CA  . ILE A 1 65  38.291 42.205  27.487 A 65  ? 1.00 21.40  1 
+ATOM   470  C C   . ILE A 1 65  39.308 43.361  27.450 A 65  ? 1.00 18.81  1 
+ATOM   471  O O   . ILE A 1 65  39.185 44.270  28.275 A 65  ? 1.00 22.15  1 
+ATOM   472  C CB  . ILE A 1 65  38.880 40.988  28.218 A 65  ? 1.00 21.60  1 
+ATOM   473  C CG1 . ILE A 1 65  37.768 39.982  28.459 A 65  ? 1.00 24.64  1 
+ATOM   474  C CG2 . ILE A 1 65  39.518 41.397  29.563 A 65  ? 1.00 19.09  1 
+ATOM   475  C CD1 . ILE A 1 65  38.290 38.529  28.684 A 65  ? 1.00 33.45  1 
+ATOM   476  N N   . ALA A 1 66  40.247 43.371  26.490 A 66  ? 1.00 22.49  1 
+ATOM   477  C CA  . ALA A 1 66  41.229 44.428  26.326 A 66  ? 1.00 23.47  1 
+ATOM   478  C C   . ALA A 1 66  40.556 45.752  26.050 A 66  ? 1.00 27.14  1 
+ATOM   479  O O   . ALA A 1 66  40.889 46.691  26.771 A 66  ? 1.00 22.25  1 
+ATOM   480  C CB  . ALA A 1 66  42.154 44.098  25.181 A 66  ? 1.00 26.83  1 
+ATOM   481  N N   . LEU A 1 67  39.598 45.847  25.096 A 67  ? 1.00 22.67  1 
+ATOM   482  C CA  . LEU A 1 67  38.822 47.067  24.857 A 67  ? 1.00 23.20  1 
+ATOM   483  C C   . LEU A 1 67  38.087 47.631  26.094 A 67  ? 1.00 23.28  1 
+ATOM   484  O O   . LEU A 1 67  38.032 48.833  26.366 A 67  ? 1.00 22.63  1 
+ATOM   485  C CB  . LEU A 1 67  37.710 46.875  23.851 A 67  ? 1.00 25.15  1 
+ATOM   486  C CG  . LEU A 1 67  37.953 46.957  22.398 A 67  ? 1.00 32.06  1 
+ATOM   487  C CD1 . LEU A 1 67  36.584 47.044  21.775 A 67  ? 1.00 30.24  1 
+ATOM   488  C CD2 . LEU A 1 67  38.687 48.217  21.983 A 67  ? 1.00 37.55  1 
+ATOM   489  N N   . VAL A 1 68  37.431 46.744  26.840 A 68  ? 1.00 27.54  1 
+ATOM   490  C CA  . VAL A 1 68  36.653 47.149  28.003 A 68  ? 1.00 20.21  1 
+ATOM   491  C C   . VAL A 1 68  37.537 47.626  29.102 A 68  ? 1.00 19.66  1 
+ATOM   492  O O   . VAL A 1 68  37.203 48.612  29.736 A 68  ? 1.00 30.83  1 
+ATOM   493  C CB  . VAL A 1 68  35.831 45.965  28.478 A 68  ? 1.00 26.49  1 
+ATOM   494  C CG1 . VAL A 1 68  34.940 46.335  29.616 A 68  ? 1.00 31.37  1 
+ATOM   495  C CG2 . VAL A 1 68  34.898 45.539  27.352 A 68  ? 1.00 31.66  1 
+ATOM   496  N N   . LYS A 1 69  38.667 46.995  29.384 A 69  ? 1.00 22.78  1 
+ATOM   497  C CA  . LYS A 1 69  39.562 47.475  30.424 A 69  ? 1.00 25.90  1 
+ATOM   498  C C   . LYS A 1 69  40.090 48.852  30.080 A 69  ? 1.00 24.97  1 
+ATOM   499  O O   . LYS A 1 69  40.097 49.753  30.915 A 69  ? 1.00 31.23  1 
+ATOM   500  C CB  . LYS A 1 69  40.700 46.501  30.600 A 69  ? 1.00 28.00  1 
+ATOM   501  C CG  . LYS A 1 69  40.167 45.297  31.338 A 69  ? 1.00 30.21  1 
+ATOM   502  C CD  . LYS A 1 69  41.270 44.299  31.635 A 69  ? 1.00 36.61  1 
+ATOM   503  C CE  . LYS A 1 69  40.783 43.298  32.706 A 69  ? 1.00 31.99  1 
+ATOM   504  N NZ  . LYS A 1 69  41.758 42.233  32.928 A 69  ? 1.00 42.55  1 
+ATOM   505  N N   . GLU A 1 70  40.397 49.079  28.816 A 70  ? 1.00 33.07  1 
+ATOM   506  C CA  . GLU A 1 70  40.826 50.385  28.390 A 70  ? 1.00 30.58  1 
+ATOM   507  C C   . GLU A 1 70  39.776 51.431  28.654 A 70  ? 1.00 35.74  1 
+ATOM   508  O O   . GLU A 1 70  40.061 52.492  29.219 A 70  ? 1.00 40.89  1 
+ATOM   509  C CB  . GLU A 1 70  41.137 50.372  26.925 A 70  ? 1.00 36.86  1 
+ATOM   510  C CG  . GLU A 1 70  42.419 49.619  26.569 A 70  ? 1.00 68.88  1 
+ATOM   511  C CD  . GLU A 1 70  43.756 50.224  27.053 A 70  ? 1.00 81.97  1 
+ATOM   512  O OE1 . GLU A 1 70  44.192 51.213  26.452 A 70  ? 1.00 91.43  1 
+ATOM   513  O OE2 . GLU A 1 70  44.377 49.696  27.992 A 70  ? 1.00 83.01  1 
+ATOM   514  N N   . ARG A 1 71  38.530 51.127  28.314 A 71  ? 1.00 34.88  1 
+ATOM   515  C CA  . ARG A 1 71  37.492 52.114  28.408 A 71  ? 1.00 28.25  1 
+ATOM   516  C C   . ARG A 1 71  37.148 52.412  29.843 A 71  ? 1.00 29.75  1 
+ATOM   517  O O   . ARG A 1 71  36.991 53.574  30.227 A 71  ? 1.00 34.73  1 
+ATOM   518  C CB  . ARG A 1 71  36.343 51.567  27.618 A 71  ? 1.00 34.66  1 
+ATOM   519  C CG  . ARG A 1 71  35.168 52.512  27.514 A 71  ? 1.00 40.53  1 
+ATOM   520  C CD  . ARG A 1 71  35.377 53.828  26.770 A 71  ? 1.00 43.80  1 
+ATOM   521  N NE  . ARG A 1 71  34.191 54.670  26.914 A 71  ? 1.00 44.89  1 
+ATOM   522  C CZ  . ARG A 1 71  33.973 55.394  28.021 A 71  ? 1.00 48.53  1 
+ATOM   523  N NH1 . ARG A 1 71  34.867 55.374  29.010 A 71  ? 1.00 57.90  1 
+ATOM   524  N NH2 . ARG A 1 71  32.869 56.143  28.147 A 71  ? 1.00 51.00  1 
+ATOM   525  N N   . ILE A 1 72  37.112 51.388  30.683 A 72  ? 1.00 25.93  1 
+ATOM   526  C CA  . ILE A 1 72  36.751 51.628  32.046 A 72  ? 1.00 37.60  1 
+ATOM   527  C C   . ILE A 1 72  37.787 52.553  32.685 A 72  ? 1.00 44.26  1 
+ATOM   528  O O   . ILE A 1 72  37.427 53.302  33.600 A 72  ? 1.00 48.70  1 
+ATOM   529  C CB  . ILE A 1 72  36.610 50.224  32.696 A 72  ? 1.00 41.40  1 
+ATOM   530  C CG1 . ILE A 1 72  35.159 49.850  32.530 A 72  ? 1.00 39.96  1 
+ATOM   531  C CG2 . ILE A 1 72  36.972 50.163  34.165 A 72  ? 1.00 42.22  1 
+ATOM   532  C CD1 . ILE A 1 72  34.812 48.546  33.232 A 72  ? 1.00 37.38  1 
+ATOM   533  N N   . ALA A 1 73  39.030 52.562  32.162 A 73  ? 1.00 43.97  1 
+ATOM   534  C CA  . ALA A 1 73  40.118 53.390  32.667 A 73  ? 1.00 44.66  1 
+ATOM   535  C C   . ALA A 1 73  40.006 54.893  32.371 A 73  ? 1.00 52.90  1 
+ATOM   536  O O   . ALA A 1 73  40.631 55.700  33.076 A 73  ? 1.00 55.40  1 
+ATOM   537  C CB  . ALA A 1 73  41.427 52.868  32.102 A 73  ? 1.00 46.54  1 
+ATOM   538  N N   . GLN A 1 74  39.183 55.305  31.395 A 74  ? 1.00 52.56  1 
+ATOM   539  C CA  . GLN A 1 74  38.879 56.700  31.105 A 74  ? 1.00 54.46  1 
+ATOM   540  C C   . GLN A 1 74  38.149 57.337  32.249 A 74  ? 1.00 61.22  1 
+ATOM   541  O O   . GLN A 1 74  37.207 56.740  32.781 A 74  ? 1.00 54.31  1 
+ATOM   542  C CB  . GLN A 1 74  37.966 56.863  29.913 A 74  ? 1.00 63.60  1 
+ATOM   543  C CG  . GLN A 1 74  38.663 57.055  28.588 A 74  ? 1.00 72.57  1 
+ATOM   544  C CD  . GLN A 1 74  39.765 56.027  28.429 A 74  ? 1.00 79.14  1 
+ATOM   545  O OE1 . GLN A 1 74  40.864 56.177  28.960 A 74  ? 1.00 83.90  1 
+ATOM   546  N NE2 . GLN A 1 74  39.490 54.937  27.738 A 74  ? 1.00 82.91  1 
+ATOM   547  N N   . GLU A 1 75  38.475 58.612  32.497 A 75  ? 1.00 77.77  1 
+ATOM   548  C CA  . GLU A 1 75  37.942 59.347  33.644 A 75  ? 1.00 91.10  1 
+ATOM   549  C C   . GLU A 1 75  36.415 59.360  33.749 A 75  ? 1.00 93.91  1 
+ATOM   550  O O   . GLU A 1 75  35.879 59.633  34.819 A 75  ? 1.00 95.86  1 
+ATOM   551  C CB  . GLU A 1 75  38.425 60.829  33.654 A 75  ? 1.00 98.26  1 
+ATOM   552  C CG  . GLU A 1 75  38.526 61.372  35.113 A 75  ? 1.00 103.87 1 
+ATOM   553  C CD  . GLU A 1 75  38.185 62.829  35.468 A 75  ? 1.00 104.80 1 
+ATOM   554  O OE1 . GLU A 1 75  37.004 63.210  35.441 A 75  ? 1.00 102.97 1 
+ATOM   555  O OE2 . GLU A 1 75  39.105 63.564  35.839 A 75  ? 1.00 104.78 1 
+ATOM   556  N N   . ASP A 1 76  35.616 59.078  32.718 A 76  ? 1.00 93.76  1 
+ATOM   557  C CA  . ASP A 1 76  34.169 59.072  32.914 A 76  ? 1.00 92.02  1 
+ATOM   558  C C   . ASP A 1 76  33.706 57.854  33.711 A 76  ? 1.00 89.07  1 
+ATOM   559  O O   . ASP A 1 76  32.676 57.919  34.384 A 76  ? 1.00 91.58  1 
+ATOM   560  C CB  . ASP A 1 76  33.458 59.100  31.568 A 76  ? 1.00 93.17  1 
+ATOM   561  C CG  . ASP A 1 76  33.882 57.975  30.644 A 76  ? 1.00 95.09  1 
+ATOM   562  O OD1 . ASP A 1 76  33.457 56.847  30.869 A 76  ? 1.00 93.80  1 
+ATOM   563  O OD2 . ASP A 1 76  34.641 58.228  29.711 A 76  ? 1.00 98.66  1 
+ATOM   564  N N   . CYS A 1 77  34.453 56.748  33.687 A 77  ? 1.00 83.80  1 
+ATOM   565  C CA  . CYS A 1 77  34.023 55.549  34.377 A 77  ? 1.00 86.85  1 
+ATOM   566  C C   . CYS A 1 77  34.310 55.413  35.882 A 77  ? 1.00 86.06  1 
+ATOM   567  O O   . CYS A 1 77  33.851 54.454  36.538 A 77  ? 1.00 76.52  1 
+ATOM   568  C CB  . CYS A 1 77  34.601 54.387  33.587 A 77  ? 1.00 91.50  1 
+ATOM   569  S SG  . CYS A 1 77  33.687 54.075  32.043 A 77  ? 1.00 97.16  1 
+ATOM   570  N N   . ARG A 1 78  35.006 56.403  36.489 A 78  ? 1.00 86.24  1 
+ATOM   571  C CA  . ARG A 1 78  35.295 56.377  37.930 A 78  ? 1.00 80.21  1 
+ATOM   572  C C   . ARG A 1 78  34.070 56.504  38.817 A 78  ? 1.00 76.65  1 
+ATOM   573  O O   . ARG A 1 78  34.124 56.054  39.971 A 78  ? 1.00 66.30  1 
+ATOM   574  C CB  . ARG A 1 78  36.300 57.470  38.328 A 78  ? 1.00 76.97  1 
+ATOM   575  C CG  . ARG A 1 78  36.332 58.732  37.505 A 78  ? 1.00 83.24  1 
+ATOM   576  C CD  . ARG A 1 78  35.130 59.641  37.680 A 78  ? 1.00 90.01  1 
+ATOM   577  N NE  . ARG A 1 78  35.264 60.191  39.007 A 78  ? 1.00 95.96  1 
+ATOM   578  C CZ  . ARG A 1 78  35.993 61.277  39.249 A 78  ? 1.00 99.10  1 
+ATOM   579  N NH1 . ARG A 1 78  36.520 62.025  38.277 A 78  ? 1.00 100.61 1 
+ATOM   580  N NH2 . ARG A 1 78  36.144 61.646  40.515 A 78  ? 1.00 106.26 1 
+ATOM   581  N N   . ASN A 1 79  32.968 57.042  38.246 A 79  ? 1.00 72.42  1 
+ATOM   582  C CA  . ASN A 1 79  31.688 57.065  38.942 A 79  ? 1.00 68.72  1 
+ATOM   583  C C   . ASN A 1 79  30.547 56.203  38.348 A 79  ? 1.00 60.44  1 
+ATOM   584  O O   . ASN A 1 79  29.333 56.432  38.474 A 79  ? 1.00 59.20  1 
+ATOM   585  C CB  . ASN A 1 79  31.248 58.516  39.083 A 79  ? 1.00 76.33  1 
+ATOM   586  C CG  . ASN A 1 79  31.876 59.229  40.281 A 79  ? 1.00 84.78  1 
+ATOM   587  O OD1 . ASN A 1 79  32.717 58.723  41.031 A 79  ? 1.00 81.21  1 
+ATOM   588  N ND2 . ASN A 1 79  31.493 60.483  40.481 A 79  ? 1.00 95.47  1 
+ATOM   589  N N   . GLY A 1 80  30.893 55.065  37.766 A 80  ? 1.00 50.24  1 
+ATOM   590  C CA  . GLY A 1 80  29.874 54.162  37.301 A 80  ? 1.00 42.01  1 
+ATOM   591  C C   . GLY A 1 80  29.876 54.131  35.806 A 80  ? 1.00 40.97  1 
+ATOM   592  O O   . GLY A 1 80  30.481 54.954  35.108 A 80  ? 1.00 42.41  1 
+ATOM   593  N N   . PHE A 1 81  29.175 53.126  35.339 A 81  ? 1.00 30.61  1 
+ATOM   594  C CA  . PHE A 1 81  29.106 52.875  33.933 A 81  ? 1.00 27.69  1 
+ATOM   595  C C   . PHE A 1 81  28.054 51.772  33.789 A 81  ? 1.00 29.03  1 
+ATOM   596  O O   . PHE A 1 81  27.708 51.011  34.721 A 81  ? 1.00 30.28  1 
+ATOM   597  C CB  . PHE A 1 81  30.488 52.437  33.455 A 81  ? 1.00 23.62  1 
+ATOM   598  C CG  . PHE A 1 81  31.144 51.301  34.244 A 81  ? 1.00 31.29  1 
+ATOM   599  C CD1 . PHE A 1 81  30.709 49.987  34.151 A 81  ? 1.00 32.67  1 
+ATOM   600  C CD2 . PHE A 1 81  32.177 51.582  35.106 A 81  ? 1.00 37.49  1 
+ATOM   601  C CE1 . PHE A 1 81  31.276 48.981  34.900 A 81  ? 1.00 36.53  1 
+ATOM   602  C CE2 . PHE A 1 81  32.753 50.572  35.859 A 81  ? 1.00 40.77  1 
+ATOM   603  C CZ  . PHE A 1 81  32.307 49.275  35.761 A 81  ? 1.00 43.61  1 
+ATOM   604  N N   . LEU A 1 82  27.572 51.677  32.576 A 82  ? 1.00 22.96  1 
+ATOM   605  C CA  . LEU A 1 82  26.566 50.720  32.180 A 82  ? 1.00 23.06  1 
+ATOM   606  C C   . LEU A 1 82  27.232 49.795  31.129 A 82  ? 1.00 23.88  1 
+ATOM   607  O O   . LEU A 1 82  27.737 50.305  30.120 A 82  ? 1.00 22.70  1 
+ATOM   608  C CB  . LEU A 1 82  25.443 51.611  31.676 A 82  ? 1.00 24.66  1 
+ATOM   609  C CG  . LEU A 1 82  24.393 51.169  30.711 A 82  ? 1.00 35.91  1 
+ATOM   610  C CD1 . LEU A 1 82  23.487 50.154  31.356 A 82  ? 1.00 38.55  1 
+ATOM   611  C CD2 . LEU A 1 82  23.647 52.397  30.272 A 82  ? 1.00 36.65  1 
+ATOM   612  N N   . LEU A 1 83  27.322 48.468  31.312 A 83  ? 1.00 22.35  1 
+ATOM   613  C CA  . LEU A 1 83  27.916 47.525  30.373 A 83  ? 1.00 21.98  1 
+ATOM   614  C C   . LEU A 1 83  26.790 46.979  29.510 A 83  ? 1.00 15.68  1 
+ATOM   615  O O   . LEU A 1 83  25.890 46.273  29.957 A 83  ? 1.00 20.27  1 
+ATOM   616  C CB  . LEU A 1 83  28.647 46.397  31.158 A 83  ? 1.00 21.31  1 
+ATOM   617  C CG  . LEU A 1 83  29.913 46.836  31.911 A 83  ? 1.00 22.33  1 
+ATOM   618  C CD1 . LEU A 1 83  30.399 45.707  32.742 A 83  ? 1.00 23.77  1 
+ATOM   619  C CD2 . LEU A 1 83  30.969 47.306  30.942 A 83  ? 1.00 21.58  1 
+ATOM   620  N N   . ASP A 1 84  26.821 47.301  28.234 A 84  ? 1.00 21.73  1 
+ATOM   621  C CA  . ASP A 1 84  25.834 46.813  27.329 A 84  ? 1.00 18.60  1 
+ATOM   622  C C   . ASP A 1 84  26.538 45.908  26.331 A 84  ? 1.00 19.76  1 
+ATOM   623  O O   . ASP A 1 84  27.279 46.353  25.444 A 84  ? 1.00 26.97  1 
+ATOM   624  C CB  . ASP A 1 84  25.219 48.071  26.753 A 84  ? 1.00 20.18  1 
+ATOM   625  C CG  . ASP A 1 84  24.284 47.851  25.579 A 84  ? 1.00 26.66  1 
+ATOM   626  O OD1 . ASP A 1 84  23.727 46.759  25.479 A 84  ? 1.00 20.63  1 
+ATOM   627  O OD2 . ASP A 1 84  24.147 48.769  24.756 A 84  ? 1.00 25.38  1 
+ATOM   628  N N   . GLY A 1 85  26.338 44.610  26.441 A 85  ? 1.00 18.28  1 
+ATOM   629  C CA  . GLY A 1 85  26.933 43.697  25.483 A 85  ? 1.00 20.17  1 
+ATOM   630  C C   . GLY A 1 85  28.144 42.984  25.997 A 85  ? 1.00 20.42  1 
+ATOM   631  O O   . GLY A 1 85  28.746 42.135  25.324 A 85  ? 1.00 24.43  1 
+ATOM   632  N N   . PHE A 1 86  28.474 43.263  27.270 A 86  ? 1.00 19.63  1 
+ATOM   633  C CA  . PHE A 1 86  29.653 42.677  27.895 A 86  ? 1.00 15.06  1 
+ATOM   634  C C   . PHE A 1 86  29.300 42.433  29.357 A 86  ? 1.00 16.02  1 
+ATOM   635  O O   . PHE A 1 86  28.662 43.281  29.948 A 86  ? 1.00 17.35  1 
+ATOM   636  C CB  . PHE A 1 86  30.850 43.633  27.792 A 86  ? 1.00 16.51  1 
+ATOM   637  C CG  . PHE A 1 86  32.110 43.083  28.429 A 86  ? 1.00 19.92  1 
+ATOM   638  C CD1 . PHE A 1 86  32.380 43.279  29.780 A 86  ? 1.00 19.32  1 
+ATOM   639  C CD2 . PHE A 1 86  32.982 42.320  27.685 A 86  ? 1.00 18.32  1 
+ATOM   640  C CE1 . PHE A 1 86  33.516 42.701  30.345 A 86  ? 1.00 23.56  1 
+ATOM   641  C CE2 . PHE A 1 86  34.127 41.744  28.271 A 86  ? 1.00 24.09  1 
+ATOM   642  C CZ  . PHE A 1 86  34.396 41.931  29.608 A 86  ? 1.00 23.30  1 
+ATOM   643  N N   . PRO A 1 87  29.637 41.373  30.042 A 87  ? 1.00 17.31  1 
+ATOM   644  C CA  . PRO A 1 87  30.201 40.135  29.493 A 87  ? 1.00 14.20  1 
+ATOM   645  C C   . PRO A 1 87  29.220 39.423  28.586 A 87  ? 1.00 15.84  1 
+ATOM   646  O O   . PRO A 1 87  28.004 39.540  28.685 A 87  ? 1.00 15.08  1 
+ATOM   647  C CB  . PRO A 1 87  30.562 39.298  30.721 A 87  ? 1.00 17.79  1 
+ATOM   648  C CG  . PRO A 1 87  29.514 39.755  31.754 A 87  ? 1.00 19.99  1 
+ATOM   649  C CD  . PRO A 1 87  29.467 41.275  31.506 A 87  ? 1.00 22.58  1 
+ATOM   650  N N   . ARG A 1 88  29.801 38.654  27.722 A 88  ? 1.00 16.01  1 
+ATOM   651  C CA  . ARG A 1 88  29.055 37.920  26.723 A 88  ? 1.00 23.07  1 
+ATOM   652  C C   . ARG A 1 88  29.382 36.436  26.897 A 88  ? 1.00 20.65  1 
+ATOM   653  O O   . ARG A 1 88  28.787 35.564  26.251 A 88  ? 1.00 16.57  1 
+ATOM   654  C CB  . ARG A 1 88  29.526 38.549  25.414 A 88  ? 1.00 19.25  1 
+ATOM   655  C CG  . ARG A 1 88  28.725 38.490  24.178 A 88  ? 1.00 21.95  1 
+ATOM   656  C CD  . ARG A 1 88  27.454 39.281  24.359 A 88  ? 1.00 23.84  1 
+ATOM   657  N NE  . ARG A 1 88  26.873 39.298  23.031 A 88  ? 1.00 28.56  1 
+ATOM   658  C CZ  . ARG A 1 88  26.792 40.409  22.295 A 88  ? 1.00 28.06  1 
+ATOM   659  N NH1 . ARG A 1 88  27.107 41.605  22.798 A 88  ? 1.00 21.46  1 
+ATOM   660  N NH2 . ARG A 1 88  26.328 40.311  21.053 A 88  ? 1.00 22.33  1 
+ATOM   661  N N   . THR A 1 89  30.404 36.096  27.685 A 89  ? 1.00 17.94  1 
+ATOM   662  C CA  . THR A 1 89  30.715 34.709  27.886 A 89  ? 1.00 20.36  1 
+ATOM   663  C C   . THR A 1 89  31.195 34.573  29.346 A 89  ? 1.00 15.20  1 
+ATOM   664  O O   . THR A 1 89  31.458 35.571  30.025 A 89  ? 1.00 14.40  1 
+ATOM   665  C CB  . THR A 1 89  31.822 34.210  26.905 A 89  ? 1.00 19.18  1 
+ATOM   666  O OG1 . THR A 1 89  32.985 34.981  27.240 A 89  ? 1.00 24.39  1 
+ATOM   667  C CG2 . THR A 1 89  31.513 34.326  25.412 A 89  ? 1.00 17.68  1 
+ATOM   668  N N   . ILE A 1 90  31.283 33.344  29.853 A 90  ? 1.00 16.73  1 
+ATOM   669  C CA  . ILE A 1 90  31.743 33.110  31.221 A 90  ? 1.00 25.76  1 
+ATOM   670  C C   . ILE A 1 90  33.216 33.563  31.349 A 90  ? 1.00 21.33  1 
+ATOM   671  O O   . ILE A 1 90  33.497 34.260  32.324 A 90  ? 1.00 22.19  1 
+ATOM   672  C CB  . ILE A 1 90  31.625 31.590  31.611 A 90  ? 1.00 26.68  1 
+ATOM   673  C CG1 . ILE A 1 90  30.193 31.055  31.591 A 90  ? 1.00 28.19  1 
+ATOM   674  C CG2 . ILE A 1 90  32.227 31.450  33.022 A 90  ? 1.00 26.35  1 
+ATOM   675  C CD1 . ILE A 1 90  29.211 31.631  32.634 A 90  ? 1.00 26.66  1 
+ATOM   676  N N   . PRO A 1 91  34.212 33.299  30.483 A 91  ? 1.00 16.51  1 
+ATOM   677  C CA  . PRO A 1 91  35.535 33.921  30.568 A 91  ? 1.00 17.02  1 
+ATOM   678  C C   . PRO A 1 91  35.502 35.437  30.711 A 91  ? 1.00 24.68  1 
+ATOM   679  O O   . PRO A 1 91  36.288 35.971  31.495 A 91  ? 1.00 24.46  1 
+ATOM   680  C CB  . PRO A 1 91  36.242 33.526  29.317 A 91  ? 1.00 20.92  1 
+ATOM   681  C CG  . PRO A 1 91  35.677 32.159  29.063 A 91  ? 1.00 23.66  1 
+ATOM   682  C CD  . PRO A 1 91  34.181 32.354  29.365 A 91  ? 1.00 18.59  1 
+ATOM   683  N N   . GLN A 1 92  34.624 36.171  29.974 A 92  ? 1.00 16.06  1 
+ATOM   684  C CA  . GLN A 1 92  34.575 37.605  30.140 A 92  ? 1.00 13.71  1 
+ATOM   685  C C   . GLN A 1 92  34.007 37.921  31.517 A 92  ? 1.00 15.94  1 
+ATOM   686  O O   . GLN A 1 92  34.421 38.926  32.116 A 92  ? 1.00 20.24  1 
+ATOM   687  C CB  . GLN A 1 92  33.734 38.195  29.024 A 92  ? 1.00 18.99  1 
+ATOM   688  C CG  . GLN A 1 92  34.303 37.956  27.594 A 92  ? 1.00 15.80  1 
+ATOM   689  C CD  . GLN A 1 92  33.377 38.444  26.478 A 92  ? 1.00 15.95  1 
+ATOM   690  O OE1 . GLN A 1 92  32.493 39.288  26.669 A 92  ? 1.00 14.11  1 
+ATOM   691  N NE2 . GLN A 1 92  33.519 37.974  25.252 A 92  ? 1.00 14.69  1 
+ATOM   692  N N   . ALA A 1 93  33.089 37.118  32.100 A 93  ? 1.00 17.91  1 
+ATOM   693  C CA  . ALA A 1 93  32.541 37.446  33.423 A 93  ? 1.00 23.88  1 
+ATOM   694  C C   . ALA A 1 93  33.605 37.178  34.477 A 93  ? 1.00 16.87  1 
+ATOM   695  O O   . ALA A 1 93  33.790 37.986  35.396 A 93  ? 1.00 18.41  1 
+ATOM   696  C CB  . ALA A 1 93  31.308 36.594  33.760 A 93  ? 1.00 23.17  1 
+ATOM   697  N N   . ASP A 1 94  34.311 36.050  34.355 A 94  ? 1.00 19.98  1 
+ATOM   698  C CA  . ASP A 1 94  35.444 35.776  35.246 A 94  ? 1.00 26.72  1 
+ATOM   699  C C   . ASP A 1 94  36.510 36.853  35.215 A 94  ? 1.00 28.05  1 
+ATOM   700  O O   . ASP A 1 94  36.945 37.281  36.287 A 94  ? 1.00 24.29  1 
+ATOM   701  C CB  . ASP A 1 94  36.128 34.487  34.895 A 94  ? 1.00 27.71  1 
+ATOM   702  C CG  . ASP A 1 94  35.301 33.302  35.338 A 94  ? 1.00 36.49  1 
+ATOM   703  O OD1 . ASP A 1 94  34.611 33.382  36.374 A 94  ? 1.00 29.94  1 
+ATOM   704  O OD2 . ASP A 1 94  35.361 32.307  34.623 A 94  ? 1.00 38.04  1 
+ATOM   705  N N   . ALA A 1 95  36.870 37.362  34.022 A 95  ? 1.00 21.73  1 
+ATOM   706  C CA  . ALA A 1 95  37.851 38.413  33.908 A 95  ? 1.00 22.58  1 
+ATOM   707  C C   . ALA A 1 95  37.456 39.643  34.695 A 95  ? 1.00 23.08  1 
+ATOM   708  O O   . ALA A 1 95  38.316 40.287  35.305 A 95  ? 1.00 22.24  1 
+ATOM   709  C CB  . ALA A 1 95  38.030 38.801  32.439 A 95  ? 1.00 30.84  1 
+ATOM   710  N N   . MET A 1 96  36.171 40.029  34.687 A 96  ? 1.00 25.96  1 
+ATOM   711  C CA  . MET A 1 96  35.660 41.143  35.472 A 96  ? 1.00 24.51  1 
+ATOM   712  C C   . MET A 1 96  35.829 40.881  36.968 A 96  ? 1.00 31.22  1 
+ATOM   713  O O   . MET A 1 96  36.231 41.756  37.735 A 96  ? 1.00 30.31  1 
+ATOM   714  C CB  . MET A 1 96  34.193 41.341  35.189 A 96  ? 1.00 29.30  1 
+ATOM   715  C CG  . MET A 1 96  33.874 42.444  34.199 A 96  ? 1.00 40.35  1 
+ATOM   716  S SD  . MET A 1 96  32.075 42.465  33.950 A 96  ? 1.00 42.93  1 
+ATOM   717  C CE  . MET A 1 96  31.495 43.419  35.312 A 96  ? 1.00 34.49  1 
+ATOM   718  N N   . LYS A 1 97  35.579 39.630  37.360 A 97  ? 1.00 37.96  1 
+ATOM   719  C CA  . LYS A 1 97  35.733 39.148  38.737 A 97  ? 1.00 45.23  1 
+ATOM   720  C C   . LYS A 1 97  37.192 39.350  39.141 A 97  ? 1.00 39.73  1 
+ATOM   721  O O   . LYS A 1 97  37.472 40.257  39.920 A 97  ? 1.00 35.21  1 
+ATOM   722  C CB  . LYS A 1 97  35.355 37.656  38.817 A 97  ? 1.00 47.93  1 
+ATOM   723  C CG  . LYS A 1 97  34.564 37.502  40.078 A 97  ? 1.00 60.44  1 
+ATOM   724  C CD  . LYS A 1 97  33.783 36.222  40.196 A 97  ? 1.00 65.76  1 
+ATOM   725  C CE  . LYS A 1 97  33.050 36.502  41.498 A 97  ? 1.00 74.61  1 
+ATOM   726  N NZ  . LYS A 1 97  32.365 35.323  41.977 A 97  ? 1.00 81.01  1 
+ATOM   727  N N   . GLU A 1 98  38.122 38.596  38.530 A 98  ? 1.00 38.69  1 
+ATOM   728  C CA  . GLU A 1 98  39.569 38.768  38.720 A 98  ? 1.00 38.07  1 
+ATOM   729  C C   . GLU A 1 98  40.078 40.206  38.835 A 98  ? 1.00 37.47  1 
+ATOM   730  O O   . GLU A 1 98  40.993 40.501  39.623 A 98  ? 1.00 39.85  1 
+ATOM   731  C CB  . GLU A 1 98  40.337 38.096  37.566 A 98  ? 1.00 35.66  1 
+ATOM   732  C CG  . GLU A 1 98  40.135 36.609  37.434 A 98  ? 1.00 35.33  1 
+ATOM   733  C CD  . GLU A 1 98  40.527 35.822  38.674 A 98  ? 1.00 51.96  1 
+ATOM   734  O OE1 . GLU A 1 98  39.691 35.639  39.568 A 98  ? 1.00 52.83  1 
+ATOM   735  O OE2 . GLU A 1 98  41.678 35.379  38.736 A 98  ? 1.00 63.50  1 
+ATOM   736  N N   . ALA A 1 99  39.495 41.100  38.025 A 99  ? 1.00 39.23  1 
+ATOM   737  C CA  . ALA A 1 99  39.899 42.490  37.999 A 99  ? 1.00 36.97  1 
+ATOM   738  C C   . ALA A 1 99  39.206 43.370  39.028 A 99  ? 1.00 30.71  1 
+ATOM   739  O O   . ALA A 1 99  39.436 44.578  39.006 A 99  ? 1.00 36.58  1 
+ATOM   740  C CB  . ALA A 1 99  39.670 43.086  36.578 A 99  ? 1.00 33.85  1 
+ATOM   741  N N   . GLY A 1 100 38.375 42.922  39.962 A 100 ? 1.00 36.48  1 
+ATOM   742  C CA  . GLY A 1 100 37.775 43.860  40.924 A 100 ? 1.00 35.17  1 
+ATOM   743  C C   . GLY A 1 100 36.680 44.765  40.354 A 100 ? 1.00 36.37  1 
+ATOM   744  O O   . GLY A 1 100 36.431 45.866  40.852 A 100 ? 1.00 39.36  1 
+ATOM   745  N N   . ILE A 1 101 35.985 44.319  39.280 A 101 ? 1.00 36.15  1 
+ATOM   746  C CA  . ILE A 1 101 34.864 45.066  38.723 A 101 ? 1.00 37.83  1 
+ATOM   747  C C   . ILE A 1 101 33.614 44.296  39.115 A 101 ? 1.00 39.43  1 
+ATOM   748  O O   . ILE A 1 101 33.219 43.281  38.517 A 101 ? 1.00 41.33  1 
+ATOM   749  C CB  . ILE A 1 101 34.865 45.177  37.170 A 101 ? 1.00 37.52  1 
+ATOM   750  C CG1 . ILE A 1 101 36.173 45.753  36.598 A 101 ? 1.00 30.53  1 
+ATOM   751  C CG2 . ILE A 1 101 33.628 46.042  36.841 A 101 ? 1.00 28.64  1 
+ATOM   752  C CD1 . ILE A 1 101 36.469 45.273  35.166 A 101 ? 1.00 33.83  1 
+ATOM   753  N N   . ASN A 1 102 33.039 44.800  40.182 A 102 ? 1.00 40.13  1 
+ATOM   754  C CA  . ASN A 1 102 31.793 44.278  40.733 A 102 ? 1.00 43.69  1 
+ATOM   755  C C   . ASN A 1 102 30.685 45.229  40.224 A 102 ? 1.00 40.71  1 
+ATOM   756  O O   . ASN A 1 102 30.982 46.365  39.806 A 102 ? 1.00 34.57  1 
+ATOM   757  C CB  . ASN A 1 102 31.854 44.260  42.290 A 102 ? 1.00 39.88  1 
+ATOM   758  C CG  . ASN A 1 102 32.154 45.659  42.838 A 102 ? 1.00 53.51  1 
+ATOM   759  O OD1 . ASN A 1 102 33.249 46.185  42.565 A 102 ? 1.00 51.52  1 
+ATOM   760  N ND2 . ASN A 1 102 31.246 46.346  43.552 A 102 ? 1.00 57.38  1 
+ATOM   761  N N   . VAL A 1 103 29.399 44.824  40.159 A 103 ? 1.00 34.58  1 
+ATOM   762  C CA  . VAL A 1 103 28.372 45.707  39.643 A 103 ? 1.00 29.14  1 
+ATOM   763  C C   . VAL A 1 103 27.271 45.729  40.658 A 103 ? 1.00 25.58  1 
+ATOM   764  O O   . VAL A 1 103 27.144 44.832  41.501 A 103 ? 1.00 26.58  1 
+ATOM   765  C CB  . VAL A 1 103 27.780 45.248  38.259 A 103 ? 1.00 32.44  1 
+ATOM   766  C CG1 . VAL A 1 103 28.899 45.246  37.269 A 103 ? 1.00 25.15  1 
+ATOM   767  C CG2 . VAL A 1 103 27.146 43.894  38.301 A 103 ? 1.00 29.59  1 
+ATOM   768  N N   . ASP A 1 104 26.464 46.759  40.530 A 104 ? 1.00 25.82  1 
+ATOM   769  C CA  . ASP A 1 104 25.332 46.877  41.404 A 104 ? 1.00 24.56  1 
+ATOM   770  C C   . ASP A 1 104 24.124 46.100  40.979 A 104 ? 1.00 28.20  1 
+ATOM   771  O O   . ASP A 1 104 23.498 45.493  41.846 A 104 ? 1.00 21.75  1 
+ATOM   772  C CB  . ASP A 1 104 24.986 48.303  41.522 A 104 ? 1.00 29.61  1 
+ATOM   773  C CG  . ASP A 1 104 26.128 49.007  42.261 A 104 ? 1.00 39.01  1 
+ATOM   774  O OD1 . ASP A 1 104 26.394 48.723  43.441 A 104 ? 1.00 40.49  1 
+ATOM   775  O OD2 . ASP A 1 104 26.773 49.834  41.630 A 104 ? 1.00 31.93  1 
+ATOM   776  N N   . TYR A 1 105 23.831 46.089  39.678 A 105 ? 1.00 19.14  1 
+ATOM   777  C CA  . TYR A 1 105 22.614 45.492  39.142 A 105 ? 1.00 25.20  1 
+ATOM   778  C C   . TYR A 1 105 22.931 44.745  37.883 A 105 ? 1.00 25.41  1 
+ATOM   779  O O   . TYR A 1 105 23.764 45.224  37.097 A 105 ? 1.00 27.61  1 
+ATOM   780  C CB  . TYR A 1 105 21.548 46.495  38.715 A 105 ? 1.00 32.67  1 
+ATOM   781  C CG  . TYR A 1 105 20.839 47.286  39.803 A 105 ? 1.00 43.56  1 
+ATOM   782  C CD1 . TYR A 1 105 21.434 48.446  40.274 A 105 ? 1.00 52.04  1 
+ATOM   783  C CD2 . TYR A 1 105 19.604 46.881  40.304 A 105 ? 1.00 46.91  1 
+ATOM   784  C CE1 . TYR A 1 105 20.809 49.220  41.239 A 105 ? 1.00 55.58  1 
+ATOM   785  C CE2 . TYR A 1 105 18.972 47.644  41.280 A 105 ? 1.00 49.41  1 
+ATOM   786  C CZ  . TYR A 1 105 19.583 48.816  41.737 A 105 ? 1.00 57.41  1 
+ATOM   787  O OH  . TYR A 1 105 18.989 49.616  42.708 A 105 ? 1.00 63.15  1 
+ATOM   788  N N   . VAL A 1 106 22.320 43.572  37.739 A 106 ? 1.00 19.65  1 
+ATOM   789  C CA  . VAL A 1 106 22.348 42.878  36.473 A 106 ? 1.00 19.27  1 
+ATOM   790  C C   . VAL A 1 106 20.870 42.849  36.044 A 106 ? 1.00 21.52  1 
+ATOM   791  O O   . VAL A 1 106 19.967 42.515  36.823 A 106 ? 1.00 21.79  1 
+ATOM   792  C CB  . VAL A 1 106 22.942 41.493  36.681 A 106 ? 1.00 14.46  1 
+ATOM   793  C CG1 . VAL A 1 106 22.901 40.759  35.332 A 106 ? 1.00 17.52  1 
+ATOM   794  C CG2 . VAL A 1 106 24.412 41.568  37.146 A 106 ? 1.00 21.05  1 
+ATOM   795  N N   . LEU A 1 107 20.543 43.290  34.837 A 107 ? 1.00 19.73  1 
+ATOM   796  C CA  . LEU A 1 107 19.163 43.331  34.358 A 107 ? 1.00 20.88  1 
+ATOM   797  C C   . LEU A 1 107 19.072 42.441  33.134 A 107 ? 1.00 23.74  1 
+ATOM   798  O O   . LEU A 1 107 19.839 42.522  32.166 A 107 ? 1.00 20.53  1 
+ATOM   799  C CB  . LEU A 1 107 18.781 44.770  34.012 A 107 ? 1.00 25.86  1 
+ATOM   800  C CG  . LEU A 1 107 19.037 45.845  35.123 A 107 ? 1.00 26.90  1 
+ATOM   801  C CD1 . LEU A 1 107 18.745 47.167  34.547 A 107 ? 1.00 23.91  1 
+ATOM   802  C CD2 . LEU A 1 107 18.136 45.687  36.346 A 107 ? 1.00 28.78  1 
+ATOM   803  N N   . GLU A 1 108 18.168 41.477  33.207 A 108 ? 1.00 22.08  1 
+ATOM   804  C CA  . GLU A 1 108 17.976 40.535  32.145 A 108 ? 1.00 18.27  1 
+ATOM   805  C C   . GLU A 1 108 16.739 41.024  31.406 A 108 ? 1.00 20.53  1 
+ATOM   806  O O   . GLU A 1 108 15.736 41.348  32.022 A 108 ? 1.00 24.69  1 
+ATOM   807  C CB  . GLU A 1 108 17.795 39.197  32.772 A 108 ? 1.00 17.12  1 
+ATOM   808  C CG  . GLU A 1 108 17.479 38.112  31.769 A 108 ? 1.00 23.19  1 
+ATOM   809  C CD  . GLU A 1 108 16.878 36.862  32.373 A 108 ? 1.00 29.16  1 
+ATOM   810  O OE1 . GLU A 1 108 16.949 36.652  33.582 A 108 ? 1.00 26.95  1 
+ATOM   811  O OE2 . GLU A 1 108 16.327 36.092  31.607 A 108 ? 1.00 28.40  1 
+ATOM   812  N N   . PHE A 1 109 16.860 41.159  30.095 A 109 ? 1.00 16.76  1 
+ATOM   813  C CA  . PHE A 1 109 15.795 41.545  29.219 A 109 ? 1.00 16.96  1 
+ATOM   814  C C   . PHE A 1 109 15.347 40.241  28.577 A 109 ? 1.00 20.60  1 
+ATOM   815  O O   . PHE A 1 109 16.033 39.691  27.704 A 109 ? 1.00 21.91  1 
+ATOM   816  C CB  . PHE A 1 109 16.303 42.506  28.144 A 109 ? 1.00 19.38  1 
+ATOM   817  C CG  . PHE A 1 109 16.534 43.943  28.597 A 109 ? 1.00 29.84  1 
+ATOM   818  C CD1 . PHE A 1 109 17.292 44.250  29.712 A 109 ? 1.00 28.76  1 
+ATOM   819  C CD2 . PHE A 1 109 15.962 44.982  27.878 A 109 ? 1.00 39.45  1 
+ATOM   820  C CE1 . PHE A 1 109 17.484 45.555  30.122 A 109 ? 1.00 21.86  1 
+ATOM   821  C CE2 . PHE A 1 109 16.160 46.290  28.294 A 109 ? 1.00 37.45  1 
+ATOM   822  C CZ  . PHE A 1 109 16.916 46.586  29.411 A 109 ? 1.00 29.73  1 
+ATOM   823  N N   . ASP A 1 110 14.196 39.690  28.948 A 110 ? 1.00 18.29  1 
+ATOM   824  C CA  . ASP A 1 110 13.724 38.460  28.356 A 110 ? 1.00 21.38  1 
+ATOM   825  C C   . ASP A 1 110 12.796 38.645  27.163 A 110 ? 1.00 17.73  1 
+ATOM   826  O O   . ASP A 1 110 11.750 39.309  27.235 A 110 ? 1.00 19.51  1 
+ATOM   827  C CB  . ASP A 1 110 13.057 37.683  29.461 A 110 ? 1.00 20.74  1 
+ATOM   828  C CG  . ASP A 1 110 12.395 36.407  28.943 A 110 ? 1.00 39.61  1 
+ATOM   829  O OD1 . ASP A 1 110 13.069 35.651  28.223 A 110 ? 1.00 44.65  1 
+ATOM   830  O OD2 . ASP A 1 110 11.211 36.195  29.261 A 110 ? 1.00 42.80  1 
+ATOM   831  N N   . VAL A 1 111 13.115 38.026  26.066 A 111 ? 1.00 13.74  1 
+ATOM   832  C CA  . VAL A 1 111 12.261 38.125  24.898 A 111 ? 1.00 18.33  1 
+ATOM   833  C C   . VAL A 1 111 12.190 36.725  24.317 A 111 ? 1.00 23.62  1 
+ATOM   834  O O   . VAL A 1 111 13.216 36.063  24.352 A 111 ? 1.00 27.92  1 
+ATOM   835  C CB  . VAL A 1 111 12.903 39.113  23.915 A 111 ? 1.00 26.33  1 
+ATOM   836  C CG1 . VAL A 1 111 12.176 39.180  22.613 A 111 ? 1.00 33.87  1 
+ATOM   837  C CG2 . VAL A 1 111 12.652 40.546  24.393 A 111 ? 1.00 27.91  1 
+ATOM   838  N N   . PRO A 1 112 11.100 36.192  23.795 A 112 ? 1.00 18.89  1 
+ATOM   839  C CA  . PRO A 1 112 11.073 34.932  23.064 A 112 ? 1.00 23.18  1 
+ATOM   840  C C   . PRO A 1 112 11.931 34.951  21.804 A 112 ? 1.00 22.44  1 
+ATOM   841  O O   . PRO A 1 112 11.936 35.964  21.097 A 112 ? 1.00 24.36  1 
+ATOM   842  C CB  . PRO A 1 112 9.604  34.695  22.743 A 112 ? 1.00 19.78  1 
+ATOM   843  C CG  . PRO A 1 112 8.875  35.631  23.655 A 112 ? 1.00 20.79  1 
+ATOM   844  C CD  . PRO A 1 112 9.794  36.808  23.854 A 112 ? 1.00 18.21  1 
+ATOM   845  N N   . ASP A 1 113 12.616 33.862  21.441 A 113 ? 1.00 21.33  1 
+ATOM   846  C CA  . ASP A 1 113 13.347 33.748  20.186 A 113 ? 1.00 21.15  1 
+ATOM   847  C C   . ASP A 1 113 12.584 34.097  18.926 A 113 ? 1.00 20.23  1 
+ATOM   848  O O   . ASP A 1 113 13.097 34.687  18.000 A 113 ? 1.00 16.45  1 
+ATOM   849  C CB  . ASP A 1 113 13.861 32.342  19.980 A 113 ? 1.00 32.08  1 
+ATOM   850  C CG  . ASP A 1 113 15.006 31.883  20.899 A 113 ? 1.00 36.08  1 
+ATOM   851  O OD1 . ASP A 1 113 15.672 32.736  21.459 A 113 ? 1.00 28.01  1 
+ATOM   852  O OD2 . ASP A 1 113 15.240 30.674  21.052 A 113 ? 1.00 46.72  1 
+ATOM   853  N N   . GLU A 1 114 11.311 33.801  18.881 A 114 ? 1.00 21.14  1 
+ATOM   854  C CA  . GLU A 1 114 10.481 34.000  17.694 A 114 ? 1.00 21.97  1 
+ATOM   855  C C   . GLU A 1 114 10.252 35.458  17.333 A 114 ? 1.00 23.20  1 
+ATOM   856  O O   . GLU A 1 114 9.862  35.766  16.207 A 114 ? 1.00 23.38  1 
+ATOM   857  C CB  . GLU A 1 114 9.111  33.311  17.908 A 114 ? 1.00 20.25  1 
+ATOM   858  C CG  . GLU A 1 114 9.285  31.800  18.061 A 114 ? 1.00 16.29  1 
+ATOM   859  C CD  . GLU A 1 114 9.575  31.249  19.445 A 114 ? 1.00 27.80  1 
+ATOM   860  O OE1 . GLU A 1 114 9.790  31.988  20.409 A 114 ? 1.00 25.25  1 
+ATOM   861  O OE2 . GLU A 1 114 9.547  30.034  19.574 A 114 ? 1.00 35.12  1 
+ATOM   862  N N   . LEU A 1 115 10.447 36.399  18.260 A 115 ? 1.00 18.48  1 
+ATOM   863  C CA  . LEU A 1 115 10.260 37.817  17.934 A 115 ? 1.00 22.63  1 
+ATOM   864  C C   . LEU A 1 115 11.520 38.459  17.358 A 115 ? 1.00 17.14  1 
+ATOM   865  O O   . LEU A 1 115 11.445 39.577  16.853 A 115 ? 1.00 22.09  1 
+ATOM   866  C CB  . LEU A 1 115 9.894  38.618  19.183 A 115 ? 1.00 16.50  1 
+ATOM   867  C CG  . LEU A 1 115 8.447  38.724  19.632 A 115 ? 1.00 26.94  1 
+ATOM   868  C CD1 . LEU A 1 115 7.704  37.409  19.736 A 115 ? 1.00 22.97  1 
+ATOM   869  C CD2 . LEU A 1 115 8.535  39.366  21.024 A 115 ? 1.00 19.62  1 
+ATOM   870  N N   . ILE A 1 116 12.688 37.820  17.416 A 116 ? 1.00 13.97  1 
+ATOM   871  C CA  . ILE A 1 116 13.933 38.508  17.208 A 116 ? 1.00 9.74   1 
+ATOM   872  C C   . ILE A 1 116 14.128 38.875  15.783 A 116 ? 1.00 15.70  1 
+ATOM   873  O O   . ILE A 1 116 14.512 40.022  15.543 A 116 ? 1.00 18.13  1 
+ATOM   874  C CB  . ILE A 1 116 15.118 37.648  17.676 A 116 ? 1.00 16.67  1 
+ATOM   875  C CG1 . ILE A 1 116 15.038 37.342  19.166 A 116 ? 1.00 25.20  1 
+ATOM   876  C CG2 . ILE A 1 116 16.410 38.405  17.515 A 116 ? 1.00 20.38  1 
+ATOM   877  C CD1 . ILE A 1 116 14.720 38.497  20.100 A 116 ? 1.00 34.08  1 
+ATOM   878  N N   . VAL A 1 117 13.897 37.966  14.832 A 117 ? 1.00 16.33  1 
+ATOM   879  C CA  . VAL A 1 117 14.225 38.291  13.469 A 117 ? 1.00 16.71  1 
+ATOM   880  C C   . VAL A 1 117 13.446 39.514  12.993 A 117 ? 1.00 21.91  1 
+ATOM   881  O O   . VAL A 1 117 14.126 40.388  12.436 A 117 ? 1.00 28.27  1 
+ATOM   882  C CB  . VAL A 1 117 13.999 37.013  12.648 A 117 ? 1.00 21.49  1 
+ATOM   883  C CG1 . VAL A 1 117 13.955 37.307  11.153 A 117 ? 1.00 26.80  1 
+ATOM   884  C CG2 . VAL A 1 117 15.191 36.083  12.902 A 117 ? 1.00 22.62  1 
+ATOM   885  N N   . ASP A 1 118 12.133 39.750  13.252 A 118 ? 1.00 27.52  1 
+ATOM   886  C CA  . ASP A 1 118 11.453 40.992  12.840 A 118 ? 1.00 26.18  1 
+ATOM   887  C C   . ASP A 1 118 11.855 42.240  13.570 A 118 ? 1.00 33.69  1 
+ATOM   888  O O   . ASP A 1 118 11.803 43.327  12.976 A 118 ? 1.00 32.99  1 
+ATOM   889  C CB  . ASP A 1 118 9.956  40.872  12.967 A 118 ? 1.00 40.16  1 
+ATOM   890  C CG  . ASP A 1 118 9.362  39.878  11.975 A 118 ? 1.00 52.51  1 
+ATOM   891  O OD1 . ASP A 1 118 9.972  39.579  10.941 A 118 ? 1.00 60.07  1 
+ATOM   892  O OD2 . ASP A 1 118 8.263  39.402  12.240 A 118 ? 1.00 65.46  1 
+ATOM   893  N N   . ARG A 1 119 12.271 42.147  14.844 A 119 ? 1.00 24.50  1 
+ATOM   894  C CA  . ARG A 1 119 12.823 43.313  15.486 A 119 ? 1.00 30.39  1 
+ATOM   895  C C   . ARG A 1 119 14.023 43.741  14.703 A 119 ? 1.00 32.84  1 
+ATOM   896  O O   . ARG A 1 119 14.076 44.882  14.235 A 119 ? 1.00 43.09  1 
+ATOM   897  C CB  . ARG A 1 119 13.349 43.091  16.885 A 119 ? 1.00 24.69  1 
+ATOM   898  C CG  . ARG A 1 119 12.147 43.270  17.709 A 119 ? 1.00 17.45  1 
+ATOM   899  C CD  . ARG A 1 119 12.614 43.243  19.102 A 119 ? 1.00 16.60  1 
+ATOM   900  N NE  . ARG A 1 119 11.421 43.252  19.890 A 119 ? 1.00 12.44  1 
+ATOM   901  C CZ  . ARG A 1 119 11.441 43.334  21.207 A 119 ? 1.00 16.89  1 
+ATOM   902  N NH1 . ARG A 1 119 12.549 43.550  21.878 A 119 ? 1.00 14.06  1 
+ATOM   903  N NH2 . ARG A 1 119 10.279 43.260  21.851 A 119 ? 1.00 25.25  1 
+ATOM   904  N N   . ILE A 1 120 14.928 42.797  14.446 A 120 ? 1.00 26.70  1 
+ATOM   905  C CA  . ILE A 1 120 16.144 43.201  13.823 A 120 ? 1.00 22.95  1 
+ATOM   906  C C   . ILE A 1 120 15.993 43.613  12.372 A 120 ? 1.00 21.07  1 
+ATOM   907  O O   . ILE A 1 120 16.753 44.515  12.019 A 120 ? 1.00 20.97  1 
+ATOM   908  C CB  . ILE A 1 120 17.173 42.082  14.081 A 120 ? 1.00 23.49  1 
+ATOM   909  C CG1 . ILE A 1 120 17.584 42.257  15.571 A 120 ? 1.00 26.12  1 
+ATOM   910  C CG2 . ILE A 1 120 18.409 42.194  13.267 A 120 ? 1.00 20.91  1 
+ATOM   911  C CD1 . ILE A 1 120 18.641 41.390  16.229 A 120 ? 1.00 29.96  1 
+ATOM   912  N N   . VAL A 1 121 15.022 43.213  11.561 A 121 ? 1.00 17.44  1 
+ATOM   913  C CA  . VAL A 1 121 14.990 43.687  10.181 A 121 ? 1.00 25.51  1 
+ATOM   914  C C   . VAL A 1 121 14.486 45.127  10.063 A 121 ? 1.00 27.87  1 
+ATOM   915  O O   . VAL A 1 121 14.749 45.831  9.069  A 121 ? 1.00 29.46  1 
+ATOM   916  C CB  . VAL A 1 121 14.109 42.771  9.195  A 121 ? 1.00 29.84  1 
+ATOM   917  C CG1 . VAL A 1 121 14.722 41.392  9.259  A 121 ? 1.00 31.89  1 
+ATOM   918  C CG2 . VAL A 1 121 12.609 42.770  9.486  A 121 ? 1.00 29.22  1 
+ATOM   919  N N   . GLY A 1 122 13.725 45.594  11.052 A 122 ? 1.00 23.01  1 
+ATOM   920  C CA  . GLY A 1 122 13.285 46.970  11.062 A 122 ? 1.00 20.28  1 
+ATOM   921  C C   . GLY A 1 122 14.309 47.830  11.795 A 122 ? 1.00 22.81  1 
+ATOM   922  O O   . GLY A 1 122 14.030 49.017  11.944 A 122 ? 1.00 19.95  1 
+ATOM   923  N N   . ARG A 1 123 15.453 47.336  12.286 A 123 ? 1.00 16.72  1 
+ATOM   924  C CA  . ARG A 1 123 16.370 48.198  12.993 A 123 ? 1.00 16.86  1 
+ATOM   925  C C   . ARG A 1 123 17.171 49.081  12.041 A 123 ? 1.00 20.28  1 
+ATOM   926  O O   . ARG A 1 123 17.626 48.652  10.981 A 123 ? 1.00 20.03  1 
+ATOM   927  C CB  . ARG A 1 123 17.314 47.379  13.834 A 123 ? 1.00 12.78  1 
+ATOM   928  C CG  . ARG A 1 123 18.432 48.166  14.505 A 123 ? 1.00 13.69  1 
+ATOM   929  C CD  . ARG A 1 123 19.062 47.450  15.704 A 123 ? 1.00 19.15  1 
+ATOM   930  N NE  . ARG A 1 123 19.820 46.254  15.332 A 123 ? 1.00 18.77  1 
+ATOM   931  C CZ  . ARG A 1 123 20.399 45.419  16.211 A 123 ? 1.00 20.69  1 
+ATOM   932  N NH1 . ARG A 1 123 20.319 45.627  17.515 A 123 ? 1.00 23.25  1 
+ATOM   933  N NH2 . ARG A 1 123 21.068 44.353  15.795 A 123 ? 1.00 17.61  1 
+ATOM   934  N N   . ARG A 1 124 17.329 50.354  12.446 A 124 ? 1.00 20.44  1 
+ATOM   935  C CA  . ARG A 1 124 18.075 51.418  11.759 A 124 ? 1.00 21.94  1 
+ATOM   936  C C   . ARG A 1 124 18.848 52.144  12.874 A 124 ? 1.00 16.05  1 
+ATOM   937  O O   . ARG A 1 124 18.380 52.374  14.014 A 124 ? 1.00 19.24  1 
+ATOM   938  C CB  . ARG A 1 124 17.102 52.390  11.080 A 124 ? 1.00 21.22  1 
+ATOM   939  C CG  . ARG A 1 124 16.056 51.719  10.134 A 124 ? 1.00 19.93  1 
+ATOM   940  C CD  . ARG A 1 124 16.756 51.250  8.837  A 124 ? 1.00 25.72  1 
+ATOM   941  N NE  . ARG A 1 124 15.849 50.731  7.802  A 124 ? 1.00 26.35  1 
+ATOM   942  C CZ  . ARG A 1 124 15.457 49.451  7.820  A 124 ? 1.00 31.92  1 
+ATOM   943  N NH1 . ARG A 1 124 15.860 48.603  8.760  A 124 ? 1.00 24.37  1 
+ATOM   944  N NH2 . ARG A 1 124 14.671 48.979  6.874  A 124 ? 1.00 28.82  1 
+ATOM   945  N N   . VAL A 1 125 20.088 52.483  12.559 A 125 ? 1.00 18.98  1 
+ATOM   946  C CA  . VAL A 1 125 20.966 53.077  13.531 A 125 ? 1.00 20.59  1 
+ATOM   947  C C   . VAL A 1 125 21.605 54.366  12.987 A 125 ? 1.00 20.40  1 
+ATOM   948  O O   . VAL A 1 125 21.692 54.631  11.783 A 125 ? 1.00 18.82  1 
+ATOM   949  C CB  . VAL A 1 125 22.074 52.053  13.931 A 125 ? 1.00 19.00  1 
+ATOM   950  C CG1 . VAL A 1 125 21.467 50.733  14.377 A 125 ? 1.00 22.11  1 
+ATOM   951  C CG2 . VAL A 1 125 22.950 51.736  12.737 A 125 ? 1.00 23.07  1 
+ATOM   952  N N   . HIS A 1 126 21.928 55.220  13.949 A 126 ? 1.00 17.05  1 
+ATOM   953  C CA  . HIS A 1 126 22.804 56.339  13.735 A 126 ? 1.00 21.64  1 
+ATOM   954  C C   . HIS A 1 126 24.189 55.862  14.226 A 126 ? 1.00 19.30  1 
+ATOM   955  O O   . HIS A 1 126 24.537 55.932  15.416 A 126 ? 1.00 23.61  1 
+ATOM   956  C CB  . HIS A 1 126 22.295 57.498  14.554 A 126 ? 1.00 21.63  1 
+ATOM   957  C CG  . HIS A 1 126 23.213 58.665  14.288 A 126 ? 1.00 26.08  1 
+ATOM   958  N ND1 . HIS A 1 126 23.867 59.380  15.198 A 126 ? 1.00 22.48  1 
+ATOM   959  C CD2 . HIS A 1 126 23.473 59.169  13.019 A 126 ? 1.00 22.91  1 
+ATOM   960  C CE1 . HIS A 1 126 24.521 60.319  14.545 A 126 ? 1.00 21.17  1 
+ATOM   961  N NE2 . HIS A 1 126 24.272 60.172  13.258 A 126 ? 1.00 28.56  1 
+ATOM   962  N N   . ALA A 1 127 25.066 55.475  13.319 A 127 ? 1.00 24.92  1 
+ATOM   963  C CA  . ALA A 1 127 26.322 54.841  13.688 A 127 ? 1.00 27.42  1 
+ATOM   964  C C   . ALA A 1 127 27.277 55.648  14.511 A 127 ? 1.00 35.22  1 
+ATOM   965  O O   . ALA A 1 127 27.802 55.137  15.509 A 127 ? 1.00 40.67  1 
+ATOM   966  C CB  . ALA A 1 127 27.041 54.387  12.447 A 127 ? 1.00 26.91  1 
+ATOM   967  N N   . PRO A 1 128 27.458 56.954  14.262 A 128 ? 1.00 40.32  1 
+ATOM   968  C CA  . PRO A 1 128 28.355 57.764  15.058 A 128 ? 1.00 35.72  1 
+ATOM   969  C C   . PRO A 1 128 27.943 57.745  16.524 A 128 ? 1.00 39.27  1 
+ATOM   970  O O   . PRO A 1 128 28.805 57.752  17.407 A 128 ? 1.00 46.54  1 
+ATOM   971  C CB  . PRO A 1 128 28.277 59.143  14.438 A 128 ? 1.00 36.83  1 
+ATOM   972  C CG  . PRO A 1 128 27.812 58.895  13.050 A 128 ? 1.00 36.86  1 
+ATOM   973  C CD  . PRO A 1 128 26.822 57.781  13.235 A 128 ? 1.00 36.44  1 
+ATOM   974  N N   . SER A 1 129 26.656 57.667  16.849 A 129 ? 1.00 35.27  1 
+ATOM   975  C CA  . SER A 1 129 26.333 57.776  18.239 A 129 ? 1.00 23.47  1 
+ATOM   976  C C   . SER A 1 129 25.926 56.464  18.824 A 129 ? 1.00 32.54  1 
+ATOM   977  O O   . SER A 1 129 25.808 56.334  20.061 A 129 ? 1.00 35.53  1 
+ATOM   978  C CB  . SER A 1 129 25.223 58.760  18.417 A 129 ? 1.00 30.16  1 
+ATOM   979  O OG  . SER A 1 129 24.044 58.377  17.705 A 129 ? 1.00 35.12  1 
+ATOM   980  N N   . GLY A 1 130 25.612 55.532  17.923 A 130 ? 1.00 26.18  1 
+ATOM   981  C CA  . GLY A 1 130 25.086 54.264  18.402 A 130 ? 1.00 31.57  1 
+ATOM   982  C C   . GLY A 1 130 23.598 54.425  18.751 A 130 ? 1.00 32.35  1 
+ATOM   983  O O   . GLY A 1 130 23.027 53.495  19.323 A 130 ? 1.00 34.98  1 
+ATOM   984  N N   . ARG A 1 131 22.885 55.539  18.455 A 131 ? 1.00 30.74  1 
+ATOM   985  C CA  . ARG A 1 131 21.452 55.561  18.766 A 131 ? 1.00 23.71  1 
+ATOM   986  C C   . ARG A 1 131 20.753 54.602  17.792 A 131 ? 1.00 24.28  1 
+ATOM   987  O O   . ARG A 1 131 21.124 54.515  16.607 A 131 ? 1.00 21.25  1 
+ATOM   988  C CB  . ARG A 1 131 20.834 56.943  18.600 A 131 ? 1.00 22.87  1 
+ATOM   989  C CG  . ARG A 1 131 21.186 57.787  19.786 A 131 ? 1.00 25.33  1 
+ATOM   990  C CD  . ARG A 1 131 20.561 59.179  19.746 A 131 ? 1.00 31.06  1 
+ATOM   991  N NE  . ARG A 1 131 21.221 59.976  18.723 A 131 ? 1.00 30.64  1 
+ATOM   992  C CZ  . ARG A 1 131 22.354 60.630  18.959 A 131 ? 1.00 29.68  1 
+ATOM   993  N NH1 . ARG A 1 131 22.938 60.617  20.160 A 131 ? 1.00 30.29  1 
+ATOM   994  N NH2 . ARG A 1 131 22.908 61.281  17.947 A 131 ? 1.00 23.08  1 
+ATOM   995  N N   . VAL A 1 132 19.743 53.897  18.296 A 132 ? 1.00 24.42  1 
+ATOM   996  C CA  . VAL A 1 132 18.996 52.896  17.538 A 132 ? 1.00 19.01  1 
+ATOM   997  C C   . VAL A 1 132 17.477 53.158  17.515 A 132 ? 1.00 13.30  1 
+ATOM   998  O O   . VAL A 1 132 16.814 53.564  18.478 A 132 ? 1.00 14.89  1 
+ATOM   999  C CB  . VAL A 1 132 19.419 51.464  18.159 A 132 ? 1.00 27.21  1 
+ATOM   1000 C CG1 . VAL A 1 132 19.165 51.388  19.655 A 132 ? 1.00 27.91  1 
+ATOM   1001 C CG2 . VAL A 1 132 18.586 50.364  17.565 A 132 ? 1.00 24.25  1 
+ATOM   1002 N N   . TYR A 1 133 16.916 52.890  16.343 A 133 ? 1.00 15.85  1 
+ATOM   1003 C CA  . TYR A 1 133 15.513 53.093  16.026 A 133 ? 1.00 21.52  1 
+ATOM   1004 C C   . TYR A 1 133 14.915 51.820  15.394 A 133 ? 1.00 20.47  1 
+ATOM   1005 O O   . TYR A 1 133 15.625 50.920  14.954 A 133 ? 1.00 18.64  1 
+ATOM   1006 C CB  . TYR A 1 133 15.433 54.267  15.027 A 133 ? 1.00 25.21  1 
+ATOM   1007 C CG  . TYR A 1 133 16.013 55.579  15.528 A 133 ? 1.00 27.60  1 
+ATOM   1008 C CD1 . TYR A 1 133 15.224 56.455  16.286 A 133 ? 1.00 25.53  1 
+ATOM   1009 C CD2 . TYR A 1 133 17.316 55.908  15.188 A 133 ? 1.00 22.73  1 
+ATOM   1010 C CE1 . TYR A 1 133 15.785 57.673  16.667 A 133 ? 1.00 30.03  1 
+ATOM   1011 C CE2 . TYR A 1 133 17.887 57.132  15.588 A 133 ? 1.00 24.54  1 
+ATOM   1012 C CZ  . TYR A 1 133 17.104 58.005  16.323 A 133 ? 1.00 24.88  1 
+ATOM   1013 O OH  . TYR A 1 133 17.628 59.229  16.733 A 133 ? 1.00 25.95  1 
+ATOM   1014 N N   . HIS A 1 134 13.592 51.753  15.260 A 134 ? 1.00 20.27  1 
+ATOM   1015 C CA  . HIS A 1 134 12.920 50.671  14.575 A 134 ? 1.00 19.40  1 
+ATOM   1016 C C   . HIS A 1 134 11.872 51.327  13.699 A 134 ? 1.00 18.72  1 
+ATOM   1017 O O   . HIS A 1 134 11.007 52.053  14.215 A 134 ? 1.00 17.83  1 
+ATOM   1018 C CB  . HIS A 1 134 12.210 49.730  15.557 A 134 ? 1.00 15.32  1 
+ATOM   1019 C CG  . HIS A 1 134 11.706 48.501  14.821 A 134 ? 1.00 21.13  1 
+ATOM   1020 N ND1 . HIS A 1 134 10.556 48.276  14.167 A 134 ? 1.00 22.51  1 
+ATOM   1021 C CD2 . HIS A 1 134 12.468 47.369  14.712 A 134 ? 1.00 18.02  1 
+ATOM   1022 C CE1 . HIS A 1 134 10.613 47.062  13.668 A 134 ? 1.00 22.98  1 
+ATOM   1023 N NE2 . HIS A 1 134 11.757 46.532  13.999 A 134 ? 1.00 24.90  1 
+ATOM   1024 N N   . VAL A 1 135 11.820 50.979  12.420 A 135 ? 1.00 21.45  1 
+ATOM   1025 C CA  . VAL A 1 135 10.854 51.600  11.529 A 135 ? 1.00 24.32  1 
+ATOM   1026 C C   . VAL A 1 135 9.394  51.546  11.945 A 135 ? 1.00 32.49  1 
+ATOM   1027 O O   . VAL A 1 135 8.615  52.427  11.555 A 135 ? 1.00 33.83  1 
+ATOM   1028 C CB  . VAL A 1 135 10.957 51.010  10.116 A 135 ? 1.00 24.25  1 
+ATOM   1029 C CG1 . VAL A 1 135 12.323 51.398  9.568  A 135 ? 1.00 29.33  1 
+ATOM   1030 C CG2 . VAL A 1 135 10.715 49.521  10.097 A 135 ? 1.00 26.30  1 
+ATOM   1031 N N   . LYS A 1 136 9.031  50.478  12.695 A 136 ? 1.00 33.22  1 
+ATOM   1032 C CA  . LYS A 1 136 7.667  50.304  13.237 A 136 ? 1.00 34.28  1 
+ATOM   1033 C C   . LYS A 1 136 7.568  50.589  14.724 A 136 ? 1.00 30.05  1 
+ATOM   1034 O O   . LYS A 1 136 6.735  51.363  15.188 A 136 ? 1.00 32.74  1 
+ATOM   1035 C CB  . LYS A 1 136 7.130  48.860  13.071 A 136 ? 1.00 33.43  1 
+ATOM   1036 C CG  . LYS A 1 136 7.245  48.246  11.697 A 136 ? 1.00 45.05  1 
+ATOM   1037 C CD  . LYS A 1 136 6.950  46.762  11.781 A 136 ? 1.00 55.68  1 
+ATOM   1038 C CE  . LYS A 1 136 6.657  46.207  10.383 A 136 ? 1.00 62.38  1 
+ATOM   1039 N NZ  . LYS A 1 136 6.469  44.763  10.438 A 136 ? 1.00 70.97  1 
+ATOM   1040 N N   . PHE A 1 137 8.501  50.023  15.507 A 137 ? 1.00 27.80  1 
+ATOM   1041 C CA  . PHE A 1 137 8.263  49.977  16.941 A 137 ? 1.00 23.96  1 
+ATOM   1042 C C   . PHE A 1 137 8.764  51.187  17.679 A 137 ? 1.00 23.18  1 
+ATOM   1043 O O   . PHE A 1 137 8.381  51.422  18.832 A 137 ? 1.00 27.47  1 
+ATOM   1044 C CB  . PHE A 1 137 8.914  48.710  17.552 A 137 ? 1.00 22.50  1 
+ATOM   1045 C CG  . PHE A 1 137 8.346  47.450  16.934 A 137 ? 1.00 32.69  1 
+ATOM   1046 C CD1 . PHE A 1 137 6.992  47.346  16.631 A 137 ? 1.00 36.01  1 
+ATOM   1047 C CD2 . PHE A 1 137 9.194  46.386  16.624 A 137 ? 1.00 36.10  1 
+ATOM   1048 C CE1 . PHE A 1 137 6.489  46.191  16.029 A 137 ? 1.00 37.80  1 
+ATOM   1049 C CE2 . PHE A 1 137 8.688  45.235  16.023 A 137 ? 1.00 35.51  1 
+ATOM   1050 C CZ  . PHE A 1 137 7.333  45.131  15.713 A 137 ? 1.00 32.08  1 
+ATOM   1051 N N   . ASN A 1 138 9.642  51.947  17.056 A 138 ? 1.00 20.34  1 
+ATOM   1052 C CA  . ASN A 1 138 10.221 53.056  17.749 A 138 ? 1.00 23.14  1 
+ATOM   1053 C C   . ASN A 1 138 10.871 53.923  16.696 A 138 ? 1.00 25.33  1 
+ATOM   1054 O O   . ASN A 1 138 12.104 54.056  16.622 A 138 ? 1.00 24.22  1 
+ATOM   1055 C CB  . ASN A 1 138 11.246 52.544  18.729 A 138 ? 1.00 25.40  1 
+ATOM   1056 C CG  . ASN A 1 138 11.698 53.585  19.740 A 138 ? 1.00 30.80  1 
+ATOM   1057 O OD1 . ASN A 1 138 12.777 53.462  20.329 A 138 ? 1.00 31.43  1 
+ATOM   1058 N ND2 . ASN A 1 138 10.944 54.633  20.051 A 138 ? 1.00 31.30  1 
+ATOM   1059 N N   . PRO A 1 139 10.068 54.516  15.808 A 139 ? 1.00 25.18  1 
+ATOM   1060 C CA  . PRO A 1 139 10.584 55.204  14.637 A 139 ? 1.00 26.60  1 
+ATOM   1061 C C   . PRO A 1 139 11.249 56.549  14.973 A 139 ? 1.00 28.04  1 
+ATOM   1062 O O   . PRO A 1 139 10.957 57.118  16.053 A 139 ? 1.00 20.41  1 
+ATOM   1063 C CB  . PRO A 1 139 9.361  55.282  13.743 A 139 ? 1.00 24.06  1 
+ATOM   1064 C CG  . PRO A 1 139 8.226  55.412  14.673 A 139 ? 1.00 25.14  1 
+ATOM   1065 C CD  . PRO A 1 139 8.622  54.613  15.916 A 139 ? 1.00 25.14  1 
+ATOM   1066 N N   . PRO A 1 140 12.156 57.097  14.143 A 140 ? 1.00 21.89  1 
+ATOM   1067 C CA  . PRO A 1 140 12.639 58.484  14.325 A 140 ? 1.00 24.94  1 
+ATOM   1068 C C   . PRO A 1 140 11.489 59.513  14.106 A 140 ? 1.00 32.79  1 
+ATOM   1069 O O   . PRO A 1 140 10.477 59.167  13.475 A 140 ? 1.00 33.82  1 
+ATOM   1070 C CB  . PRO A 1 140 13.777 58.555  13.334 A 140 ? 1.00 14.35  1 
+ATOM   1071 C CG  . PRO A 1 140 13.249 57.750  12.177 A 140 ? 1.00 18.38  1 
+ATOM   1072 C CD  . PRO A 1 140 12.651 56.529  12.894 A 140 ? 1.00 22.17  1 
+ATOM   1073 N N   . LYS A 1 141 11.577 60.786  14.571 A 141 ? 1.00 33.28  1 
+ATOM   1074 C CA  . LYS A 1 141 10.533 61.820  14.450 A 141 ? 1.00 28.49  1 
+ATOM   1075 C C   . LYS A 1 141 10.428 62.236  13.006 A 141 ? 1.00 20.79  1 
+ATOM   1076 O O   . LYS A 1 141 9.377  62.640  12.524 A 141 ? 1.00 34.52  1 
+ATOM   1077 C CB  . LYS A 1 141 10.883 63.022  15.357 A 141 ? 1.00 28.74  1 
+ATOM   1078 C CG  . LYS A 1 141 10.754 62.565  16.817 A 141 ? 1.00 28.76  1 
+ATOM   1079 C CD  . LYS A 1 141 11.473 63.536  17.715 A 141 ? 1.00 39.32  1 
+ATOM   1080 C CE  . LYS A 1 141 11.519 63.023  19.151 A 141 ? 1.00 53.53  1 
+ATOM   1081 N NZ  . LYS A 1 141 12.323 63.885  20.020 A 141 ? 1.00 60.63  1 
+ATOM   1082 N N   . VAL A 1 142 11.505 62.114  12.251 A 142 ? 1.00 20.02  1 
+ATOM   1083 C CA  . VAL A 1 142 11.505 62.370  10.828 A 142 ? 1.00 28.18  1 
+ATOM   1084 C C   . VAL A 1 142 12.110 61.082  10.227 A 142 ? 1.00 31.10  1 
+ATOM   1085 O O   . VAL A 1 142 13.252 60.661  10.498 A 142 ? 1.00 27.90  1 
+ATOM   1086 C CB  . VAL A 1 142 12.377 63.646  10.539 A 142 ? 1.00 28.28  1 
+ATOM   1087 C CG1 . VAL A 1 142 12.325 63.850  9.046  A 142 ? 1.00 29.42  1 
+ATOM   1088 C CG2 . VAL A 1 142 11.957 64.872  11.407 A 142 ? 1.00 26.80  1 
+ATOM   1089 N N   . GLU A 1 143 11.321 60.416  9.410  A 143 ? 1.00 31.49  1 
+ATOM   1090 C CA  . GLU A 1 143 11.718 59.172  8.801  A 143 ? 1.00 41.64  1 
+ATOM   1091 C C   . GLU A 1 143 13.096 59.198  8.139  A 143 ? 1.00 41.12  1 
+ATOM   1092 O O   . GLU A 1 143 13.448 60.073  7.340  A 143 ? 1.00 44.60  1 
+ATOM   1093 C CB  . GLU A 1 143 10.606 58.810  7.824  A 143 ? 1.00 53.24  1 
+ATOM   1094 C CG  . GLU A 1 143 10.749 57.508  7.007  A 143 ? 1.00 73.66  1 
+ATOM   1095 C CD  . GLU A 1 143 9.483  57.011  6.281  A 143 ? 1.00 82.01  1 
+ATOM   1096 O OE1 . GLU A 1 143 8.626  57.820  5.890  A 143 ? 1.00 83.52  1 
+ATOM   1097 O OE2 . GLU A 1 143 9.362  55.790  6.107  A 143 ? 1.00 87.59  1 
+ATOM   1098 N N   . GLY A 1 144 13.927 58.251  8.571  A 144 ? 1.00 38.69  1 
+ATOM   1099 C CA  . GLY A 1 144 15.260 58.064  8.028  A 144 ? 1.00 23.85  1 
+ATOM   1100 C C   . GLY A 1 144 16.320 58.957  8.633  A 144 ? 1.00 24.25  1 
+ATOM   1101 O O   . GLY A 1 144 17.474 58.897  8.193  A 144 ? 1.00 25.77  1 
+ATOM   1102 N N   . LYS A 1 145 16.033 59.770  9.638  A 145 ? 1.00 26.01  1 
+ATOM   1103 C CA  . LYS A 1 145 17.037 60.722  10.089 A 145 ? 1.00 28.67  1 
+ATOM   1104 C C   . LYS A 1 145 17.154 60.573  11.575 A 145 ? 1.00 27.94  1 
+ATOM   1105 O O   . LYS A 1 145 16.188 60.303  12.293 A 145 ? 1.00 28.01  1 
+ATOM   1106 C CB  . LYS A 1 145 16.659 62.186  9.822  A 145 ? 1.00 27.19  1 
+ATOM   1107 C CG  . LYS A 1 145 16.244 62.558  8.408  A 145 ? 1.00 27.14  1 
+ATOM   1108 C CD  . LYS A 1 145 17.425 62.505  7.529  A 145 ? 1.00 24.35  1 
+ATOM   1109 C CE  . LYS A 1 145 16.816 62.743  6.193  A 145 ? 1.00 28.27  1 
+ATOM   1110 N NZ  . LYS A 1 145 17.869 62.607  5.232  A 145 ? 1.00 23.85  1 
+ATOM   1111 N N   . ASP A 1 146 18.354 60.773  12.087 A 146 ? 1.00 26.12  1 
+ATOM   1112 C CA  . ASP A 1 146 18.527 60.716  13.497 A 146 ? 1.00 28.76  1 
+ATOM   1113 C C   . ASP A 1 146 17.902 61.992  14.096 A 146 ? 1.00 30.04  1 
+ATOM   1114 O O   . ASP A 1 146 18.118 63.080  13.573 A 146 ? 1.00 34.21  1 
+ATOM   1115 C CB  . ASP A 1 146 20.019 60.587  13.695 A 146 ? 1.00 23.57  1 
+ATOM   1116 C CG  . ASP A 1 146 20.437 60.730  15.135 A 146 ? 1.00 28.55  1 
+ATOM   1117 O OD1 . ASP A 1 146 20.070 59.919  15.991 A 146 ? 1.00 28.50  1 
+ATOM   1118 O OD2 . ASP A 1 146 21.164 61.676  15.393 A 146 ? 1.00 31.43  1 
+ATOM   1119 N N   . ASP A 1 147 17.190 61.879  15.213 A 147 ? 1.00 30.22  1 
+ATOM   1120 C CA  . ASP A 1 147 16.517 62.933  15.961 A 147 ? 1.00 35.16  1 
+ATOM   1121 C C   . ASP A 1 147 17.370 64.106  16.391 A 147 ? 1.00 41.54  1 
+ATOM   1122 O O   . ASP A 1 147 16.985 65.266  16.259 A 147 ? 1.00 47.42  1 
+ATOM   1123 C CB  . ASP A 1 147 15.898 62.337  17.210 A 147 ? 1.00 28.79  1 
+ATOM   1124 C CG  . ASP A 1 147 14.693 61.426  16.990 A 147 ? 1.00 26.78  1 
+ATOM   1125 O OD1 . ASP A 1 147 14.242 61.247  15.880 A 147 ? 1.00 26.62  1 
+ATOM   1126 O OD2 . ASP A 1 147 14.187 60.871  17.943 A 147 ? 1.00 33.87  1 
+ATOM   1127 N N   . VAL A 1 148 18.572 63.785  16.853 A 148 ? 1.00 38.44  1 
+ATOM   1128 C CA  . VAL A 1 148 19.530 64.752  17.344 A 148 ? 1.00 35.46  1 
+ATOM   1129 C C   . VAL A 1 148 20.308 65.445  16.239 A 148 ? 1.00 32.92  1 
+ATOM   1130 O O   . VAL A 1 148 20.359 66.663  16.142 A 148 ? 1.00 41.42  1 
+ATOM   1131 C CB  . VAL A 1 148 20.453 63.990  18.325 A 148 ? 1.00 36.53  1 
+ATOM   1132 C CG1 . VAL A 1 148 21.535 64.842  18.981 A 148 ? 1.00 43.62  1 
+ATOM   1133 C CG2 . VAL A 1 148 19.558 63.529  19.462 A 148 ? 1.00 33.95  1 
+ATOM   1134 N N   . THR A 1 149 20.915 64.727  15.344 A 149 ? 1.00 29.89  1 
+ATOM   1135 C CA  . THR A 1 149 21.763 65.360  14.392 A 149 ? 1.00 28.74  1 
+ATOM   1136 C C   . THR A 1 149 21.109 65.528  13.059 A 149 ? 1.00 33.15  1 
+ATOM   1137 O O   . THR A 1 149 21.721 66.135  12.166 A 149 ? 1.00 33.44  1 
+ATOM   1138 C CB  . THR A 1 149 23.067 64.545  14.212 A 149 ? 1.00 27.75  1 
+ATOM   1139 O OG1 . THR A 1 149 22.740 63.377  13.487 A 149 ? 1.00 29.08  1 
+ATOM   1140 C CG2 . THR A 1 149 23.714 64.169  15.499 A 149 ? 1.00 23.53  1 
+ATOM   1141 N N   . GLY A 1 150 19.955 64.916  12.789 A 150 ? 1.00 30.36  1 
+ATOM   1142 C CA  . GLY A 1 150 19.389 65.023  11.444 A 150 ? 1.00 26.99  1 
+ATOM   1143 C C   . GLY A 1 150 20.135 64.251  10.365 A 150 ? 1.00 25.62  1 
+ATOM   1144 O O   . GLY A 1 150 19.877 64.351  9.159  A 150 ? 1.00 29.50  1 
+ATOM   1145 N N   . GLU A 1 151 21.081 63.418  10.801 A 151 ? 1.00 30.76  1 
+ATOM   1146 C CA  . GLU A 1 151 21.826 62.570  9.898  A 151 ? 1.00 31.74  1 
+ATOM   1147 C C   . GLU A 1 151 21.047 61.311  9.535  A 151 ? 1.00 29.22  1 
+ATOM   1148 O O   . GLU A 1 151 20.270 60.766  10.319 A 151 ? 1.00 26.44  1 
+ATOM   1149 C CB  . GLU A 1 151 23.117 62.205  10.560 A 151 ? 1.00 35.83  1 
+ATOM   1150 C CG  . GLU A 1 151 24.145 63.317  10.561 A 151 ? 1.00 42.57  1 
+ATOM   1151 C CD  . GLU A 1 151 25.317 63.047  11.493 A 151 ? 1.00 52.40  1 
+ATOM   1152 O OE1 . GLU A 1 151 25.895 61.969  11.408 A 151 ? 1.00 59.87  1 
+ATOM   1153 O OE2 . GLU A 1 151 25.664 63.907  12.303 A 151 ? 1.00 63.32  1 
+ATOM   1154 N N   . GLU A 1 152 21.328 60.861  8.327  A 152 ? 1.00 29.78  1 
+ATOM   1155 C CA  . GLU A 1 152 20.683 59.723  7.720  A 152 ? 1.00 40.41  1 
+ATOM   1156 C C   . GLU A 1 152 20.987 58.437  8.522  A 152 ? 1.00 41.63  1 
+ATOM   1157 O O   . GLU A 1 152 22.117 58.203  9.003  A 152 ? 1.00 47.05  1 
+ATOM   1158 C CB  . GLU A 1 152 21.194 59.697  6.283  A 152 ? 1.00 39.69  1 
+ATOM   1159 C CG  . GLU A 1 152 20.390 58.891  5.261  A 152 ? 1.00 52.14  1 
+ATOM   1160 C CD  . GLU A 1 152 19.048 59.446  4.773  A 152 ? 1.00 56.13  1 
+ATOM   1161 O OE1 . GLU A 1 152 18.109 59.534  5.550  A 152 ? 1.00 54.04  1 
+ATOM   1162 O OE2 . GLU A 1 152 18.918 59.765  3.590  A 152 ? 1.00 67.86  1 
+ATOM   1163 N N   . LEU A 1 153 19.934 57.666  8.790  A 153 ? 1.00 33.23  1 
+ATOM   1164 C CA  . LEU A 1 153 20.090 56.412  9.516  A 153 ? 1.00 33.73  1 
+ATOM   1165 C C   . LEU A 1 153 20.514 55.309  8.534  A 153 ? 1.00 37.08  1 
+ATOM   1166 O O   . LEU A 1 153 20.252 55.401  7.326  A 153 ? 1.00 35.21  1 
+ATOM   1167 C CB  . LEU A 1 153 18.781 56.079  10.188 A 153 ? 1.00 25.04  1 
+ATOM   1168 C CG  . LEU A 1 153 18.374 57.112  11.221 A 153 ? 1.00 19.61  1 
+ATOM   1169 C CD1 . LEU A 1 153 17.029 56.729  11.739 A 153 ? 1.00 22.29  1 
+ATOM   1170 C CD2 . LEU A 1 153 19.407 57.231  12.302 A 153 ? 1.00 19.25  1 
+ATOM   1171 N N   . THR A 1 154 21.202 54.249  8.973  A 154 ? 1.00 32.66  1 
+ATOM   1172 C CA  . THR A 1 154 21.658 53.190  8.095  A 154 ? 1.00 25.57  1 
+ATOM   1173 C C   . THR A 1 154 21.204 51.862  8.721  A 154 ? 1.00 28.71  1 
+ATOM   1174 O O   . THR A 1 154 20.647 51.837  9.850  A 154 ? 1.00 22.81  1 
+ATOM   1175 C CB  . THR A 1 154 23.240 53.250  7.944  A 154 ? 1.00 24.18  1 
+ATOM   1176 O OG1 . THR A 1 154 23.887 53.318  9.212  A 154 ? 1.00 25.95  1 
+ATOM   1177 C CG2 . THR A 1 154 23.697 54.526  7.287  A 154 ? 1.00 32.42  1 
+ATOM   1178 N N   . THR A 1 155 21.420 50.764  7.992  A 155 ? 1.00 22.86  1 
+ATOM   1179 C CA  . THR A 1 155 21.171 49.444  8.553  A 155 ? 1.00 29.13  1 
+ATOM   1180 C C   . THR A 1 155 22.511 48.807  8.882  A 155 ? 1.00 23.46  1 
+ATOM   1181 O O   . THR A 1 155 23.544 49.124  8.298  A 155 ? 1.00 33.84  1 
+ATOM   1182 C CB  . THR A 1 155 20.398 48.630  7.547  A 155 ? 1.00 23.33  1 
+ATOM   1183 O OG1 . THR A 1 155 21.165 48.608  6.369  A 155 ? 1.00 36.29  1 
+ATOM   1184 C CG2 . THR A 1 155 19.135 49.291  7.127  A 155 ? 1.00 26.67  1 
+ATOM   1185 N N   . ARG A 1 156 22.602 47.980  9.890  A 156 ? 1.00 24.19  1 
+ATOM   1186 C CA  . ARG A 1 156 23.818 47.270  10.158 A 156 ? 1.00 29.74  1 
+ATOM   1187 C C   . ARG A 1 156 23.937 46.129  9.152  A 156 ? 1.00 30.49  1 
+ATOM   1188 O O   . ARG A 1 156 22.965 45.487  8.692  A 156 ? 1.00 25.60  1 
+ATOM   1189 C CB  . ARG A 1 156 23.770 46.767  11.585 A 156 ? 1.00 29.92  1 
+ATOM   1190 C CG  . ARG A 1 156 24.197 47.879  12.528 A 156 ? 1.00 29.70  1 
+ATOM   1191 C CD  . ARG A 1 156 24.163 47.484  13.977 A 156 ? 1.00 32.72  1 
+ATOM   1192 N NE  . ARG A 1 156 24.554 46.097  14.182 A 156 ? 1.00 23.91  1 
+ATOM   1193 C CZ  . ARG A 1 156 24.321 45.507  15.337 A 156 ? 1.00 22.39  1 
+ATOM   1194 N NH1 . ARG A 1 156 23.810 46.190  16.331 A 156 ? 1.00 18.90  1 
+ATOM   1195 N NH2 . ARG A 1 156 24.583 44.231  15.522 A 156 ? 1.00 21.23  1 
+ATOM   1196 N N   . LYS A 1 157 25.209 45.893  8.840  A 157 ? 1.00 30.14  1 
+ATOM   1197 C CA  . LYS A 1 157 25.618 44.885  7.852  A 157 ? 1.00 36.32  1 
+ATOM   1198 C C   . LYS A 1 157 25.246 43.470  8.313  A 157 ? 1.00 34.85  1 
+ATOM   1199 O O   . LYS A 1 157 24.904 42.622  7.505  A 157 ? 1.00 29.40  1 
+ATOM   1200 C CB  . LYS A 1 157 27.139 44.916  7.632  A 157 ? 1.00 45.21  1 
+ATOM   1201 C CG  . LYS A 1 157 27.925 46.171  7.166  A 157 ? 1.00 66.21  1 
+ATOM   1202 C CD  . LYS A 1 157 27.832 47.491  7.978  A 157 ? 1.00 69.30  1 
+ATOM   1203 C CE  . LYS A 1 157 28.295 47.435  9.433  A 157 ? 1.00 67.90  1 
+ATOM   1204 N NZ  . LYS A 1 157 27.330 48.130  10.268 A 157 ? 1.00 59.59  1 
+ATOM   1205 N N   . ASP A 1 158 25.330 43.207  9.631  A 158 ? 1.00 27.72  1 
+ATOM   1206 C CA  . ASP A 1 158 25.037 41.923  10.230 A 158 ? 1.00 22.58  1 
+ATOM   1207 C C   . ASP A 1 158 23.558 41.788  10.628 A 158 ? 1.00 23.77  1 
+ATOM   1208 O O   . ASP A 1 158 23.137 40.888  11.347 A 158 ? 1.00 23.52  1 
+ATOM   1209 C CB  . ASP A 1 158 26.023 41.808  11.400 A 158 ? 1.00 18.63  1 
+ATOM   1210 C CG  . ASP A 1 158 25.801 42.776  12.548 A 158 ? 1.00 25.36  1 
+ATOM   1211 O OD1 . ASP A 1 158 25.283 43.851  12.308 A 158 ? 1.00 23.75  1 
+ATOM   1212 O OD2 . ASP A 1 158 26.141 42.476  13.699 A 158 ? 1.00 22.19  1 
+ATOM   1213 N N   . ASP A 1 159 22.670 42.699  10.221 A 159 ? 1.00 22.20  1 
+ATOM   1214 C CA  . ASP A 1 159 21.262 42.561  10.522 A 159 ? 1.00 22.82  1 
+ATOM   1215 C C   . ASP A 1 159 20.494 42.016  9.332  A 159 ? 1.00 33.97  1 
+ATOM   1216 O O   . ASP A 1 159 19.650 42.689  8.724  A 159 ? 1.00 48.79  1 
+ATOM   1217 C CB  . ASP A 1 159 20.648 43.890  10.940 A 159 ? 1.00 24.27  1 
+ATOM   1218 C CG  . ASP A 1 159 21.002 44.350  12.347 A 159 ? 1.00 25.38  1 
+ATOM   1219 O OD1 . ASP A 1 159 21.619 43.630  13.123 A 159 ? 1.00 21.20  1 
+ATOM   1220 O OD2 . ASP A 1 159 20.672 45.479  12.638 A 159 ? 1.00 21.21  1 
+ATOM   1221 N N   . GLN A 1 160 20.899 40.828  8.874  A 160 ? 1.00 44.86  1 
+ATOM   1222 C CA  . GLN A 1 160 20.054 40.082  7.944  A 160 ? 1.00 46.67  1 
+ATOM   1223 C C   . GLN A 1 160 19.689 38.809  8.687  A 160 ? 1.00 40.62  1 
+ATOM   1224 O O   . GLN A 1 160 20.435 38.358  9.585  A 160 ? 1.00 30.26  1 
+ATOM   1225 C CB  . GLN A 1 160 20.728 39.640  6.676  A 160 ? 1.00 58.15  1 
+ATOM   1226 C CG  . GLN A 1 160 21.152 40.744  5.745  A 160 ? 1.00 71.86  1 
+ATOM   1227 C CD  . GLN A 1 160 22.649 40.914  5.852  A 160 ? 1.00 83.20  1 
+ATOM   1228 O OE1 . GLN A 1 160 23.385 40.029  6.315  A 160 ? 1.00 85.76  1 
+ATOM   1229 N NE2 . GLN A 1 160 23.142 42.076  5.456  A 160 ? 1.00 94.35  1 
+ATOM   1230 N N   . GLU A 1 161 18.553 38.261  8.255  A 161 ? 1.00 33.46  1 
+ATOM   1231 C CA  . GLU A 1 161 17.942 37.066  8.799  A 161 ? 1.00 29.44  1 
+ATOM   1232 C C   . GLU A 1 161 18.925 35.929  9.092  A 161 ? 1.00 30.28  1 
+ATOM   1233 O O   . GLU A 1 161 18.945 35.421  10.227 A 161 ? 1.00 26.51  1 
+ATOM   1234 C CB  . GLU A 1 161 16.920 36.733  7.795  A 161 ? 1.00 32.95  1 
+ATOM   1235 C CG  . GLU A 1 161 15.999 35.552  8.012  A 161 ? 1.00 53.23  1 
+ATOM   1236 C CD  . GLU A 1 161 14.748 35.661  7.126  A 161 ? 1.00 67.25  1 
+ATOM   1237 O OE1 . GLU A 1 161 14.858 35.852  5.898  A 161 ? 1.00 72.00  1 
+ATOM   1238 O OE2 . GLU A 1 161 13.649 35.573  7.684  A 161 ? 1.00 71.74  1 
+ATOM   1239 N N   . GLU A 1 162 19.847 35.559  8.181  A 162 ? 1.00 25.87  1 
+ATOM   1240 C CA  . GLU A 1 162 20.712 34.443  8.506  A 162 ? 1.00 25.40  1 
+ATOM   1241 C C   . GLU A 1 162 21.809 34.739  9.498  A 162 ? 1.00 27.85  1 
+ATOM   1242 O O   . GLU A 1 162 22.129 33.853  10.290 A 162 ? 1.00 26.83  1 
+ATOM   1243 C CB  . GLU A 1 162 21.297 33.885  7.242  A 162 ? 1.00 38.07  1 
+ATOM   1244 C CG  . GLU A 1 162 20.162 33.253  6.378  A 162 ? 1.00 66.76  1 
+ATOM   1245 C CD  . GLU A 1 162 19.068 32.377  7.051  A 162 ? 1.00 77.76  1 
+ATOM   1246 O OE1 . GLU A 1 162 19.372 31.314  7.615  A 162 ? 1.00 76.86  1 
+ATOM   1247 O OE2 . GLU A 1 162 17.891 32.766  6.989  A 162 ? 1.00 82.71  1 
+ATOM   1248 N N   . THR A 1 163 22.382 35.951  9.529  A 163 ? 1.00 24.33  1 
+ATOM   1249 C CA  . THR A 1 163 23.378 36.312  10.514 A 163 ? 1.00 17.27  1 
+ATOM   1250 C C   . THR A 1 163 22.699 36.426  11.855 A 163 ? 1.00 14.23  1 
+ATOM   1251 O O   . THR A 1 163 23.332 35.982  12.797 A 163 ? 1.00 18.16  1 
+ATOM   1252 C CB  . THR A 1 163 24.024 37.637  10.229 A 163 ? 1.00 22.22  1 
+ATOM   1253 O OG1 . THR A 1 163 24.370 37.534  8.871  A 163 ? 1.00 23.93  1 
+ATOM   1254 C CG2 . THR A 1 163 25.227 37.972  11.077 A 163 ? 1.00 18.66  1 
+ATOM   1255 N N   . VAL A 1 164 21.460 36.915  11.989 A 164 ? 1.00 17.85  1 
+ATOM   1256 C CA  . VAL A 1 164 20.732 36.952  13.256 A 164 ? 1.00 20.38  1 
+ATOM   1257 C C   . VAL A 1 164 20.535 35.509  13.773 A 164 ? 1.00 18.27  1 
+ATOM   1258 O O   . VAL A 1 164 20.627 35.211  14.964 A 164 ? 1.00 15.67  1 
+ATOM   1259 C CB  . VAL A 1 164 19.358 37.625  12.994 A 164 ? 1.00 28.64  1 
+ATOM   1260 C CG1 . VAL A 1 164 18.500 37.663  14.231 A 164 ? 1.00 25.70  1 
+ATOM   1261 C CG2 . VAL A 1 164 19.575 39.045  12.591 A 164 ? 1.00 32.10  1 
+ATOM   1262 N N   . ARG A 1 165 20.189 34.559  12.910 A 165 ? 1.00 18.98  1 
+ATOM   1263 C CA  . ARG A 1 165 20.001 33.162  13.347 A 165 ? 1.00 21.55  1 
+ATOM   1264 C C   . ARG A 1 165 21.249 32.540  13.966 A 165 ? 1.00 22.72  1 
+ATOM   1265 O O   . ARG A 1 165 21.232 31.882  15.043 A 165 ? 1.00 23.45  1 
+ATOM   1266 C CB  . ARG A 1 165 19.529 32.365  12.146 A 165 ? 1.00 28.98  1 
+ATOM   1267 C CG  . ARG A 1 165 18.077 32.631  12.181 A 165 ? 1.00 42.85  1 
+ATOM   1268 C CD  . ARG A 1 165 17.291 31.953  11.104 A 165 ? 1.00 62.01  1 
+ATOM   1269 N NE  . ARG A 1 165 15.902 32.196  11.468 A 165 ? 1.00 80.24  1 
+ATOM   1270 C CZ  . ARG A 1 165 14.909 32.325  10.581 A 165 ? 1.00 88.22  1 
+ATOM   1271 N NH1 . ARG A 1 165 15.099 32.226  9.250  A 165 ? 1.00 91.07  1 
+ATOM   1272 N NH2 . ARG A 1 165 13.692 32.568  11.074 A 165 ? 1.00 91.78  1 
+ATOM   1273 N N   . LYS A 1 166 22.365 32.880  13.294 A 166 ? 1.00 16.12  1 
+ATOM   1274 C CA  . LYS A 1 166 23.644 32.450  13.793 A 166 ? 1.00 19.19  1 
+ATOM   1275 C C   . LYS A 1 166 23.895 33.093  15.129 A 166 ? 1.00 17.78  1 
+ATOM   1276 O O   . LYS A 1 166 24.266 32.386  16.088 A 166 ? 1.00 17.47  1 
+ATOM   1277 C CB  . LYS A 1 166 24.755 32.828  12.834 A 166 ? 1.00 32.39  1 
+ATOM   1278 C CG  . LYS A 1 166 24.691 31.972  11.575 A 166 ? 1.00 44.21  1 
+ATOM   1279 C CD  . LYS A 1 166 25.711 32.369  10.502 A 166 ? 1.00 56.21  1 
+ATOM   1280 C CE  . LYS A 1 166 25.353 31.635  9.208  A 166 ? 1.00 67.75  1 
+ATOM   1281 N NZ  . LYS A 1 166 26.274 31.961  8.135  A 166 ? 1.00 77.81  1 
+ATOM   1282 N N   . ARG A 1 167 23.637 34.403  15.257 A 167 ? 1.00 14.61  1 
+ATOM   1283 C CA  . ARG A 1 167 23.859 35.071  16.525 A 167 ? 1.00 15.89  1 
+ATOM   1284 C C   . ARG A 1 167 22.992 34.466  17.608 A 167 ? 1.00 16.26  1 
+ATOM   1285 O O   . ARG A 1 167 23.486 34.362  18.729 A 167 ? 1.00 16.68  1 
+ATOM   1286 C CB  . ARG A 1 167 23.527 36.558  16.451 A 167 ? 1.00 20.63  1 
+ATOM   1287 C CG  . ARG A 1 167 24.499 37.362  15.615 A 167 ? 1.00 19.15  1 
+ATOM   1288 C CD  A ARG A 1 167 24.502 38.811  16.129 A 167 ? 0.50 24.49  1 
+ATOM   1289 C CD  B ARG A 1 167 24.690 38.671  16.294 A 167 ? 0.50 23.17  1 
+ATOM   1290 N NE  A ARG A 1 167 23.377 39.692  15.806 A 167 ? 0.50 23.32  1 
+ATOM   1291 N NE  B ARG A 1 167 23.697 39.706  16.111 A 167 ? 0.50 24.59  1 
+ATOM   1292 C CZ  A ARG A 1 167 23.342 40.399  14.676 A 167 ? 0.50 16.77  1 
+ATOM   1293 C CZ  B ARG A 1 167 23.245 40.509  17.085 A 167 ? 0.50 23.03  1 
+ATOM   1294 N NH1 A ARG A 1 167 24.181 40.144  13.699 A 167 ? 0.50 27.31  1 
+ATOM   1295 N NH1 B ARG A 1 167 23.482 40.319  18.402 A 167 ? 0.50 27.91  1 
+ATOM   1296 N NH2 A ARG A 1 167 22.424 41.308  14.455 A 167 ? 0.50 5.51   1 
+ATOM   1297 N NH2 B ARG A 1 167 22.409 41.488  16.714 A 167 ? 0.50 18.45  1 
+ATOM   1298 N N   . LEU A 1 168 21.736 34.060  17.339 A 168 ? 1.00 18.87  1 
+ATOM   1299 C CA  . LEU A 1 168 20.894 33.428  18.379 A 168 ? 1.00 18.37  1 
+ATOM   1300 C C   . LEU A 1 168 21.418 32.111  18.964 A 168 ? 1.00 15.26  1 
+ATOM   1301 O O   . LEU A 1 168 21.293 31.824  20.148 A 168 ? 1.00 14.59  1 
+ATOM   1302 C CB  . LEU A 1 168 19.541 33.109  17.853 A 168 ? 1.00 19.47  1 
+ATOM   1303 C CG  . LEU A 1 168 18.389 33.876  18.318 A 168 ? 1.00 33.18  1 
+ATOM   1304 C CD1 . LEU A 1 168 17.174 33.001  18.017 A 168 ? 1.00 29.76  1 
+ATOM   1305 C CD2 . LEU A 1 168 18.501 34.209  19.829 A 168 ? 1.00 32.09  1 
+ATOM   1306 N N   . VAL A 1 169 21.925 31.249  18.094 A 169 ? 1.00 26.09  1 
+ATOM   1307 C CA  . VAL A 1 169 22.603 29.993  18.470 A 169 ? 1.00 30.51  1 
+ATOM   1308 C C   . VAL A 1 169 23.842 30.245  19.353 A 169 ? 1.00 22.02  1 
+ATOM   1309 O O   . VAL A 1 169 24.011 29.553  20.374 A 169 ? 1.00 25.50  1 
+ATOM   1310 C CB  . VAL A 1 169 23.019 29.242  17.160 A 169 ? 1.00 27.97  1 
+ATOM   1311 C CG1 . VAL A 1 169 23.878 28.046  17.490 A 169 ? 1.00 25.96  1 
+ATOM   1312 C CG2 . VAL A 1 169 21.780 28.769  16.406 A 169 ? 1.00 23.43  1 
+ATOM   1313 N N   . GLU A 1 170 24.692 31.241  19.012 A 170 ? 1.00 16.54  1 
+ATOM   1314 C CA  . GLU A 1 170 25.889 31.549  19.798 A 170 ? 1.00 18.47  1 
+ATOM   1315 C C   . GLU A 1 170 25.434 32.130  21.117 A 170 ? 1.00 16.07  1 
+ATOM   1316 O O   . GLU A 1 170 26.081 31.833  22.115 A 170 ? 1.00 15.71  1 
+ATOM   1317 C CB  . GLU A 1 170 26.793 32.602  19.179 A 170 ? 1.00 20.83  1 
+ATOM   1318 C CG  . GLU A 1 170 27.357 32.183  17.895 A 170 ? 1.00 26.40  1 
+ATOM   1319 C CD  . GLU A 1 170 28.771 31.674  18.056 A 170 ? 1.00 34.23  1 
+ATOM   1320 O OE1 . GLU A 1 170 29.666 32.406  18.493 A 170 ? 1.00 31.32  1 
+ATOM   1321 O OE2 . GLU A 1 170 28.978 30.523  17.692 A 170 ? 1.00 49.90  1 
+ATOM   1322 N N   . TYR A 1 171 24.354 32.925  21.145 A 171 ? 1.00 14.06  1 
+ATOM   1323 C CA  . TYR A 1 171 23.794 33.424  22.374 A 171 ? 1.00 11.70  1 
+ATOM   1324 C C   . TYR A 1 171 23.393 32.236  23.239 A 171 ? 1.00 10.66  1 
+ATOM   1325 O O   . TYR A 1 171 23.705 32.182  24.426 A 171 ? 1.00 15.53  1 
+ATOM   1326 C CB  . TYR A 1 171 22.586 34.304  22.076 A 171 ? 1.00 8.79   1 
+ATOM   1327 C CG  . TYR A 1 171 21.855 34.686  23.358 A 171 ? 1.00 12.93  1 
+ATOM   1328 C CD1 . TYR A 1 171 22.379 35.655  24.198 A 171 ? 1.00 15.64  1 
+ATOM   1329 C CD2 . TYR A 1 171 20.712 34.037  23.753 A 171 ? 1.00 15.73  1 
+ATOM   1330 C CE1 . TYR A 1 171 21.813 35.981  25.410 A 171 ? 1.00 17.39  1 
+ATOM   1331 C CE2 . TYR A 1 171 20.127 34.341  24.992 A 171 ? 1.00 19.42  1 
+ATOM   1332 C CZ  . TYR A 1 171 20.679 35.318  25.814 A 171 ? 1.00 22.02  1 
+ATOM   1333 O OH  . TYR A 1 171 20.111 35.638  27.042 A 171 ? 1.00 18.14  1 
+ATOM   1334 N N   . HIS A 1 172 22.676 31.248  22.763 A 172 ? 1.00 16.23  1 
+ATOM   1335 C CA  . HIS A 1 172 22.188 30.172  23.627 A 172 ? 1.00 18.45  1 
+ATOM   1336 C C   . HIS A 1 172 23.312 29.286  24.119 A 172 ? 1.00 18.43  1 
+ATOM   1337 O O   . HIS A 1 172 23.372 28.883  25.294 A 172 ? 1.00 18.10  1 
+ATOM   1338 C CB  . HIS A 1 172 21.136 29.341  22.873 A 172 ? 1.00 17.33  1 
+ATOM   1339 C CG  . HIS A 1 172 19.759 29.989  22.906 A 172 ? 1.00 15.22  1 
+ATOM   1340 N ND1 . HIS A 1 172 18.953 30.156  23.953 A 172 ? 1.00 25.05  1 
+ATOM   1341 C CD2 . HIS A 1 172 19.144 30.562  21.809 A 172 ? 1.00 19.89  1 
+ATOM   1342 C CE1 . HIS A 1 172 17.891 30.813  23.549 A 172 ? 1.00 27.06  1 
+ATOM   1343 N NE2 . HIS A 1 172 18.026 31.049  22.258 A 172 ? 1.00 23.50  1 
+ATOM   1344 N N   . GLN A 1 173 24.306 29.134  23.258 A 173 ? 1.00 16.50  1 
+ATOM   1345 C CA  . GLN A 1 173 25.463 28.312  23.673 A 173 ? 1.00 24.75  1 
+ATOM   1346 C C   . GLN A 1 173 26.378 28.959  24.688 A 173 ? 1.00 17.73  1 
+ATOM   1347 O O   . GLN A 1 173 26.768 28.327  25.650 A 173 ? 1.00 21.15  1 
+ATOM   1348 C CB  . GLN A 1 173 26.334 27.911  22.449 A 173 ? 1.00 24.76  1 
+ATOM   1349 C CG  . GLN A 1 173 25.723 26.838  21.571 A 173 ? 1.00 21.25  1 
+ATOM   1350 C CD  . GLN A 1 173 26.438 26.524  20.286 A 173 ? 1.00 35.07  1 
+ATOM   1351 O OE1 . GLN A 1 173 26.463 25.381  19.838 A 173 ? 1.00 42.94  1 
+ATOM   1352 N NE2 . GLN A 1 173 27.046 27.457  19.592 A 173 ? 1.00 35.45  1 
+ATOM   1353 N N   . MET A 1 174 26.696 30.254  24.523 A 174 ? 1.00 26.04  1 
+ATOM   1354 C CA  . MET A 1 174 27.780 30.924  25.231 A 174 ? 1.00 16.63  1 
+ATOM   1355 C C   . MET A 1 174 27.350 31.962  26.189 A 174 ? 1.00 14.52  1 
+ATOM   1356 O O   . MET A 1 174 28.031 32.138  27.194 A 174 ? 1.00 19.50  1 
+ATOM   1357 C CB  . MET A 1 174 28.718 31.680  24.356 A 174 ? 1.00 15.94  1 
+ATOM   1358 C CG  . MET A 1 174 29.289 31.050  23.072 A 174 ? 1.00 38.68  1 
+ATOM   1359 S SD  . MET A 1 174 30.211 29.526  23.399 A 174 ? 1.00 42.51  1 
+ATOM   1360 C CE  . MET A 1 174 31.373 30.185  24.584 A 174 ? 1.00 45.74  1 
+ATOM   1361 N N   . THR A 1 175 26.232 32.646  25.930 A 175 ? 1.00 15.93  1 
+ATOM   1362 C CA  . THR A 1 175 25.882 33.824  26.706 A 175 ? 1.00 20.80  1 
+ATOM   1363 C C   . THR A 1 175 24.768 33.506  27.662 A 175 ? 1.00 22.75  1 
+ATOM   1364 O O   . THR A 1 175 24.838 33.941  28.815 A 175 ? 1.00 19.66  1 
+ATOM   1365 C CB  . THR A 1 175 25.427 35.010  25.806 A 175 ? 1.00 15.05  1 
+ATOM   1366 O OG1 . THR A 1 175 26.434 35.116  24.831 A 175 ? 1.00 15.12  1 
+ATOM   1367 C CG2 . THR A 1 175 25.209 36.343  26.547 A 175 ? 1.00 13.66  1 
+ATOM   1368 N N   . ALA A 1 176 23.791 32.708  27.207 A 176 ? 1.00 17.11  1 
+ATOM   1369 C CA  . ALA A 1 176 22.709 32.326  28.101 A 176 ? 1.00 19.62  1 
+ATOM   1370 C C   . ALA A 1 176 23.182 31.802  29.462 A 176 ? 1.00 18.00  1 
+ATOM   1371 O O   . ALA A 1 176 22.468 32.016  30.452 A 176 ? 1.00 17.46  1 
+ATOM   1372 C CB  . ALA A 1 176 21.839 31.236  27.463 A 176 ? 1.00 25.53  1 
+ATOM   1373 N N   . PRO A 1 177 24.354 31.136  29.583 A 177 ? 1.00 18.68  1 
+ATOM   1374 C CA  . PRO A 1 177 24.840 30.655  30.859 A 177 ? 1.00 22.56  1 
+ATOM   1375 C C   . PRO A 1 177 25.098 31.759  31.872 A 177 ? 1.00 26.32  1 
+ATOM   1376 O O   . PRO A 1 177 25.183 31.459  33.070 A 177 ? 1.00 25.97  1 
+ATOM   1377 C CB  . PRO A 1 177 26.070 29.871  30.484 A 177 ? 1.00 22.51  1 
+ATOM   1378 C CG  . PRO A 1 177 25.742 29.241  29.117 A 177 ? 1.00 20.39  1 
+ATOM   1379 C CD  . PRO A 1 177 25.070 30.405  28.505 A 177 ? 1.00 16.87  1 
+ATOM   1380 N N   . LEU A 1 178 25.280 33.013  31.433 A 178 ? 1.00 17.44  1 
+ATOM   1381 C CA  . LEU A 1 178 25.494 34.116  32.326 A 178 ? 1.00 19.87  1 
+ATOM   1382 C C   . LEU A 1 178 24.251 34.374  33.171 A 178 ? 1.00 22.27  1 
+ATOM   1383 O O   . LEU A 1 178 24.392 34.955  34.262 A 178 ? 1.00 21.74  1 
+ATOM   1384 C CB  . LEU A 1 178 25.871 35.370  31.534 A 178 ? 1.00 20.20  1 
+ATOM   1385 C CG  . LEU A 1 178 27.246 35.357  30.896 A 178 ? 1.00 20.79  1 
+ATOM   1386 C CD1 . LEU A 1 178 27.437 36.608  30.127 A 178 ? 1.00 17.20  1 
+ATOM   1387 C CD2 . LEU A 1 178 28.317 35.341  31.955 A 178 ? 1.00 26.85  1 
+ATOM   1388 N N   . ILE A 1 179 23.041 33.926  32.787 A 179 ? 1.00 20.11  1 
+ATOM   1389 C CA  . ILE A 1 179 21.847 34.121  33.617 A 179 ? 1.00 20.22  1 
+ATOM   1390 C C   . ILE A 1 179 22.043 33.341  34.922 A 179 ? 1.00 18.78  1 
+ATOM   1391 O O   . ILE A 1 179 21.829 33.929  35.978 A 179 ? 1.00 25.03  1 
+ATOM   1392 C CB  . ILE A 1 179 20.563 33.642  32.860 A 179 ? 1.00 19.24  1 
+ATOM   1393 C CG1 . ILE A 1 179 20.330 34.577  31.655 A 179 ? 1.00 19.48  1 
+ATOM   1394 C CG2 . ILE A 1 179 19.359 33.621  33.820 A 179 ? 1.00 15.26  1 
+ATOM   1395 C CD1 . ILE A 1 179 19.363 34.061  30.604 A 179 ? 1.00 26.50  1 
+ATOM   1396 N N   . GLY A 1 180 22.507 32.094  34.879 A 180 ? 1.00 15.40  1 
+ATOM   1397 C CA  . GLY A 1 180 22.743 31.291  36.059 A 180 ? 1.00 21.16  1 
+ATOM   1398 C C   . GLY A 1 180 23.936 31.788  36.861 A 180 ? 1.00 26.48  1 
+ATOM   1399 O O   . GLY A 1 180 23.881 31.828  38.106 A 180 ? 1.00 22.84  1 
+ATOM   1400 N N   . TYR A 1 181 25.001 32.215  36.144 A 181 ? 1.00 24.74  1 
+ATOM   1401 C CA  . TYR A 1 181 26.209 32.813  36.742 A 181 ? 1.00 22.13  1 
+ATOM   1402 C C   . TYR A 1 181 25.873 33.945  37.716 A 181 ? 1.00 18.40  1 
+ATOM   1403 O O   . TYR A 1 181 26.193 33.901  38.911 A 181 ? 1.00 22.35  1 
+ATOM   1404 C CB  . TYR A 1 181 27.140 33.355  35.625 A 181 ? 1.00 21.69  1 
+ATOM   1405 C CG  . TYR A 1 181 28.489 33.927  36.089 A 181 ? 1.00 23.52  1 
+ATOM   1406 C CD1 . TYR A 1 181 28.603 35.224  36.552 A 181 ? 1.00 19.96  1 
+ATOM   1407 C CD2 . TYR A 1 181 29.618 33.116  36.045 A 181 ? 1.00 26.38  1 
+ATOM   1408 C CE1 . TYR A 1 181 29.825 35.728  36.976 A 181 ? 1.00 29.06  1 
+ATOM   1409 C CE2 . TYR A 1 181 30.840 33.617  36.468 A 181 ? 1.00 26.56  1 
+ATOM   1410 C CZ  . TYR A 1 181 30.947 34.918  36.928 A 181 ? 1.00 29.23  1 
+ATOM   1411 O OH  . TYR A 1 181 32.186 35.413  37.317 A 181 ? 1.00 33.06  1 
+ATOM   1412 N N   . TYR A 1 182 25.194 34.979  37.221 A 182 ? 1.00 27.88  1 
+ATOM   1413 C CA  . TYR A 1 182 24.857 36.175  37.960 A 182 ? 1.00 20.66  1 
+ATOM   1414 C C   . TYR A 1 182 23.688 35.939  38.869 A 182 ? 1.00 25.55  1 
+ATOM   1415 O O   . TYR A 1 182 23.566 36.705  39.814 A 182 ? 1.00 22.46  1 
+ATOM   1416 C CB  . TYR A 1 182 24.536 37.293  36.986 A 182 ? 1.00 18.15  1 
+ATOM   1417 C CG  . TYR A 1 182 25.815 37.884  36.435 A 182 ? 1.00 23.80  1 
+ATOM   1418 C CD1 . TYR A 1 182 26.753 38.411  37.316 A 182 ? 1.00 25.62  1 
+ATOM   1419 C CD2 . TYR A 1 182 26.071 37.822  35.075 A 182 ? 1.00 20.65  1 
+ATOM   1420 C CE1 . TYR A 1 182 27.950 38.888  36.826 A 182 ? 1.00 23.86  1 
+ATOM   1421 C CE2 . TYR A 1 182 27.282 38.286  34.588 A 182 ? 1.00 22.91  1 
+ATOM   1422 C CZ  . TYR A 1 182 28.218 38.800  35.463 A 182 ? 1.00 27.81  1 
+ATOM   1423 O OH  . TYR A 1 182 29.467 39.174  34.966 A 182 ? 1.00 26.86  1 
+ATOM   1424 N N   . SER A 1 183 22.802 34.974  38.593 A 183 ? 1.00 17.79  1 
+ATOM   1425 C CA  . SER A 1 183 21.773 34.685  39.550 A 183 ? 1.00 22.82  1 
+ATOM   1426 C C   . SER A 1 183 22.498 34.117  40.779 A 183 ? 1.00 24.33  1 
+ATOM   1427 O O   . SER A 1 183 22.192 34.532  41.892 A 183 ? 1.00 28.47  1 
+ATOM   1428 C CB  . SER A 1 183 20.820 33.670  38.952 A 183 ? 1.00 27.48  1 
+ATOM   1429 O OG  . SER A 1 183 19.962 34.251  37.970 A 183 ? 1.00 36.61  1 
+ATOM   1430 N N   . LYS A 1 184 23.470 33.220  40.641 A 184 ? 1.00 22.39  1 
+ATOM   1431 C CA  . LYS A 1 184 24.305 32.796  41.740 A 184 ? 1.00 32.86  1 
+ATOM   1432 C C   . LYS A 1 184 25.041 33.947  42.441 A 184 ? 1.00 36.64  1 
+ATOM   1433 O O   . LYS A 1 184 25.197 33.926  43.674 A 184 ? 1.00 31.46  1 
+ATOM   1434 C CB  . LYS A 1 184 25.349 31.811  41.274 A 184 ? 1.00 45.13  1 
+ATOM   1435 C CG  . LYS A 1 184 24.805 30.395  41.301 A 184 ? 1.00 65.07  1 
+ATOM   1436 C CD  . LYS A 1 184 25.953 29.372  41.312 A 184 ? 1.00 80.43  1 
+ATOM   1437 C CE  . LYS A 1 184 25.516 27.942  41.715 A 184 ? 1.00 90.18  1 
+ATOM   1438 N NZ  . LYS A 1 184 25.133 27.852  43.121 A 184 ? 1.00 95.35  1 
+ATOM   1439 N N   . GLU A 1 185 25.532 34.938  41.694 A 185 ? 1.00 28.97  1 
+ATOM   1440 C CA  . GLU A 1 185 26.114 36.110  42.295 A 185 ? 1.00 26.04  1 
+ATOM   1441 C C   . GLU A 1 185 25.074 36.823  43.129 A 185 ? 1.00 29.58  1 
+ATOM   1442 O O   . GLU A 1 185 25.445 37.289  44.215 A 185 ? 1.00 27.30  1 
+ATOM   1443 C CB  . GLU A 1 185 26.630 37.121  41.249 A 185 ? 1.00 30.11  1 
+ATOM   1444 C CG  . GLU A 1 185 27.857 36.591  40.537 A 185 ? 1.00 31.47  1 
+ATOM   1445 C CD  . GLU A 1 185 29.022 36.322  41.493 A 185 ? 1.00 37.80  1 
+ATOM   1446 O OE1 . GLU A 1 185 29.457 37.242  42.181 A 185 ? 1.00 38.02  1 
+ATOM   1447 O OE2 . GLU A 1 185 29.501 35.191  41.552 A 185 ? 1.00 35.63  1 
+ATOM   1448 N N   . ALA A 1 186 23.799 36.967  42.704 A 186 ? 1.00 22.47  1 
+ATOM   1449 C CA  . ALA A 1 186 22.815 37.702  43.488 A 186 ? 1.00 20.60  1 
+ATOM   1450 C C   . ALA A 1 186 22.450 36.961  44.777 A 186 ? 1.00 24.28  1 
+ATOM   1451 O O   . ALA A 1 186 22.235 37.529  45.854 A 186 ? 1.00 25.34  1 
+ATOM   1452 C CB  . ALA A 1 186 21.568 37.882  42.680 A 186 ? 1.00 19.02  1 
+ATOM   1453 N N   . GLU A 1 187 22.415 35.638  44.701 A 187 ? 1.00 31.08  1 
+ATOM   1454 C CA  . GLU A 1 187 22.141 34.782  45.857 A 187 ? 1.00 44.44  1 
+ATOM   1455 C C   . GLU A 1 187 23.150 34.955  46.976 A 187 ? 1.00 40.98  1 
+ATOM   1456 O O   . GLU A 1 187 22.828 34.905  48.176 A 187 ? 1.00 33.46  1 
+ATOM   1457 C CB  . GLU A 1 187 22.152 33.310  45.466 A 187 ? 1.00 56.38  1 
+ATOM   1458 C CG  . GLU A 1 187 20.806 32.860  44.911 A 187 ? 1.00 76.88  1 
+ATOM   1459 C CD  . GLU A 1 187 20.739 31.369  44.618 A 187 ? 1.00 86.20  1 
+ATOM   1460 O OE1 . GLU A 1 187 20.664 30.571  45.562 A 187 ? 1.00 91.02  1 
+ATOM   1461 O OE2 . GLU A 1 187 20.757 31.020  43.436 A 187 ? 1.00 91.61  1 
+ATOM   1462 N N   . ALA A 1 188 24.399 35.166  46.536 A 188 ? 1.00 30.39  1 
+ATOM   1463 C CA  . ALA A 1 188 25.497 35.366  47.468 A 188 ? 1.00 35.28  1 
+ATOM   1464 C C   . ALA A 1 188 25.615 36.777  48.053 A 188 ? 1.00 33.05  1 
+ATOM   1465 O O   . ALA A 1 188 26.471 37.056  48.894 A 188 ? 1.00 38.47  1 
+ATOM   1466 C CB  . ALA A 1 188 26.798 34.962  46.745 A 188 ? 1.00 31.61  1 
+ATOM   1467 N N   . GLY A 1 189 24.743 37.688  47.643 A 189 ? 1.00 33.11  1 
+ATOM   1468 C CA  . GLY A 1 189 24.765 39.076  48.082 A 189 ? 1.00 38.03  1 
+ATOM   1469 C C   . GLY A 1 189 25.738 40.009  47.310 A 189 ? 1.00 39.17  1 
+ATOM   1470 O O   . GLY A 1 189 25.867 41.197  47.661 A 189 ? 1.00 38.53  1 
+ATOM   1471 N N   . ASN A 1 190 26.374 39.541  46.221 A 190 ? 1.00 32.23  1 
+ATOM   1472 C CA  . ASN A 1 190 27.363 40.312  45.461 A 190 ? 1.00 28.46  1 
+ATOM   1473 C C   . ASN A 1 190 26.836 41.319  44.448 A 190 ? 1.00 25.65  1 
+ATOM   1474 O O   . ASN A 1 190 27.599 42.167  44.016 A 190 ? 1.00 32.64  1 
+ATOM   1475 C CB  . ASN A 1 190 28.307 39.357  44.735 A 190 ? 1.00 34.00  1 
+ATOM   1476 C CG  . ASN A 1 190 29.016 38.341  45.616 A 190 ? 1.00 34.48  1 
+ATOM   1477 O OD1 . ASN A 1 190 29.153 38.496  46.827 A 190 ? 1.00 33.98  1 
+ATOM   1478 N ND2 . ASN A 1 190 29.479 37.218  45.112 A 190 ? 1.00 35.91  1 
+ATOM   1479 N N   . THR A 1 191 25.556 41.263  44.069 A 191 ? 1.00 26.13  1 
+ATOM   1480 C CA  . THR A 1 191 24.855 42.119  43.112 A 191 ? 1.00 29.10  1 
+ATOM   1481 C C   . THR A 1 191 23.337 41.897  43.350 A 191 ? 1.00 30.66  1 
+ATOM   1482 O O   . THR A 1 191 22.924 40.980  44.099 A 191 ? 1.00 27.02  1 
+ATOM   1483 C CB  . THR A 1 191 25.234 41.732  41.612 A 191 ? 1.00 26.13  1 
+ATOM   1484 O OG1 . THR A 1 191 24.835 42.853  40.815 A 191 ? 1.00 28.32  1 
+ATOM   1485 C CG2 . THR A 1 191 24.563 40.464  41.070 A 191 ? 1.00 26.95  1 
+ATOM   1486 N N   . LYS A 1 192 22.520 42.760  42.707 A 192 ? 1.00 31.45  1 
+ATOM   1487 C CA  . LYS A 1 192 21.066 42.643  42.614 A 192 ? 1.00 30.19  1 
+ATOM   1488 C C   . LYS A 1 192 20.766 42.082  41.200 A 192 ? 1.00 26.48  1 
+ATOM   1489 O O   . LYS A 1 192 21.477 42.422  40.243 A 192 ? 1.00 26.22  1 
+ATOM   1490 C CB  . LYS A 1 192 20.449 44.043  42.842 A 192 ? 1.00 26.39  1 
+ATOM   1491 C CG  . LYS A 1 192 20.470 44.348  44.357 A 192 ? 1.00 44.92  1 
+ATOM   1492 C CD  . LYS A 1 192 20.175 45.801  44.791 A 192 ? 1.00 56.84  1 
+ATOM   1493 C CE  . LYS A 1 192 19.401 45.922  46.117 A 192 ? 1.00 62.41  1 
+ATOM   1494 N NZ  . LYS A 1 192 17.996 45.547  45.934 A 192 ? 1.00 71.82  1 
+ATOM   1495 N N   . TYR A 1 193 19.780 41.212  40.951 A 193 ? 1.00 29.59  1 
+ATOM   1496 C CA  . TYR A 1 193 19.512 40.627  39.611 A 193 ? 1.00 26.17  1 
+ATOM   1497 C C   . TYR A 1 193 18.078 41.014  39.353 A 193 ? 1.00 22.39  1 
+ATOM   1498 O O   . TYR A 1 193 17.328 40.851  40.302 A 193 ? 1.00 29.92  1 
+ATOM   1499 C CB  . TYR A 1 193 19.649 39.084  39.628 A 193 ? 1.00 16.14  1 
+ATOM   1500 C CG  . TYR A 1 193 19.616 38.390  38.306 A 193 ? 1.00 23.88  1 
+ATOM   1501 C CD1 . TYR A 1 193 18.419 38.015  37.750 A 193 ? 1.00 28.45  1 
+ATOM   1502 C CD2 . TYR A 1 193 20.768 38.216  37.613 A 193 ? 1.00 21.54  1 
+ATOM   1503 C CE1 . TYR A 1 193 18.368 37.484  36.473 A 193 ? 1.00 27.30  1 
+ATOM   1504 C CE2 . TYR A 1 193 20.734 37.682  36.334 A 193 ? 1.00 27.18  1 
+ATOM   1505 C CZ  . TYR A 1 193 19.534 37.328  35.772 A 193 ? 1.00 22.84  1 
+ATOM   1506 O OH  . TYR A 1 193 19.490 36.855  34.496 A 193 ? 1.00 23.98  1 
+ATOM   1507 N N   . ALA A 1 194 17.604 41.586  38.241 A 194 ? 1.00 25.70  1 
+ATOM   1508 C CA  . ALA A 1 194 16.181 41.854  38.027 A 194 ? 1.00 22.71  1 
+ATOM   1509 C C   . ALA A 1 194 15.867 41.433  36.601 A 194 ? 1.00 24.56  1 
+ATOM   1510 O O   . ALA A 1 194 16.666 41.662  35.701 A 194 ? 1.00 23.26  1 
+ATOM   1511 C CB  . ALA A 1 194 15.820 43.324  38.124 A 194 ? 1.00 27.76  1 
+ATOM   1512 N N   . LYS A 1 195 14.803 40.679  36.385 A 195 ? 1.00 22.73  1 
+ATOM   1513 C CA  . LYS A 1 195 14.390 40.266  35.066 A 195 ? 1.00 23.39  1 
+ATOM   1514 C C   . LYS A 1 195 13.277 41.223  34.553 A 195 ? 1.00 27.00  1 
+ATOM   1515 O O   . LYS A 1 195 12.415 41.677  35.322 A 195 ? 1.00 29.46  1 
+ATOM   1516 C CB  . LYS A 1 195 13.973 38.819  35.238 A 195 ? 1.00 21.78  1 
+ATOM   1517 C CG  . LYS A 1 195 13.755 38.186  33.909 A 195 ? 1.00 29.40  1 
+ATOM   1518 C CD  . LYS A 1 195 13.211 36.799  34.127 A 195 ? 1.00 38.23  1 
+ATOM   1519 C CE  . LYS A 1 195 12.745 36.343  32.751 A 195 ? 1.00 39.99  1 
+ATOM   1520 N NZ  . LYS A 1 195 12.355 34.938  32.727 A 195 ? 1.00 49.37  1 
+ATOM   1521 N N   . VAL A 1 196 13.287 41.732  33.311 A 196 ? 1.00 20.78  1 
+ATOM   1522 C CA  . VAL A 1 196 12.218 42.589  32.815 A 196 ? 1.00 23.44  1 
+ATOM   1523 C C   . VAL A 1 196 11.666 41.946  31.524 A 196 ? 1.00 28.74  1 
+ATOM   1524 O O   . VAL A 1 196 12.321 41.203  30.767 A 196 ? 1.00 21.38  1 
+ATOM   1525 C CB  . VAL A 1 196 12.717 44.035  32.521 A 196 ? 1.00 32.45  1 
+ATOM   1526 C CG1 . VAL A 1 196 13.508 44.521  33.736 A 196 ? 1.00 37.45  1 
+ATOM   1527 C CG2 . VAL A 1 196 13.623 44.112  31.315 A 196 ? 1.00 31.23  1 
+ATOM   1528 N N   . ASP A 1 197 10.384 42.181  31.309 A 197 ? 1.00 22.69  1 
+ATOM   1529 C CA  . ASP A 1 197 9.688  41.664  30.175 A 197 ? 1.00 16.27  1 
+ATOM   1530 C C   . ASP A 1 197 10.000 42.516  28.963 A 197 ? 1.00 21.71  1 
+ATOM   1531 O O   . ASP A 1 197 9.359  43.537  28.745 A 197 ? 1.00 20.20  1 
+ATOM   1532 C CB  . ASP A 1 197 8.206  41.681  30.416 A 197 ? 1.00 22.42  1 
+ATOM   1533 C CG  . ASP A 1 197 7.386  41.039  29.288 A 197 ? 1.00 18.45  1 
+ATOM   1534 O OD1 . ASP A 1 197 7.877  40.724  28.216 A 197 ? 1.00 21.07  1 
+ATOM   1535 O OD2 . ASP A 1 197 6.214  40.837  29.484 A 197 ? 1.00 23.53  1 
+ATOM   1536 N N   . GLY A 1 198 10.921 42.068  28.123 A 198 ? 1.00 16.61  1 
+ATOM   1537 C CA  . GLY A 1 198 11.316 42.835  26.964 A 198 ? 1.00 21.26  1 
+ATOM   1538 C C   . GLY A 1 198 10.257 42.800  25.859 A 198 ? 1.00 27.33  1 
+ATOM   1539 O O   . GLY A 1 198 10.499 43.434  24.830 A 198 ? 1.00 21.75  1 
+ATOM   1540 N N   . THR A 1 199 9.094  42.109  25.950 A 199 ? 1.00 23.59  1 
+ATOM   1541 C CA  . THR A 1 199 8.045  42.211  24.904 A 199 ? 1.00 24.67  1 
+ATOM   1542 C C   . THR A 1 199 7.121  43.430  25.058 A 199 ? 1.00 26.11  1 
+ATOM   1543 O O   . THR A 1 199 6.469  43.835  24.074 A 199 ? 1.00 31.06  1 
+ATOM   1544 C CB  . THR A 1 199 7.149  40.904  24.823 A 199 ? 1.00 20.04  1 
+ATOM   1545 O OG1 . THR A 1 199 6.307  40.816  25.949 A 199 ? 1.00 20.89  1 
+ATOM   1546 C CG2 . THR A 1 199 8.016  39.649  24.778 A 199 ? 1.00 20.89  1 
+ATOM   1547 N N   . LYS A 1 200 7.171  44.113  26.224 A 200 ? 1.00 23.64  1 
+ATOM   1548 C CA  . LYS A 1 200 6.346  45.271  26.476 A 200 ? 1.00 19.12  1 
+ATOM   1549 C C   . LYS A 1 200 6.785  46.344  25.533 A 200 ? 1.00 24.01  1 
+ATOM   1550 O O   . LYS A 1 200 7.861  46.304  24.939 A 200 ? 1.00 22.82  1 
+ATOM   1551 C CB  . LYS A 1 200 6.509  45.758  27.894 A 200 ? 1.00 22.39  1 
+ATOM   1552 C CG  . LYS A 1 200 5.870  44.746  28.839 A 200 ? 1.00 18.31  1 
+ATOM   1553 C CD  . LYS A 1 200 5.898  45.383  30.175 A 200 ? 1.00 26.54  1 
+ATOM   1554 C CE  . LYS A 1 200 5.474  44.334  31.116 A 200 ? 1.00 24.03  1 
+ATOM   1555 N NZ  . LYS A 1 200 5.688  44.892  32.400 A 200 ? 1.00 28.94  1 
+ATOM   1556 N N   . PRO A 1 201 5.945  47.296  25.281 A 201 ? 1.00 25.29  1 
+ATOM   1557 C CA  . PRO A 1 201 6.324  48.459  24.505 A 201 ? 1.00 23.26  1 
+ATOM   1558 C C   . PRO A 1 201 7.525  49.152  25.131 A 201 ? 1.00 21.27  1 
+ATOM   1559 O O   . PRO A 1 201 7.674  49.071  26.368 A 201 ? 1.00 22.64  1 
+ATOM   1560 C CB  . PRO A 1 201 5.022  49.240  24.502 A 201 ? 1.00 29.11  1 
+ATOM   1561 C CG  . PRO A 1 201 3.940  48.167  24.515 A 201 ? 1.00 26.68  1 
+ATOM   1562 C CD  . PRO A 1 201 4.511  47.257  25.583 A 201 ? 1.00 33.70  1 
+ATOM   1563 N N   . VAL A 1 202 8.368  49.799  24.296 A 202 ? 1.00 24.14  1 
+ATOM   1564 C CA  . VAL A 1 202 9.572  50.527  24.721 A 202 ? 1.00 21.75  1 
+ATOM   1565 C C   . VAL A 1 202 9.234  51.377  25.959 A 202 ? 1.00 24.15  1 
+ATOM   1566 O O   . VAL A 1 202 9.796  51.162  27.026 A 202 ? 1.00 29.61  1 
+ATOM   1567 C CB  . VAL A 1 202 10.094 51.474  23.582 A 202 ? 1.00 20.87  1 
+ATOM   1568 C CG1 . VAL A 1 202 11.238 52.354  24.054 A 202 ? 1.00 17.93  1 
+ATOM   1569 C CG2 . VAL A 1 202 10.665 50.653  22.471 A 202 ? 1.00 22.03  1 
+ATOM   1570 N N   . ALA A 1 203 8.262  52.286  25.965 A 203 ? 1.00 26.44  1 
+ATOM   1571 C CA  . ALA A 1 203 8.001  53.132  27.123 A 203 ? 1.00 24.59  1 
+ATOM   1572 C C   . ALA A 1 203 7.638  52.381  28.370 A 203 ? 1.00 24.66  1 
+ATOM   1573 O O   . ALA A 1 203 7.981  52.795  29.484 A 203 ? 1.00 26.00  1 
+ATOM   1574 C CB  . ALA A 1 203 6.872  54.099  26.846 A 203 ? 1.00 34.37  1 
+ATOM   1575 N N   . GLU A 1 204 6.959  51.252  28.190 A 204 ? 1.00 28.00  1 
+ATOM   1576 C CA  . GLU A 1 204 6.592  50.429  29.321 A 204 ? 1.00 27.26  1 
+ATOM   1577 C C   . GLU A 1 204 7.818  49.739  29.914 A 204 ? 1.00 31.42  1 
+ATOM   1578 O O   . GLU A 1 204 7.951  49.646  31.138 A 204 ? 1.00 23.09  1 
+ATOM   1579 C CB  . GLU A 1 204 5.587  49.382  28.900 A 204 ? 1.00 36.46  1 
+ATOM   1580 C CG  . GLU A 1 204 4.144  49.866  28.988 A 204 ? 1.00 44.61  1 
+ATOM   1581 C CD  . GLU A 1 204 3.138  48.709  28.884 A 204 ? 1.00 48.97  1 
+ATOM   1582 O OE1 . GLU A 1 204 2.993  47.948  29.851 A 204 ? 1.00 52.39  1 
+ATOM   1583 O OE2 . GLU A 1 204 2.506  48.562  27.836 A 204 ? 1.00 51.56  1 
+ATOM   1584 N N   . VAL A 1 205 8.729  49.235  29.080 A 205 ? 1.00 31.86  1 
+ATOM   1585 C CA  . VAL A 1 205 9.958  48.634  29.563 A 205 ? 1.00 22.63  1 
+ATOM   1586 C C   . VAL A 1 205 10.665 49.763  30.292 A 205 ? 1.00 21.22  1 
+ATOM   1587 O O   . VAL A 1 205 11.202 49.541  31.373 A 205 ? 1.00 18.70  1 
+ATOM   1588 C CB  . VAL A 1 205 10.851 48.117  28.381 A 205 ? 1.00 24.22  1 
+ATOM   1589 C CG1 . VAL A 1 205 12.176 47.554  28.946 A 205 ? 1.00 19.79  1 
+ATOM   1590 C CG2 . VAL A 1 205 10.157 47.007  27.589 A 205 ? 1.00 17.92  1 
+ATOM   1591 N N   . ARG A 1 206 10.676 50.985  29.748 A 206 ? 1.00 23.27  1 
+ATOM   1592 C CA  . ARG A 1 206 11.381 52.102  30.354 A 206 ? 1.00 26.40  1 
+ATOM   1593 C C   . ARG A 1 206 10.866 52.395  31.765 A 206 ? 1.00 29.43  1 
+ATOM   1594 O O   . ARG A 1 206 11.653 52.530  32.704 A 206 ? 1.00 32.42  1 
+ATOM   1595 C CB  . ARG A 1 206 11.196 53.246  29.421 A 206 ? 1.00 26.38  1 
+ATOM   1596 C CG  . ARG A 1 206 11.935 54.435  29.920 A 206 ? 1.00 49.92  1 
+ATOM   1597 C CD  . ARG A 1 206 11.129 55.634  29.476 A 206 ? 1.00 67.93  1 
+ATOM   1598 N NE  . ARG A 1 206 11.566 56.767  30.264 A 206 ? 1.00 84.85  1 
+ATOM   1599 C CZ  . ARG A 1 206 12.176 57.834  29.727 A 206 ? 1.00 93.86  1 
+ATOM   1600 N NH1 . ARG A 1 206 12.338 57.978  28.402 A 206 ? 1.00 92.58  1 
+ATOM   1601 N NH2 . ARG A 1 206 12.607 58.797  30.557 A 206 ? 1.00 100.35 1 
+ATOM   1602 N N   . ALA A 1 207 9.544  52.377  31.942 A 207 ? 1.00 26.47  1 
+ATOM   1603 C CA  . ALA A 1 207 8.907  52.492  33.247 A 207 ? 1.00 31.60  1 
+ATOM   1604 C C   . ALA A 1 207 9.202  51.350  34.241 A 207 ? 1.00 38.53  1 
+ATOM   1605 O O   . ALA A 1 207 9.309  51.604  35.465 A 207 ? 1.00 38.74  1 
+ATOM   1606 C CB  . ALA A 1 207 7.414  52.565  33.084 A 207 ? 1.00 26.98  1 
+ATOM   1607 N N   . ASP A 1 208 9.362  50.072  33.834 A 208 ? 1.00 34.71  1 
+ATOM   1608 C CA  . ASP A 1 208 9.716  48.993  34.790 A 208 ? 1.00 29.57  1 
+ATOM   1609 C C   . ASP A 1 208 11.108 49.181  35.354 A 208 ? 1.00 23.15  1 
+ATOM   1610 O O   . ASP A 1 208 11.374 49.013  36.553 A 208 ? 1.00 27.89  1 
+ATOM   1611 C CB  . ASP A 1 208 9.597  47.611  34.097 A 208 ? 1.00 28.86  1 
+ATOM   1612 C CG  . ASP A 1 208 8.157  47.235  33.726 A 208 ? 1.00 36.94  1 
+ATOM   1613 O OD1 . ASP A 1 208 7.226  47.532  34.481 A 208 ? 1.00 38.17  1 
+ATOM   1614 O OD2 . ASP A 1 208 7.946  46.649  32.669 A 208 ? 1.00 43.37  1 
+ATOM   1615 N N   . LEU A 1 209 11.976 49.631  34.439 A 209 ? 1.00 29.55  1 
+ATOM   1616 C CA  . LEU A 1 209 13.339 49.966  34.772 A 209 ? 1.00 30.90  1 
+ATOM   1617 C C   . LEU A 1 209 13.384 51.107  35.751 A 209 ? 1.00 30.94  1 
+ATOM   1618 O O   . LEU A 1 209 14.199 50.983  36.656 A 209 ? 1.00 31.15  1 
+ATOM   1619 C CB  . LEU A 1 209 14.144 50.369  33.555 A 209 ? 1.00 22.64  1 
+ATOM   1620 C CG  . LEU A 1 209 14.484 49.203  32.619 A 209 ? 1.00 32.03  1 
+ATOM   1621 C CD1 . LEU A 1 209 15.195 49.765  31.380 A 209 ? 1.00 30.31  1 
+ATOM   1622 C CD2 . LEU A 1 209 15.357 48.179  33.319 A 209 ? 1.00 27.70  1 
+ATOM   1623 N N   . GLU A 1 210 12.618 52.198  35.657 A 210 ? 1.00 29.77  1 
+ATOM   1624 C CA  . GLU A 1 210 12.663 53.230  36.684 A 210 ? 1.00 32.29  1 
+ATOM   1625 C C   . GLU A 1 210 12.246 52.665  38.009 A 210 ? 1.00 37.37  1 
+ATOM   1626 O O   . GLU A 1 210 12.926 52.974  38.982 A 210 ? 1.00 37.57  1 
+ATOM   1627 C CB  . GLU A 1 210 11.762 54.334  36.399 A 210 ? 1.00 30.94  1 
+ATOM   1628 C CG  . GLU A 1 210 12.483 55.212  35.433 A 210 ? 1.00 46.47  1 
+ATOM   1629 C CD  . GLU A 1 210 11.646 56.411  35.024 A 210 ? 1.00 59.35  1 
+ATOM   1630 O OE1 . GLU A 1 210 11.393 57.236  35.902 A 210 ? 1.00 73.54  1 
+ATOM   1631 O OE2 . GLU A 1 210 11.248 56.534  33.859 A 210 ? 1.00 55.93  1 
+ATOM   1632 N N   . LYS A 1 211 11.260 51.747  38.076 A 211 ? 1.00 40.32  1 
+ATOM   1633 C CA  . LYS A 1 211 10.927 51.111  39.364 A 211 ? 1.00 46.86  1 
+ATOM   1634 C C   . LYS A 1 211 12.078 50.386  40.001 A 211 ? 1.00 44.48  1 
+ATOM   1635 O O   . LYS A 1 211 12.239 50.401  41.213 A 211 ? 1.00 53.79  1 
+ATOM   1636 C CB  . LYS A 1 211 9.840  50.063  39.295 A 211 ? 1.00 49.66  1 
+ATOM   1637 C CG  . LYS A 1 211 8.532  50.780  39.159 A 211 ? 1.00 66.99  1 
+ATOM   1638 C CD  . LYS A 1 211 7.786  50.219  37.961 A 211 ? 1.00 79.45  1 
+ATOM   1639 C CE  . LYS A 1 211 6.678  51.165  37.481 A 211 ? 1.00 83.43  1 
+ATOM   1640 N NZ  . LYS A 1 211 6.007  50.590  36.327 A 211 ? 1.00 85.04  1 
+ATOM   1641 N N   . ILE A 1 212 12.897 49.723  39.210 A 212 ? 1.00 43.75  1 
+ATOM   1642 C CA  . ILE A 1 212 14.037 48.992  39.744 A 212 ? 1.00 41.73  1 
+ATOM   1643 C C   . ILE A 1 212 15.155 49.961  40.162 A 212 ? 1.00 40.35  1 
+ATOM   1644 O O   . ILE A 1 212 15.751 49.755  41.216 A 212 ? 1.00 44.48  1 
+ATOM   1645 C CB  . ILE A 1 212 14.508 47.961  38.630 A 212 ? 1.00 38.89  1 
+ATOM   1646 C CG1 . ILE A 1 212 13.375 46.935  38.326 A 212 ? 1.00 38.67  1 
+ATOM   1647 C CG2 . ILE A 1 212 15.806 47.281  39.075 A 212 ? 1.00 33.58  1 
+ATOM   1648 C CD1 . ILE A 1 212 13.602 46.019  37.091 A 212 ? 1.00 32.12  1 
+ATOM   1649 N N   . LEU A 1 213 15.456 51.032  39.420 A 213 ? 1.00 40.42  1 
+ATOM   1650 C CA  . LEU A 1 213 16.624 51.868  39.661 A 213 ? 1.00 49.31  1 
+ATOM   1651 C C   . LEU A 1 213 16.440 53.187  40.423 A 213 ? 1.00 54.79  1 
+ATOM   1652 O O   . LEU A 1 213 17.458 53.704  40.904 A 213 ? 1.00 53.77  1 
+ATOM   1653 C CB  . LEU A 1 213 17.321 52.160  38.292 A 213 ? 1.00 37.29  1 
+ATOM   1654 C CG  . LEU A 1 213 17.772 50.963  37.443 A 213 ? 1.00 35.90  1 
+ATOM   1655 C CD1 . LEU A 1 213 18.238 51.457  36.081 A 213 ? 1.00 37.96  1 
+ATOM   1656 C CD2 . LEU A 1 213 18.910 50.230  38.104 A 213 ? 1.00 30.51  1 
+ATOM   1657 N N   . GLY A 1 214 15.248 53.773  40.555 A 214 ? 1.00 60.83  1 
+ATOM   1658 C CA  . GLY A 1 214 15.055 55.001  41.318 A 214 ? 1.00 66.76  1 
+ATOM   1659 C C   . GLY A 1 214 14.400 56.086  40.466 A 214 ? 1.00 77.41  1 
+ATOM   1660 O O   . GLY A 1 214 13.852 57.041  41.020 A 214 ? 1.00 81.95  1 
+ATOM   1661 O OXT . GLY A 1 214 14.430 55.983  39.238 A 214 ? 1.00 80.44  1 
+HETATM 1662 P PA  . AP5 C 2 .   18.089 46.955  20.531 A 215 ? 1.00 17.77  1 
+HETATM 1663 O O1A . AP5 C 2 .   17.885 47.954  21.576 A 215 ? 1.00 16.47  1 
+HETATM 1664 O O2A . AP5 C 2 .   18.847 47.325  19.359 A 215 ? 1.00 15.16  1 
+HETATM 1665 O O3A . AP5 C 2 .   18.390 45.546  21.247 A 215 ? 1.00 19.11  1 
+HETATM 1666 P PB  . AP5 C 2 .   19.799 44.954  21.708 A 215 ? 1.00 16.65  1 
+HETATM 1667 O O1B . AP5 C 2 .   19.334 44.008  22.760 A 215 ? 1.00 15.25  1 
+HETATM 1668 O O2B . AP5 C 2 .   20.626 46.063  22.136 A 215 ? 1.00 17.16  1 
+HETATM 1669 O O3B . AP5 C 2 .   20.354 44.137  20.429 A 215 ? 1.00 15.96  1 
+HETATM 1670 P PG  . AP5 C 2 .   21.897 43.758  20.174 A 215 ? 1.00 19.71  1 
+HETATM 1671 O O1G A AP5 C 2 .   21.897 42.507  19.181 A 215 ? 0.50 18.18  1 
+HETATM 1672 O O1G B AP5 C 2 .   22.628 44.918  19.622 A 215 ? 0.50 22.41  1 
+HETATM 1673 O O2G . AP5 C 2 .   22.353 43.229  21.474 A 215 ? 1.00 30.10  1 
+HETATM 1674 O O3G A AP5 C 2 .   22.628 44.918  19.622 A 215 ? 0.50 22.41  1 
+HETATM 1675 O O3G B AP5 C 2 .   21.897 42.507  19.181 A 215 ? 0.50 18.18  1 
+HETATM 1676 P PD  A AP5 C 2 .   23.797 45.114  18.528 A 215 ? 0.50 37.05  1 
+HETATM 1677 P PD  B AP5 C 2 .   23.334 42.002  18.604 A 215 ? 0.50 32.08  1 
+HETATM 1678 O O1D A AP5 C 2 .   23.854 46.581  18.294 A 215 ? 0.50 43.58  1 
+HETATM 1679 O O1D B AP5 C 2 .   23.291 40.533  18.837 A 215 ? 0.50 25.40  1 
+HETATM 1680 O O2D A AP5 C 2 .   23.326 44.324  17.361 A 215 ? 0.50 43.58  1 
+HETATM 1681 O O2D B AP5 C 2 .   23.442 42.412  17.183 A 215 ? 0.50 32.78  1 
+HETATM 1682 O O3D A AP5 C 2 .   25.870 44.772  18.892 A 215 ? 0.50 36.10  1 
+HETATM 1683 O O3D B AP5 C 2 .   24.469 42.554  19.660 A 215 ? 0.50 34.55  1 
+HETATM 1684 P PE  . AP5 C 2 .   25.829 43.456  19.553 A 215 ? 1.00 25.81  1 
+HETATM 1685 O O1E A AP5 C 2 .   24.469 42.554  19.660 A 215 ? 0.50 34.55  1 
+HETATM 1686 O O1E B AP5 C 2 .   25.870 44.772  18.892 A 215 ? 0.50 36.10  1 
+HETATM 1687 O O2E . AP5 C 2 .   26.407 43.595  20.903 A 215 ? 1.00 31.63  1 
+HETATM 1688 O O5F . AP5 C 2 .   16.664 46.579  19.961 A 215 ? 1.00 19.72  1 
+HETATM 1689 C C5F . AP5 C 2 .   16.543 45.843  18.766 A 215 ? 1.00 15.12  1 
+HETATM 1690 C C4F . AP5 C 2 .   15.520 46.464  17.814 A 215 ? 1.00 20.75  1 
+HETATM 1691 O O4F . AP5 C 2 .   14.167 46.347  18.313 A 215 ? 1.00 17.34  1 
+HETATM 1692 C C3F . AP5 C 2 .   15.758 47.986  17.508 A 215 ? 1.00 14.48  1 
+HETATM 1693 O O3F . AP5 C 2 .   15.239 48.274  16.227 A 215 ? 1.00 13.13  1 
+HETATM 1694 C C2F . AP5 C 2 .   14.853 48.663  18.549 A 215 ? 1.00 15.06  1 
+HETATM 1695 O O2F . AP5 C 2 .   14.344 49.927  18.068 A 215 ? 1.00 18.78  1 
+HETATM 1696 C C1F . AP5 C 2 .   13.766 47.596  18.882 A 215 ? 1.00 12.64  1 
+HETATM 1697 N N9A . AP5 C 2 .   13.106 47.571  20.171 A 215 ? 1.00 16.08  1 
+HETATM 1698 C C8A . AP5 C 2 .   13.724 47.823  21.374 A 215 ? 1.00 15.47  1 
+HETATM 1699 N N7A . AP5 C 2 .   12.929 47.661  22.405 A 215 ? 1.00 18.45  1 
+HETATM 1700 C C5A . AP5 C 2 .   11.690 47.264  21.916 A 215 ? 1.00 19.01  1 
+HETATM 1701 C C6A . AP5 C 2 .   10.452 46.992  22.534 A 215 ? 1.00 17.84  1 
+HETATM 1702 N N6A . AP5 C 2 .   10.265 47.142  23.846 A 215 ? 1.00 16.43  1 
+HETATM 1703 N N1A . AP5 C 2 .   9.421  46.705  21.718 A 215 ? 1.00 18.69  1 
+HETATM 1704 C C2A . AP5 C 2 .   9.647  46.591  20.416 A 215 ? 1.00 17.51  1 
+HETATM 1705 N N3A . AP5 C 2 .   10.750 46.812  19.701 A 215 ? 1.00 17.03  1 
+HETATM 1706 C C4A . AP5 C 2 .   11.799 47.190  20.490 A 215 ? 1.00 19.52  1 
+HETATM 1707 O O5J . AP5 C 2 .   26.954 42.555  18.868 A 215 ? 1.00 26.97  1 
+HETATM 1708 C C5J . AP5 C 2 .   27.043 42.291  17.471 A 215 ? 1.00 17.15  1 
+HETATM 1709 C C4J . AP5 C 2 .   28.387 41.590  17.248 A 215 ? 1.00 20.83  1 
+HETATM 1710 O O4J . AP5 C 2 .   29.446 42.276  17.982 A 215 ? 1.00 21.77  1 
+HETATM 1711 C C3J . AP5 C 2 .   28.351 40.164  17.844 A 215 ? 1.00 18.19  1 
+HETATM 1712 O O3J . AP5 C 2 .   27.754 39.232  16.913 A 215 ? 1.00 16.22  1 
+HETATM 1713 C C2J . AP5 C 2 .   29.838 39.895  18.106 A 215 ? 1.00 18.14  1 
+HETATM 1714 O O2J . AP5 C 2 .   30.514 39.703  16.874 A 215 ? 1.00 19.73  1 
+HETATM 1715 C C1J . AP5 C 2 .   30.173 41.289  18.687 A 215 ? 1.00 14.80  1 
+HETATM 1716 N N9B . AP5 C 2 .   30.420 41.506  20.099 A 215 ? 1.00 18.44  1 
+HETATM 1717 C C8B . AP5 C 2 .   29.899 42.503  20.829 A 215 ? 1.00 14.07  1 
+HETATM 1718 N N7B . AP5 C 2 .   30.217 42.424  22.086 A 215 ? 1.00 17.74  1 
+HETATM 1719 C C5B . AP5 C 2 .   30.966 41.318  22.252 A 215 ? 1.00 15.06  1 
+HETATM 1720 C C6B . AP5 C 2 .   31.484 40.713  23.388 A 215 ? 1.00 18.26  1 
+HETATM 1721 N N6B . AP5 C 2 .   31.368 41.238  24.626 A 215 ? 1.00 15.83  1 
+HETATM 1722 N N1B . AP5 C 2 .   32.095 39.556  23.160 A 215 ? 1.00 13.73  1 
+HETATM 1723 C C2B . AP5 C 2 .   32.310 39.150  21.918 A 215 ? 1.00 14.83  1 
+HETATM 1724 N N3B . AP5 C 2 .   31.828 39.596  20.774 A 215 ? 1.00 13.67  1 
+HETATM 1725 C C4B . AP5 C 2 .   31.109 40.715  20.989 A 215 ? 1.00 13.30  1 
+HETATM 1726 O O   . HOH E 3 .   25.596 36.586  22.522 A 301 ? 1.00 16.28  1 
+HETATM 1727 O O   . HOH E 3 .   25.457 36.154  20.002 A 302 ? 1.00 15.85  1 
+HETATM 1728 O O   . HOH E 3 .   27.360 39.954  14.345 A 303 ? 1.00 17.20  1 
+HETATM 1729 O O   . HOH E 3 .   15.282 51.799  19.712 A 304 ? 1.00 22.17  1 
+HETATM 1730 O O   . HOH E 3 .   13.020 48.007  25.085 A 305 ? 1.00 22.52  1 
+HETATM 1731 O O   . HOH E 3 .   12.773 45.390  25.482 A 306 ? 1.00 21.76  1 
+HETATM 1732 O O   . HOH E 3 .   27.132 45.881  22.539 A 307 ? 1.00 21.21  1 
+HETATM 1733 O O   . HOH E 3 .   30.510 31.136  28.189 A 308 ? 1.00 25.89  1 
+HETATM 1734 O O   . HOH E 3 .   16.207 36.004  28.983 A 309 ? 1.00 21.26  1 
+HETATM 1735 O O   . HOH E 3 .   14.242 62.088  13.362 A 310 ? 1.00 17.64  1 
+HETATM 1736 O O   . HOH E 3 .   25.813 40.978  27.818 A 311 ? 1.00 27.01  1 
+HETATM 1737 O O   . HOH E 3 .   9.008  43.719  33.343 A 312 ? 1.00 28.03  1 
+HETATM 1738 O O   . HOH E 3 .   16.543 37.340  26.353 A 313 ? 1.00 22.43  1 
+HETATM 1739 O O   . HOH E 3 .   3.939  42.513  26.204 A 314 ? 1.00 25.60  1 
+HETATM 1740 O O   . HOH E 3 .   31.576 39.129  37.011 A 315 ? 1.00 32.36  1 
+HETATM 1741 O O   . HOH E 3 .   25.175 47.132  20.346 A 316 ? 1.00 29.77  1 
+HETATM 1742 O O   . HOH E 3 .   28.278 45.144  11.548 A 317 ? 1.00 27.88  1 
+HETATM 1743 O O   . HOH E 3 .   33.867 35.301  22.895 A 318 ? 1.00 28.20  1 
+HETATM 1744 O O   . HOH E 3 .   34.234 31.923  25.442 A 319 ? 1.00 31.89  1 
+HETATM 1745 O O   . HOH E 3 .   21.619 48.040  19.533 A 320 ? 1.00 19.81  1 
+HETATM 1746 O O   . HOH E 3 .   13.043 35.071  15.348 A 321 ? 1.00 27.40  1 
+HETATM 1747 O O   . HOH E 3 .   23.568 39.008  23.839 A 322 ? 1.00 33.01  1 
+HETATM 1748 O O   . HOH E 3 .   13.437 39.589  38.710 A 323 ? 1.00 37.96  1 
+HETATM 1749 O O   . HOH E 3 .   13.211 55.614  9.722  A 324 ? 1.00 34.98  1 
+HETATM 1750 O O   . HOH E 3 .   23.669 39.156  27.032 A 325 ? 1.00 36.61  1 
+HETATM 1751 O O   . HOH E 3 .   16.156 56.578  19.719 A 326 ? 1.00 48.18  1 
+HETATM 1752 O O   . HOH E 3 .   29.598 51.295  11.870 A 327 ? 1.00 35.73  1 
+HETATM 1753 O O   . HOH E 3 .   17.432 34.051  27.206 A 328 ? 1.00 54.06  1 
+HETATM 1754 O O   . HOH E 3 .   27.504 36.286  17.940 A 329 ? 1.00 29.59  1 
+HETATM 1755 O O   . HOH E 3 .   30.017 52.340  16.042 A 330 ? 1.00 35.74  1 
+HETATM 1756 O O   . HOH E 3 .   10.768 37.243  14.268 A 331 ? 1.00 38.68  1 
+HETATM 1757 O O   . HOH E 3 .   30.339 52.486  24.065 A 332 ? 1.00 35.78  1 
+HETATM 1758 O O   . HOH E 3 .   8.972  37.962  30.845 A 333 ? 1.00 41.23  1 
+HETATM 1759 O O   . HOH E 3 .   8.802  62.000  8.672  A 334 ? 1.00 39.15  1 
+HETATM 1760 O O   . HOH E 3 .   24.368 50.514  17.180 A 335 ? 1.00 41.79  1 
+HETATM 1761 O O   . HOH E 3 .   31.297 48.990  11.275 A 336 ? 1.00 42.39  1 
+HETATM 1762 O O   . HOH E 3 .   10.452 55.084  10.299 A 337 ? 1.00 50.01  1 
+HETATM 1763 O O   . HOH E 3 .   42.937 38.041  28.710 A 338 ? 1.00 49.55  1 
+HETATM 1764 O O   . HOH E 3 .   25.481 50.887  9.641  A 339 ? 1.00 41.11  1 
+HETATM 1765 O O   . HOH E 3 .   26.141 43.595  28.875 A 340 ? 1.00 57.69  1 
+HETATM 1766 O O   . HOH E 3 .   22.519 48.492  17.070 A 341 ? 1.00 36.60  1 
+HETATM 1767 O O   . HOH E 3 .   13.806 52.080  5.412  A 342 ? 1.00 53.46  1 
+HETATM 1768 O O   . HOH E 3 .   36.713 51.518  19.206 A 343 ? 1.00 42.97  1 
+HETATM 1769 O O   . HOH E 3 .   38.718 36.798  11.750 A 344 ? 1.00 55.46  1 
+HETATM 1770 O O   . HOH E 3 .   27.412 51.920  16.472 A 345 ? 1.00 44.19  1 
+HETATM 1771 O O   . HOH E 3 .   32.573 36.131  7.752  A 346 ? 1.00 51.02  1 
+HETATM 1772 O O   . HOH E 3 .   43.113 40.868  26.644 A 347 ? 1.00 41.86  1 
+HETATM 1773 O O   . HOH E 3 .   26.339 61.999  17.029 A 348 ? 1.00 43.95  1 
+HETATM 1774 O O   . HOH E 3 .   13.085 32.354  24.356 A 349 ? 1.00 53.20  1 
+HETATM 1775 O O   . HOH E 3 .   35.015 54.871  14.423 A 350 ? 1.00 48.99  1 
+HETATM 1776 O O   . HOH E 3 .   14.074 55.114  22.273 A 351 ? 1.00 55.09  1 
+HETATM 1777 O O   . HOH E 3 .   11.836 59.991  25.928 A 352 ? 1.00 58.11  1 
+HETATM 1778 O O   . HOH E 3 .   22.433 36.589  28.809 A 353 ? 1.00 63.91  1 
+HETATM 1779 O O   . HOH E 3 .   40.246 59.186  36.182 A 354 ? 1.00 47.64  1 
+HETATM 1780 O O   . HOH E 3 .   23.218 41.004  22.097 A 355 ? 1.00 55.72  1 
+HETATM 1781 O O   . HOH E 3 .   16.131 34.762  35.353 A 356 ? 1.00 39.37  1 
+HETATM 1782 O O   . HOH E 3 .   29.009 54.557  19.783 A 357 ? 1.00 54.35  1 
+HETATM 1783 O O   . HOH E 3 .   45.595 38.998  26.142 A 358 ? 1.00 19.77  1 
+HETATM 1784 O O   . HOH E 3 .   28.191 44.453  14.475 A 359 ? 1.00 23.31  1 
+HETATM 1785 O O   . HOH E 3 .   9.204  38.029  28.270 A 360 ? 1.00 25.00  1 
+HETATM 1786 O O   . HOH E 3 .   6.832  45.766  22.116 A 361 ? 1.00 27.78  1 
+HETATM 1787 O O   . HOH E 3 .   23.337 46.533  22.599 A 362 ? 1.00 22.31  1 
+HETATM 1788 O O   . HOH E 3 .   40.003 34.189  23.836 A 363 ? 1.00 30.38  1 
+HETATM 1789 O O   . HOH E 3 .   3.660  41.393  29.054 A 364 ? 1.00 29.88  1 
+HETATM 1790 O O   . HOH E 3 .   7.251  50.670  21.366 A 365 ? 1.00 28.72  1 
+HETATM 1791 O O   . HOH E 3 .   25.488 29.039  34.559 A 366 ? 1.00 44.50  1 
+HETATM 1792 O O   . HOH E 3 .   27.100 25.500  17.068 A 367 ? 1.00 37.14  1 
+HETATM 1793 O O   . HOH E 3 .   23.774 32.874  49.923 A 368 ? 1.00 28.18  1 
+HETATM 1794 O O   . HOH E 3 .   24.846 55.706  10.567 A 369 ? 1.00 34.26  1 
+HETATM 1795 O O   . HOH E 3 .   26.922 50.280  11.984 A 370 ? 1.00 39.27  1 
+HETATM 1796 O O   . HOH E 3 .   40.994 39.834  34.542 A 371 ? 1.00 34.86  1 
+HETATM 1797 O O   . HOH E 3 .   38.928 35.051  31.559 A 372 ? 1.00 31.59  1 
+HETATM 1798 O O   . HOH E 3 .   12.123 59.041  17.847 A 373 ? 1.00 34.27  1 
+HETATM 1799 O O   . HOH E 3 .   8.733  65.027  8.110  A 374 ? 1.00 48.29  1 
+HETATM 1800 O O   . HOH E 3 .   9.836  44.826  11.104 A 375 ? 1.00 40.54  1 
+HETATM 1801 O O   . HOH E 3 .   18.036 39.059  1.106  A 376 ? 1.00 47.03  1 
+HETATM 1802 O O   . HOH E 3 .   20.124 47.545  11.089 A 377 ? 1.00 38.59  1 
+HETATM 1803 O O   . HOH E 3 .   15.531 34.707  23.250 A 378 ? 1.00 32.99  1 
+HETATM 1804 O O   . HOH E 3 .   6.615  43.506  5.938  A 379 ? 1.00 37.23  1 
+HETATM 1805 O O   . HOH E 3 .   15.327 60.252  4.773  A 380 ? 1.00 41.60  1 
+HETATM 1806 O O   . HOH E 3 .   37.260 33.768  22.690 A 381 ? 1.00 34.29  1 
+HETATM 1807 O O   . HOH E 3 .   5.123  47.906  20.867 A 382 ? 1.00 43.95  1 
+HETATM 1808 O O   . HOH E 3 .   29.888 28.658  29.354 A 383 ? 1.00 40.00  1 
+HETATM 1809 O O   . HOH E 3 .   41.993 49.212  7.143  A 384 ? 1.00 67.55  1 
+HETATM 1810 O O   . HOH E 3 .   6.717  53.022  23.365 A 385 ? 1.00 67.54  1 
+HETATM 1811 O O   . HOH E 3 .   32.244 32.066  19.403 A 386 ? 1.00 44.86  1 
+HETATM 1812 O O   . HOH E 3 .   4.350  47.719  32.238 A 387 ? 1.00 73.19  1 
+HETATM 1813 O O   . HOH E 3 .   29.481 42.062  41.990 A 388 ? 1.00 45.85  1 
+HETATM 1814 O O   . HOH E 3 .   39.794 37.367  9.353  A 389 ? 1.00 68.61  1 
+HETATM 1815 O O   . HOH E 3 .   6.029  45.540  19.504 A 390 ? 1.00 53.50  1 
+HETATM 1816 O O   . HOH E 3 .   17.029 40.023  6.462  A 391 ? 1.00 51.08  1 
+HETATM 1817 O O   . HOH E 3 .   26.848 43.689  47.205 A 392 ? 1.00 43.70  1 
+HETATM 1818 O O   . HOH E 3 .   28.609 32.788  39.775 A 393 ? 1.00 36.61  1 
+HETATM 1819 O O   . HOH E 3 .   17.425 66.489  13.506 A 394 ? 1.00 43.52  1 
+HETATM 1820 O O   . HOH E 3 .   32.755 29.616  36.028 A 395 ? 1.00 51.86  1 
+HETATM 1821 O O   . HOH E 3 .   12.148 30.004  16.579 A 396 ? 1.00 51.18  1 
+HETATM 1822 O O   . HOH E 3 .   10.668 30.840  22.720 A 397 ? 1.00 47.05  1 
+HETATM 1823 O O   . HOH E 3 .   39.381 44.374  9.252  A 398 ? 1.00 67.50  1 
+HETATM 1824 O O   . HOH E 3 .   19.060 30.554  15.851 A 399 ? 1.00 52.33  1 
+HETATM 1825 O O   . HOH E 3 .   45.137 52.638  15.714 A 400 ? 1.00 57.15  1 
+HETATM 1826 O O   . HOH E 3 .   23.618 38.572  20.730 A 401 ? 1.00 72.64  1 
+HETATM 1827 O O   . HOH E 3 .   41.685 37.298  33.804 A 402 ? 1.00 43.42  1 
+HETATM 1828 O O   . HOH E 3 .   29.862 28.723  20.144 A 403 ? 1.00 59.07  1 
+HETATM 1829 O O   . HOH E 3 .   15.870 65.078  19.427 A 404 ? 1.00 51.65  1 
+HETATM 1830 O O   . HOH E 3 .   19.310 28.493  26.106 A 405 ? 1.00 37.32  1 
+HETATM 1831 O O   . HOH E 3 .   49.509 46.617  12.088 A 406 ? 1.00 62.48  1 
+HETATM 1832 O O   . HOH E 3 .   43.166 43.792  35.527 A 407 ? 1.00 59.32  1 
+HETATM 1833 O O   . HOH E 3 .   6.848  42.517  34.221 A 408 ? 1.00 44.62  1 
+HETATM 1834 O O   . HOH E 3 .   14.017 54.754  25.671 A 409 ? 1.00 48.60  1 
+HETATM 1835 O O   . HOH E 3 .   11.552 37.836  7.900  A 410 ? 1.00 59.57  1 
+HETATM 1836 O O   . HOH E 3 .   9.933  66.389  20.365 A 411 ? 1.00 36.56  1 
+HETATM 1837 O O   . HOH E 3 .   43.474 51.060  18.443 A 412 ? 1.00 49.42  1 
+HETATM 1838 O O   . HOH E 3 .   8.770  59.990  30.602 A 413 ? 1.00 69.57  1 
+HETATM 1839 O O   . HOH E 3 .   9.320  60.011  19.492 A 414 ? 1.00 53.90  1 
+HETATM 1840 O O   . HOH E 3 .   7.059  36.965  14.011 A 415 ? 1.00 43.34  1 
+HETATM 1841 O O   . HOH E 3 .   38.160 34.328  12.917 A 416 ? 1.00 66.53  1 
+HETATM 1842 O O   . HOH E 3 .   6.030  42.318  21.847 A 417 ? 1.00 48.51  1 
+HETATM 1843 O O   . HOH E 3 .   4.807  40.626  31.711 A 418 ? 1.00 41.24  1 
+HETATM 1844 O O   . HOH E 3 .   24.913 63.389  18.996 A 419 ? 1.00 48.75  1 
+HETATM 1845 O O   . HOH E 3 .   37.961 34.219  16.864 A 420 ? 1.00 43.46  1 
+HETATM 1846 O O   . HOH E 3 .   31.789 59.423  28.277 A 421 ? 1.00 63.66  1 
+HETATM 1847 O O   . HOH E 3 .   7.038  38.920  5.927  A 422 ? 1.00 47.84  1 
+HETATM 1848 O O   . HOH E 3 .   25.989 65.922  17.980 A 423 ? 1.00 92.64  1 
+HETATM 1849 O O   . HOH E 3 .   7.137  55.109  30.794 A 424 ? 1.00 51.46  1 
+HETATM 1850 O O   . HOH E 3 .   23.323 66.801  20.932 A 425 ? 1.00 56.75  1 
+HETATM 1851 O O   . HOH E 3 .   29.627 39.761  40.789 A 426 ? 1.00 43.36  1 
+HETATM 1852 O O   . HOH E 3 .   26.191 35.291  8.524  A 427 ? 1.00 45.04  1 
+HETATM 1853 O O   . HOH E 3 .   11.817 41.950  38.134 A 428 ? 1.00 47.91  1 
+HETATM 1854 O O   . HOH E 3 .   24.499 43.812  22.913 A 429 ? 1.00 30.66  1 
+HETATM 1855 O O   . HOH E 3 .   21.594 29.250  39.195 A 430 ? 1.00 51.34  1 
+HETATM 1856 O O   . HOH E 3 .   14.692 57.503  26.183 A 431 ? 1.00 65.76  1 
+HETATM 1857 O O   . HOH E 3 .   21.776 30.228  32.723 A 432 ? 1.00 49.54  1 
+HETATM 1858 O O   . HOH E 3 .   43.494 44.683  8.116  A 433 ? 1.00 80.98  1 
+HETATM 1859 O O   . HOH E 3 .   17.764 32.952  36.707 A 434 ? 1.00 55.46  1 
+HETATM 1860 O O   . HOH E 3 .   40.165 50.611  19.877 A 435 ? 1.00 47.61  1 
+HETATM 1861 O O   . HOH E 3 .   41.546 48.772  33.202 A 436 ? 1.00 53.83  1 
+HETATM 1862 O O   . HOH E 3 .   8.423  64.875  10.953 A 437 ? 1.00 49.52  1 
+HETATM 1863 O O   . HOH E 3 .   32.402 54.455  24.269 A 438 ? 1.00 55.06  1 
+HETATM 1864 O O   . HOH E 3 .   32.554 30.589  38.658 A 439 ? 1.00 69.44  1 
+HETATM 1865 O O   . HOH E 3 .   19.782 29.447  35.543 A 440 ? 1.00 77.94  1 
+HETATM 1866 O O   . HOH E 3 .   18.508 41.682  47.064 A 441 ? 1.00 56.59  1 
+HETATM 1867 O O   . HOH E 3 .   23.527 67.385  10.336 A 442 ? 1.00 73.49  1 
+HETATM 1868 O O   . HOH E 3 .   4.497  53.731  14.920 A 443 ? 1.00 72.06  1 
+HETATM 1869 O O   . HOH E 3 .   10.239 45.411  39.661 A 444 ? 1.00 79.81  1 
+HETATM 1870 O O   . HOH E 3 .   39.018 33.124  26.868 A 445 ? 1.00 35.70  1 
+HETATM 1871 O O   . HOH E 3 .   26.791 30.572  14.383 A 446 ? 1.00 44.60  1 
+HETATM 1872 O O   . HOH E 3 .   38.345 40.599  10.477 A 447 ? 1.00 31.82  1 
+HETATM 1873 O O   . HOH E 3 .   10.577 66.628  6.955  A 448 ? 1.00 53.04  1 
+HETATM 1874 O O   . HOH E 3 .   20.090 36.512  5.367  A 449 ? 1.00 45.06  1 
+HETATM 1875 O O   . HOH E 3 .   10.885 27.784  21.584 A 450 ? 1.00 59.57  1 
+HETATM 1876 O O   . HOH E 3 .   15.710 33.114  31.295 A 451 ? 1.00 68.34  1 
+HETATM 1877 O O   . HOH E 3 .   22.392 42.836  1.924  A 452 ? 1.00 92.57  1 
+HETATM 1878 O O   . HOH E 3 .   28.122 38.516  6.064  A 453 ? 1.00 82.43  1 
+HETATM 1879 O O   . HOH E 3 .   15.216 64.740  12.755 A 454 ? 1.00 35.20  1 
+HETATM 1880 O O   . HOH E 3 .   20.197 64.217  6.430  A 455 ? 1.00 45.93  1 
+HETATM 1881 O O   . HOH E 3 .   25.812 38.728  18.933 A 456 ? 1.00 59.25  1 
+HETATM 1882 O O   . HOH E 3 .   39.961 34.805  34.503 A 457 ? 1.00 42.20  1 
+HETATM 1883 O O   . HOH E 3 .   4.337  43.965  13.243 A 458 ? 1.00 58.81  1 
+HETATM 1884 O O   . HOH E 3 .   18.956 52.051  5.225  A 459 ? 1.00 63.75  1 
+HETATM 1885 O O   . HOH E 3 .   14.161 33.114  34.250 A 460 ? 1.00 97.69  1 
+HETATM 1886 O O   . HOH E 3 .   10.114 46.766  37.264 A 461 ? 1.00 52.16  1 
+HETATM 1887 O O   . HOH E 3 .   24.067 67.933  18.552 A 462 ? 1.00 85.10  1 
+HETATM 1888 O O   . HOH E 3 .   16.814 50.012  44.520 A 463 ? 1.00 79.48  1 
+HETATM 1889 O O   . HOH E 3 .   27.818 59.760  30.349 A 464 ? 1.00 59.18  1 
+HETATM 1890 O O   . HOH E 3 .   9.349  66.014  17.563 A 465 ? 1.00 68.04  1 
+HETATM 1891 O O   . HOH E 3 .   37.570 53.233  17.287 A 466 ? 1.00 46.75  1 
+HETATM 1892 O O   . HOH E 3 .   12.812 28.624  19.758 A 467 ? 1.00 60.62  1 
+HETATM 1893 O O   . HOH E 3 .   10.086 46.232  8.712  A 468 ? 1.00 45.81  1 
+HETATM 1894 O O   . HOH E 3 .   39.225 50.766  24.502 A 469 ? 1.00 60.05  1 
+HETATM 1895 O O   . HOH E 3 .   30.789 46.239  11.591 A 470 ? 1.00 64.20  1 
+HETATM 1896 O O   . HOH E 3 .   16.104 42.427  5.445  A 471 ? 1.00 61.84  1 
+HETATM 1897 O O   . HOH E 3 .   42.535 42.337  10.717 A 472 ? 1.00 55.32  1 
+HETATM 1898 O O   . HOH E 3 .   38.696 48.016  8.258  A 473 ? 1.00 76.57  1 
+HETATM 1899 O O   . HOH E 3 .   2.855  52.242  25.858 A 474 ? 1.00 65.77  1 
+HETATM 1900 O O   . HOH E 3 .   16.031 39.802  3.063  A 475 ? 1.00 55.81  1 
+HETATM 1901 O O   . HOH E 3 .   24.310 61.583  30.610 A 476 ? 1.00 55.63  1 
+HETATM 1902 O O   . HOH E 3 .   5.846  54.857  18.712 A 477 ? 1.00 66.17  1 
+HETATM 1903 O O   . HOH E 3 .   21.605 58.126  23.468 A 478 ? 1.00 84.99  1 
+HETATM 1904 O O   . HOH E 3 .   26.128 51.029  14.411 A 479 ? 1.00 52.13  1 
+HETATM 1905 O O   . HOH E 3 .   21.290 62.495  0.905  A 480 ? 1.00 71.24  1 
+HETATM 1906 O O   . HOH E 3 .   39.526 50.421  7.055  A 481 ? 1.00 71.01  1 
+HETATM 1907 O O   . HOH E 3 .   30.262 60.358  31.669 A 482 ? 1.00 69.26  1 
+HETATM 1908 O O   . HOH E 3 .   16.311 45.183  6.482  A 483 ? 1.00 78.90  1 
+HETATM 1909 O O   . HOH E 3 .   43.655 46.627  28.150 A 484 ? 1.00 62.22  1 
+HETATM 1910 O O   . HOH E 3 .   9.870  44.035  36.213 A 485 ? 1.00 69.48  1 
+HETATM 1911 O O   . HOH E 3 .   32.269 44.152  10.518 A 486 ? 1.00 74.47  1 
+HETATM 1912 O O   . HOH E 3 .   21.824 66.974  8.262  A 487 ? 1.00 47.71  1 
+HETATM 1913 O O   . HOH E 3 .   21.598 44.267  6.261  A 488 ? 1.00 58.62  1 
+HETATM 1914 O O   . HOH E 3 .   7.851  40.668  8.490  A 489 ? 1.00 62.00  1 
+HETATM 1915 O O   . HOH E 3 .   43.182 43.002  38.713 A 490 ? 1.00 42.41  1 
+HETATM 1916 O O   . HOH E 3 .   29.523 53.352  40.916 A 491 ? 1.00 66.48  1 
+HETATM 1917 O O   . HOH E 3 .   6.567  62.652  5.125  A 492 ? 1.00 56.38  1 
+HETATM 1918 O O   . HOH E 3 .   34.073 32.824  21.802 A 493 ? 1.00 61.62  1 
+HETATM 1919 O O   . HOH E 3 .   46.746 48.998  12.977 A 494 ? 1.00 63.98  1 
+HETATM 1920 O O   . HOH E 3 .   16.273 57.609  4.408  A 495 ? 1.00 81.40  1 
+HETATM 1921 O O   . HOH E 3 .   29.717 43.275  9.808  A 496 ? 1.00 47.90  1 
+HETATM 1922 O O   . HOH E 3 .   32.864 29.316  26.993 A 497 ? 1.00 57.06  1 
+HETATM 1923 O O   . HOH E 3 .   27.420 52.904  8.999  A 498 ? 1.00 52.15  1 
+HETATM 1924 O O   . HOH E 3 .   34.696 33.372  16.527 A 499 ? 1.00 85.47  1 
+HETATM 1925 O O   . HOH E 3 .   31.284 41.355  38.672 A 500 ? 1.00 60.84  1 
+HETATM 1926 O O   . HOH E 3 .   40.129 52.881  8.058  A 501 ? 1.00 56.09  1 
+HETATM 1927 O O   . HOH E 3 .   11.530 31.821  14.592 A 502 ? 1.00 59.89  1 
+HETATM 1928 O O   . HOH E 3 .   18.388 35.888  40.263 A 503 ? 1.00 62.98  1 
+HETATM 1929 O O   . HOH E 3 .   24.624 37.008  5.996  A 504 ? 1.00 60.08  1 
+HETATM 1930 O O   . HOH E 3 .   14.138 54.384  7.557  A 505 ? 1.00 55.55  1 
+HETATM 1931 O O   . HOH E 3 .   20.876 30.493  9.653  A 506 ? 1.00 62.57  1 
+HETATM 1932 O O   . HOH E 3 .   27.328 58.149  21.600 A 507 ? 1.00 67.74  1 
+HETATM 1933 O O   . HOH E 3 .   44.148 48.327  31.469 A 508 ? 1.00 62.63  1 
+HETATM 1934 O O   . HOH E 3 .   35.552 30.378  32.797 A 509 ? 1.00 60.19  1 
+HETATM 1935 O O   . HOH E 3 .   45.321 44.866  40.838 A 510 ? 1.00 49.33  1 
+HETATM 1936 O O   . HOH E 3 .   28.439 36.467  50.549 A 511 ? 1.00 69.37  1 
+HETATM 1937 O O   . HOH E 3 .   21.371 62.014  3.596  A 512 ? 1.00 49.98  1 
+HETATM 1938 O O   . HOH E 3 .   25.890 66.068  9.239  A 513 ? 1.00 64.09  1 
+HETATM 1939 O O   . HOH E 3 .   45.734 51.886  12.941 A 514 ? 1.00 87.03  1 
+HETATM 1940 O O   . HOH E 3 .   27.444 56.080  23.709 A 515 ? 1.00 73.73  1 
+HETATM 1941 O O   . HOH E 3 .   28.445 27.443  27.536 A 516 ? 1.00 55.49  1 
+HETATM 1942 O O   . HOH E 3 .   39.014 31.727  31.716 A 517 ? 1.00 60.98  1 
+HETATM 1943 O O   . HOH E 3 .   30.469 58.394  36.070 A 518 ? 1.00 61.00  1 
+HETATM 1944 O O   . HOH E 3 .   35.297 51.498  42.943 A 519 ? 1.00 62.19  1 
+HETATM 1945 O O   . HOH E 3 .   25.252 31.535  45.433 A 520 ? 1.00 60.86  1 
+HETATM 1946 O O   . HOH E 3 .   12.628 30.582  26.713 A 521 ? 1.00 88.31  1 
+HETATM 1947 O O   . HOH E 3 .   10.907 56.239  26.269 A 522 ? 1.00 78.48  1 
+HETATM 1948 O O   . HOH E 3 .   25.305 34.266  5.500  A 523 ? 1.00 77.16  1 
+HETATM 1949 O O   . HOH E 3 .   29.666 56.430  11.280 A 524 ? 1.00 82.31  1 
+HETATM 1950 O O   . HOH E 3 .   14.372 31.727  16.145 A 525 ? 1.00 63.48  1 
+HETATM 1951 O O   . HOH E 3 .   36.595 56.088  41.181 A 526 ? 1.00 68.21  1 
+HETATM 1952 O O   . HOH E 3 .   30.588 56.291  25.754 A 527 ? 1.00 67.97  1 
+HETATM 1953 O O   . HOH E 3 .   23.820 45.463  45.863 A 528 ? 1.00 71.02  1 
+HETATM 1954 O O   . HOH E 3 .   37.553 56.554  35.361 A 529 ? 1.00 38.17  1 
+HETATM 1955 O O   . HOH E 3 .   40.463 61.999  38.163 A 530 ? 1.00 59.25  1 
+HETATM 1956 O O   . HOH E 3 .   30.307 27.374  11.952 A 531 ? 1.00 90.79  1 
+HETATM 1957 O O   . HOH E 3 .   11.176 48.839  6.067  A 534 ? 1.00 82.53  1 
+HETATM 1958 O O   . HOH E 3 .   22.707 63.031  5.796  A 535 ? 1.00 72.50  1 
+HETATM 1959 O O   . HOH E 3 .   30.118 54.769  17.243 A 536 ? 1.00 61.10  1 
+HETATM 1960 O O   . HOH E 3 .   26.111 39.613  7.723  A 537 ? 1.00 69.07  1 
+HETATM 1961 O O   . HOH E 3 .   9.208  45.673  30.600 A 538 ? 1.00 56.63  1 
+HETATM 1962 O O   . HOH E 3 .   16.608 59.554  19.579 A 539 ? 1.00 52.84  1 
+HETATM 1963 O O   . HOH E 3 .   28.975 53.951  22.347 A 540 ? 1.00 65.19  1 
+HETATM 1964 O O   . HOH E 3 .   9.468  40.396  34.049 A 541 ? 1.00 57.03  1 
+HETATM 1965 O O   . HOH E 3 .   29.298 60.386  34.180 A 542 ? 1.00 82.76  1 
+HETATM 1966 O O   . HOH E 3 .   10.634 60.171  32.792 A 543 ? 1.00 80.06  1 
+ATOM   1967 N N   . MET B 1 1   12.440 6.614   -1.137 B 1   ? 1.00 84.71  1 
+ATOM   1968 C CA  . MET B 1 1   13.491 5.717   -0.668 B 1   ? 1.00 76.22  1 
+ATOM   1969 C C   . MET B 1 1   13.148 5.442   0.796  B 1   ? 1.00 71.67  1 
+ATOM   1970 O O   . MET B 1 1   12.868 6.366   1.556  B 1   ? 1.00 63.59  1 
+ATOM   1971 C CB  . MET B 1 1   14.812 6.448   -0.874 B 1   ? 1.00 75.77  1 
+ATOM   1972 C CG  . MET B 1 1   15.976 5.572   -1.280 B 1   ? 1.00 71.66  1 
+ATOM   1973 S SD  . MET B 1 1   17.080 5.513   0.137  B 1   ? 1.00 66.16  1 
+ATOM   1974 C CE  . MET B 1 1   18.072 6.943   -0.151 B 1   ? 1.00 65.65  1 
+ATOM   1975 N N   . ARG B 1 2   13.034 4.158   1.147  B 2   ? 1.00 68.59  1 
+ATOM   1976 C CA  . ARG B 1 2   12.484 3.732   2.434  B 2   ? 1.00 67.43  1 
+ATOM   1977 C C   . ARG B 1 2   13.498 2.869   3.183  B 2   ? 1.00 57.10  1 
+ATOM   1978 O O   . ARG B 1 2   14.114 1.992   2.555  B 2   ? 1.00 53.89  1 
+ATOM   1979 C CB  . ARG B 1 2   11.195 2.956   2.146  B 2   ? 1.00 72.67  1 
+ATOM   1980 C CG  . ARG B 1 2   10.165 3.697   1.313  B 2   ? 1.00 72.08  1 
+ATOM   1981 C CD  . ARG B 1 2   9.624  2.850   0.185  B 2   ? 1.00 73.99  1 
+ATOM   1982 N NE  . ARG B 1 2   8.201  3.110   0.140  B 2   ? 1.00 84.42  1 
+ATOM   1983 C CZ  . ARG B 1 2   7.320  2.313   -0.472 B 2   ? 1.00 87.12  1 
+ATOM   1984 N NH1 . ARG B 1 2   7.700  1.235   -1.169 B 2   ? 1.00 81.73  1 
+ATOM   1985 N NH2 . ARG B 1 2   6.024  2.633   -0.378 B 2   ? 1.00 89.07  1 
+ATOM   1986 N N   . ILE B 1 3   13.757 3.053   4.467  B 3   ? 1.00 48.30  1 
+ATOM   1987 C CA  . ILE B 1 3   14.820 2.298   5.099  B 3   ? 1.00 41.09  1 
+ATOM   1988 C C   . ILE B 1 3   14.372 2.025   6.524  B 3   ? 1.00 46.91  1 
+ATOM   1989 O O   . ILE B 1 3   13.660 2.825   7.142  B 3   ? 1.00 47.93  1 
+ATOM   1990 C CB  . ILE B 1 3   16.126 3.129   5.107  B 3   ? 1.00 39.02  1 
+ATOM   1991 C CG1 . ILE B 1 3   16.572 3.543   3.735  B 3   ? 1.00 34.33  1 
+ATOM   1992 C CG2 . ILE B 1 3   17.243 2.280   5.656  B 3   ? 1.00 35.63  1 
+ATOM   1993 C CD1 . ILE B 1 3   17.526 4.738   3.782  B 3   ? 1.00 31.71  1 
+ATOM   1994 N N   . ILE B 1 4   14.732 0.846   7.026  B 4   ? 1.00 49.38  1 
+ATOM   1995 C CA  . ILE B 1 4   14.527 0.452   8.416  B 4   ? 1.00 49.63  1 
+ATOM   1996 C C   . ILE B 1 4   15.955 0.383   9.003  B 4   ? 1.00 47.41  1 
+ATOM   1997 O O   . ILE B 1 4   16.934 0.000   8.324  B 4   ? 1.00 43.23  1 
+ATOM   1998 C CB  . ILE B 1 4   13.839 -0.968  8.544  B 4   ? 1.00 51.23  1 
+ATOM   1999 C CG1 . ILE B 1 4   12.411 -0.962  8.018  B 4   ? 1.00 59.00  1 
+ATOM   2000 C CG2 . ILE B 1 4   13.787 -1.370  10.010 B 4   ? 1.00 51.37  1 
+ATOM   2001 C CD1 . ILE B 1 4   11.690 -2.343  8.025  B 4   ? 1.00 60.42  1 
+ATOM   2002 N N   . LEU B 1 5   16.113 0.790   10.258 B 5   ? 1.00 42.10  1 
+ATOM   2003 C CA  . LEU B 1 5   17.364 0.610   10.949 B 5   ? 1.00 41.72  1 
+ATOM   2004 C C   . LEU B 1 5   17.066 -0.411  12.013 B 5   ? 1.00 40.37  1 
+ATOM   2005 O O   . LEU B 1 5   16.071 -0.292  12.735 B 5   ? 1.00 42.94  1 
+ATOM   2006 C CB  . LEU B 1 5   17.817 1.896   11.571 B 5   ? 1.00 40.46  1 
+ATOM   2007 C CG  . LEU B 1 5   17.955 3.057   10.600 B 5   ? 1.00 42.49  1 
+ATOM   2008 C CD1 . LEU B 1 5   18.514 4.244   11.389 B 5   ? 1.00 47.45  1 
+ATOM   2009 C CD2 . LEU B 1 5   18.845 2.684   9.406  B 5   ? 1.00 37.74  1 
+ATOM   2010 N N   . LEU B 1 6   17.961 -1.390  12.084 B 6   ? 1.00 36.41  1 
+ATOM   2011 C CA  . LEU B 1 6   17.873 -2.565  12.933 B 6   ? 1.00 40.19  1 
+ATOM   2012 C C   . LEU B 1 6   19.120 -2.684  13.799 B 6   ? 1.00 39.44  1 
+ATOM   2013 O O   . LEU B 1 6   20.227 -2.447  13.301 B 6   ? 1.00 42.64  1 
+ATOM   2014 C CB  . LEU B 1 6   17.758 -3.744  12.031 B 6   ? 1.00 41.77  1 
+ATOM   2015 C CG  . LEU B 1 6   16.842 -4.871  12.331 B 6   ? 1.00 48.66  1 
+ATOM   2016 C CD1 . LEU B 1 6   15.402 -4.380  12.555 B 6   ? 1.00 46.66  1 
+ATOM   2017 C CD2 . LEU B 1 6   16.983 -5.852  11.167 B 6   ? 1.00 49.02  1 
+ATOM   2018 N N   . GLY B 1 7   19.057 -3.003  15.080 B 7   ? 1.00 44.76  1 
+ATOM   2019 C CA  . GLY B 1 7   20.272 -3.070  15.888 B 7   ? 1.00 40.36  1 
+ATOM   2020 C C   . GLY B 1 7   19.954 -2.918  17.356 B 7   ? 1.00 41.77  1 
+ATOM   2021 O O   . GLY B 1 7   18.844 -2.521  17.735 B 7   ? 1.00 43.95  1 
+ATOM   2022 N N   . ALA B 1 8   20.929 -3.294  18.183 B 8   ? 1.00 39.38  1 
+ATOM   2023 C CA  . ALA B 1 8   20.758 -3.337  19.621 B 8   ? 1.00 35.60  1 
+ATOM   2024 C C   . ALA B 1 8   20.475 -1.974  20.190 B 8   ? 1.00 27.31  1 
+ATOM   2025 O O   . ALA B 1 8   20.799 -0.992  19.522 B 8   ? 1.00 33.53  1 
+ATOM   2026 C CB  . ALA B 1 8   22.035 -3.915  20.266 B 8   ? 1.00 37.34  1 
+ATOM   2027 N N   . PRO B 1 9   19.946 -1.841  21.419 B 9   ? 1.00 37.00  1 
+ATOM   2028 C CA  . PRO B 1 9   19.941 -0.573  22.161 B 9   ? 1.00 29.14  1 
+ATOM   2029 C C   . PRO B 1 9   21.313 0.109   22.079 B 9   ? 1.00 35.37  1 
+ATOM   2030 O O   . PRO B 1 9   22.304 -0.513  22.486 B 9   ? 1.00 42.22  1 
+ATOM   2031 C CB  . PRO B 1 9   19.573 -1.010  23.539 B 9   ? 1.00 33.91  1 
+ATOM   2032 C CG  . PRO B 1 9   18.671 -2.184  23.335 B 9   ? 1.00 30.86  1 
+ATOM   2033 C CD  . PRO B 1 9   19.367 -2.929  22.219 B 9   ? 1.00 33.98  1 
+ATOM   2034 N N   . GLY B 1 10  21.464 1.299   21.495 B 10  ? 1.00 38.61  1 
+ATOM   2035 C CA  . GLY B 1 10  22.728 2.031   21.494 B 10  ? 1.00 32.57  1 
+ATOM   2036 C C   . GLY B 1 10  23.612 1.650   20.330 B 10  ? 1.00 30.37  1 
+ATOM   2037 O O   . GLY B 1 10  24.784 2.003   20.301 B 10  ? 1.00 34.38  1 
+ATOM   2038 N N   . ALA B 1 11  23.098 0.947   19.342 B 11  ? 1.00 34.02  1 
+ATOM   2039 C CA  . ALA B 1 11  23.890 0.547   18.190 B 11  ? 1.00 33.03  1 
+ATOM   2040 C C   . ALA B 1 11  24.343 1.712   17.300 B 11  ? 1.00 35.80  1 
+ATOM   2041 O O   . ALA B 1 11  25.245 1.535   16.462 B 11  ? 1.00 43.03  1 
+ATOM   2042 C CB  . ALA B 1 11  23.091 -0.431  17.346 B 11  ? 1.00 31.19  1 
+ATOM   2043 N N   . GLY B 1 12  23.720 2.893   17.440 B 12  ? 1.00 33.35  1 
+ATOM   2044 C CA  . GLY B 1 12  24.077 4.056   16.658 B 12  ? 1.00 30.37  1 
+ATOM   2045 C C   . GLY B 1 12  22.990 4.425   15.684 B 12  ? 1.00 31.40  1 
+ATOM   2046 O O   . GLY B 1 12  23.215 5.330   14.878 B 12  ? 1.00 40.02  1 
+ATOM   2047 N N   . LYS B 1 13  21.787 3.848   15.763 B 13  ? 1.00 29.01  1 
+ATOM   2048 C CA  . LYS B 1 13  20.779 4.049   14.730 B 13  ? 1.00 34.98  1 
+ATOM   2049 C C   . LYS B 1 13  20.288 5.485   14.599 B 13  ? 1.00 33.86  1 
+ATOM   2050 O O   . LYS B 1 13  20.339 6.050   13.502 B 13  ? 1.00 40.66  1 
+ATOM   2051 C CB  . LYS B 1 13  19.571 3.150   14.972 B 13  ? 1.00 34.62  1 
+ATOM   2052 C CG  . LYS B 1 13  19.826 1.646   14.878 B 13  ? 1.00 41.10  1 
+ATOM   2053 C CD  . LYS B 1 13  18.593 0.810   15.259 B 13  ? 1.00 41.42  1 
+ATOM   2054 C CE  . LYS B 1 13  18.013 1.059   16.675 B 13  ? 1.00 40.36  1 
+ATOM   2055 N NZ  . LYS B 1 13  18.879 0.536   17.689 B 13  ? 1.00 33.42  1 
+ATOM   2056 N N   . GLY B 1 14  19.841 6.161   15.640 B 14  ? 1.00 30.00  1 
+ATOM   2057 C CA  . GLY B 1 14  19.422 7.545   15.550 B 14  ? 1.00 29.39  1 
+ATOM   2058 C C   . GLY B 1 14  20.566 8.450   15.119 B 14  ? 1.00 38.09  1 
+ATOM   2059 O O   . GLY B 1 14  20.348 9.299   14.248 B 14  ? 1.00 38.51  1 
+ATOM   2060 N N   . THR B 1 15  21.786 8.237   15.651 B 15  ? 1.00 37.44  1 
+ATOM   2061 C CA  . THR B 1 15  22.940 9.041   15.293 B 15  ? 1.00 33.43  1 
+ATOM   2062 C C   . THR B 1 15  23.058 8.991   13.791 B 15  ? 1.00 32.89  1 
+ATOM   2063 O O   . THR B 1 15  23.175 10.044  13.166 B 15  ? 1.00 30.84  1 
+ATOM   2064 C CB  . THR B 1 15  24.234 8.500   15.922 B 15  ? 1.00 36.32  1 
+ATOM   2065 O OG1 . THR B 1 15  24.090 8.662   17.329 B 15  ? 1.00 38.15  1 
+ATOM   2066 C CG2 . THR B 1 15  25.481 9.251   15.515 B 15  ? 1.00 37.68  1 
+ATOM   2067 N N   . GLN B 1 16  22.914 7.843   13.158 B 16  ? 1.00 32.92  1 
+ATOM   2068 C CA  . GLN B 1 16  23.052 7.821   11.715 B 16  ? 1.00 36.52  1 
+ATOM   2069 C C   . GLN B 1 16  21.813 8.215   10.931 B 16  ? 1.00 39.40  1 
+ATOM   2070 O O   . GLN B 1 16  21.889 8.729   9.816  B 16  ? 1.00 42.84  1 
+ATOM   2071 C CB  . GLN B 1 16  23.502 6.458   11.302 B 16  ? 1.00 32.86  1 
+ATOM   2072 C CG  . GLN B 1 16  24.868 6.174   11.887 B 16  ? 1.00 34.60  1 
+ATOM   2073 C CD  . GLN B 1 16  25.969 7.091   11.400 B 16  ? 1.00 34.87  1 
+ATOM   2074 O OE1 . GLN B 1 16  26.979 7.292   12.064 B 16  ? 1.00 36.99  1 
+ATOM   2075 N NE2 . GLN B 1 16  25.870 7.644   10.208 B 16  ? 1.00 40.19  1 
+ATOM   2076 N N   . ALA B 1 17  20.653 7.998   11.495 B 17  ? 1.00 39.01  1 
+ATOM   2077 C CA  . ALA B 1 17  19.414 8.452   10.923 B 17  ? 1.00 47.16  1 
+ATOM   2078 C C   . ALA B 1 17  19.407 9.931   10.549 B 17  ? 1.00 43.52  1 
+ATOM   2079 O O   . ALA B 1 17  18.894 10.279  9.485  B 17  ? 1.00 44.04  1 
+ATOM   2080 C CB  . ALA B 1 17  18.311 8.228   11.918 B 17  ? 1.00 49.09  1 
+ATOM   2081 N N   . GLN B 1 18  19.997 10.805  11.370 B 18  ? 1.00 44.22  1 
+ATOM   2082 C CA  . GLN B 1 18  20.001 12.242  11.128 B 18  ? 1.00 48.06  1 
+ATOM   2083 C C   . GLN B 1 18  20.752 12.539  9.870  B 18  ? 1.00 48.99  1 
+ATOM   2084 O O   . GLN B 1 18  20.228 13.295  9.050  B 18  ? 1.00 49.18  1 
+ATOM   2085 C CB  . GLN B 1 18  20.651 13.030  12.231 B 18  ? 1.00 52.01  1 
+ATOM   2086 C CG  . GLN B 1 18  19.844 13.002  13.529 B 18  ? 1.00 64.20  1 
+ATOM   2087 C CD  . GLN B 1 18  20.717 13.009  14.801 B 18  ? 1.00 76.47  1 
+ATOM   2088 O OE1 . GLN B 1 18  20.261 12.589  15.863 B 18  ? 1.00 80.71  1 
+ATOM   2089 N NE2 . GLN B 1 18  21.988 13.408  14.870 B 18  ? 1.00 76.58  1 
+ATOM   2090 N N   . PHE B 1 19  21.915 11.920  9.668  B 19  ? 1.00 47.30  1 
+ATOM   2091 C CA  . PHE B 1 19  22.622 12.089  8.417  B 19  ? 1.00 52.09  1 
+ATOM   2092 C C   . PHE B 1 19  21.761 11.614  7.227  B 19  ? 1.00 52.15  1 
+ATOM   2093 O O   . PHE B 1 19  21.701 12.322  6.217  B 19  ? 1.00 48.70  1 
+ATOM   2094 C CB  . PHE B 1 19  23.982 11.315  8.458  B 19  ? 1.00 62.83  1 
+ATOM   2095 C CG  . PHE B 1 19  24.366 10.647  7.110  B 19  ? 1.00 78.66  1 
+ATOM   2096 C CD1 . PHE B 1 19  24.827 11.402  6.031  B 19  ? 1.00 82.12  1 
+ATOM   2097 C CD2 . PHE B 1 19  24.156 9.276   6.923  B 19  ? 1.00 81.20  1 
+ATOM   2098 C CE1 . PHE B 1 19  25.059 10.794  4.810  B 19  ? 1.00 80.52  1 
+ATOM   2099 C CE2 . PHE B 1 19  24.391 8.681   5.697  B 19  ? 1.00 78.78  1 
+ATOM   2100 C CZ  . PHE B 1 19  24.835 9.443   4.648  B 19  ? 1.00 80.40  1 
+ATOM   2101 N N   . ILE B 1 20  21.096 10.442  7.257  B 20  ? 1.00 54.77  1 
+ATOM   2102 C CA  . ILE B 1 20  20.352 9.941   6.085  B 20  ? 1.00 53.50  1 
+ATOM   2103 C C   . ILE B 1 20  19.277 10.955  5.691  B 20  ? 1.00 55.71  1 
+ATOM   2104 O O   . ILE B 1 20  19.088 11.260  4.516  B 20  ? 1.00 55.97  1 
+ATOM   2105 C CB  . ILE B 1 20  19.727 8.544   6.428  B 20  ? 1.00 43.65  1 
+ATOM   2106 C CG1 . ILE B 1 20  20.853 7.526   6.571  B 20  ? 1.00 43.73  1 
+ATOM   2107 C CG2 . ILE B 1 20  18.783 8.072   5.326  B 20  ? 1.00 36.90  1 
+ATOM   2108 C CD1 . ILE B 1 20  20.692 6.504   7.714  B 20  ? 1.00 37.34  1 
+ATOM   2109 N N   . MET B 1 21  18.640 11.539  6.706  B 21  ? 1.00 53.50  1 
+ATOM   2110 C CA  . MET B 1 21  17.584 12.511  6.566  B 21  ? 1.00 55.59  1 
+ATOM   2111 C C   . MET B 1 21  18.019 13.768  5.786  B 21  ? 1.00 63.26  1 
+ATOM   2112 O O   . MET B 1 21  17.646 14.000  4.619  B 21  ? 1.00 54.67  1 
+ATOM   2113 C CB  . MET B 1 21  17.171 12.741  7.993  B 21  ? 1.00 45.94  1 
+ATOM   2114 C CG  . MET B 1 21  16.117 13.778  8.216  B 21  ? 1.00 59.65  1 
+ATOM   2115 S SD  . MET B 1 21  15.667 13.800  9.963  B 21  ? 1.00 68.89  1 
+ATOM   2116 C CE  . MET B 1 21  17.230 14.160  10.717 B 21  ? 1.00 65.04  1 
+ATOM   2117 N N   . GLU B 1 22  18.939 14.517  6.400  B 22  ? 1.00 68.11  1 
+ATOM   2118 C CA  . GLU B 1 22  19.457 15.752  5.835  B 22  ? 1.00 69.95  1 
+ATOM   2119 C C   . GLU B 1 22  20.054 15.548  4.462  B 22  ? 1.00 61.74  1 
+ATOM   2120 O O   . GLU B 1 22  20.015 16.446  3.627  B 22  ? 1.00 62.70  1 
+ATOM   2121 C CB  . GLU B 1 22  20.556 16.389  6.736  B 22  ? 1.00 80.66  1 
+ATOM   2122 C CG  . GLU B 1 22  21.914 15.659  6.882  B 22  ? 1.00 96.02  1 
+ATOM   2123 C CD  . GLU B 1 22  23.132 16.441  7.418  B 22  ? 1.00 103.95 1 
+ATOM   2124 O OE1 . GLU B 1 22  23.305 16.504  8.643  B 22  ? 1.00 106.95 1 
+ATOM   2125 O OE2 . GLU B 1 22  23.927 16.950  6.610  B 22  ? 1.00 106.47 1 
+ATOM   2126 N N   . LYS B 1 23  20.610 14.371  4.225  B 23  ? 1.00 55.62  1 
+ATOM   2127 C CA  . LYS B 1 23  21.283 14.154  2.976  B 23  ? 1.00 64.35  1 
+ATOM   2128 C C   . LYS B 1 23  20.345 13.533  1.962  B 23  ? 1.00 66.14  1 
+ATOM   2129 O O   . LYS B 1 23  20.562 13.666  0.760  B 23  ? 1.00 69.30  1 
+ATOM   2130 C CB  . LYS B 1 23  22.495 13.252  3.214  B 23  ? 1.00 70.08  1 
+ATOM   2131 C CG  . LYS B 1 23  23.671 13.477  2.258  B 23  ? 1.00 77.32  1 
+ATOM   2132 C CD  . LYS B 1 23  24.033 12.153  1.600  B 23  ? 1.00 77.45  1 
+ATOM   2133 C CE  . LYS B 1 23  25.035 12.305  0.473  B 23  ? 1.00 76.19  1 
+ATOM   2134 N NZ  . LYS B 1 23  25.206 11.005  -0.143 B 23  ? 1.00 70.39  1 
+ATOM   2135 N N   . TYR B 1 24  19.288 12.836  2.336  B 24  ? 1.00 65.86  1 
+ATOM   2136 C CA  . TYR B 1 24  18.518 12.180  1.304  B 24  ? 1.00 66.45  1 
+ATOM   2137 C C   . TYR B 1 24  17.121 12.746  1.190  B 24  ? 1.00 68.07  1 
+ATOM   2138 O O   . TYR B 1 24  16.349 12.397  0.290  B 24  ? 1.00 63.72  1 
+ATOM   2139 C CB  . TYR B 1 24  18.537 10.672  1.616  B 24  ? 1.00 67.20  1 
+ATOM   2140 C CG  . TYR B 1 24  19.927 10.040  1.444  B 24  ? 1.00 65.48  1 
+ATOM   2141 C CD1 . TYR B 1 24  20.337 9.705   0.176  B 24  ? 1.00 66.90  1 
+ATOM   2142 C CD2 . TYR B 1 24  20.777 9.794   2.509  B 24  ? 1.00 65.22  1 
+ATOM   2143 C CE1 . TYR B 1 24  21.572 9.134   -0.033 B 24  ? 1.00 65.93  1 
+ATOM   2144 C CE2 . TYR B 1 24  22.015 9.222   2.301  B 24  ? 1.00 62.68  1 
+ATOM   2145 C CZ  . TYR B 1 24  22.406 8.896   1.020  B 24  ? 1.00 59.30  1 
+ATOM   2146 O OH  . TYR B 1 24  23.642 8.343   0.766  B 24  ? 1.00 55.27  1 
+ATOM   2147 N N   . GLY B 1 25  16.807 13.633  2.130  B 25  ? 1.00 65.70  1 
+ATOM   2148 C CA  . GLY B 1 25  15.537 14.321  2.173  B 25  ? 1.00 68.83  1 
+ATOM   2149 C C   . GLY B 1 25  14.372 13.599  2.839  B 25  ? 1.00 69.97  1 
+ATOM   2150 O O   . GLY B 1 25  13.421 14.262  3.273  B 25  ? 1.00 75.41  1 
+ATOM   2151 N N   . ILE B 1 26  14.388 12.268  2.923  B 26  ? 1.00 68.22  1 
+ATOM   2152 C CA  . ILE B 1 26  13.304 11.475  3.522  B 26  ? 1.00 59.20  1 
+ATOM   2153 C C   . ILE B 1 26  13.047 11.819  4.978  B 26  ? 1.00 52.29  1 
+ATOM   2154 O O   . ILE B 1 26  14.011 12.185  5.640  B 26  ? 1.00 59.87  1 
+ATOM   2155 C CB  . ILE B 1 26  13.627 9.977   3.429  B 26  ? 1.00 56.62  1 
+ATOM   2156 C CG1 . ILE B 1 26  15.003 9.610   3.977  B 26  ? 1.00 54.45  1 
+ATOM   2157 C CG2 . ILE B 1 26  13.497 9.635   1.979  B 26  ? 1.00 48.49  1 
+ATOM   2158 C CD1 . ILE B 1 26  15.252 8.104   4.018  B 26  ? 1.00 62.43  1 
+ATOM   2159 N N   . PRO B 1 27  11.843 11.768  5.552  B 27  ? 1.00 55.31  1 
+ATOM   2160 C CA  . PRO B 1 27  11.619 11.921  6.997  B 27  ? 1.00 57.76  1 
+ATOM   2161 C C   . PRO B 1 27  11.911 10.709  7.912  B 27  ? 1.00 59.90  1 
+ATOM   2162 O O   . PRO B 1 27  11.626 9.544   7.591  B 27  ? 1.00 65.00  1 
+ATOM   2163 C CB  . PRO B 1 27  10.169 12.403  7.067  B 27  ? 1.00 56.55  1 
+ATOM   2164 C CG  . PRO B 1 27  9.544  11.660  5.902  B 27  ? 1.00 55.45  1 
+ATOM   2165 C CD  . PRO B 1 27  10.584 11.838  4.809  B 27  ? 1.00 58.04  1 
+ATOM   2166 N N   . GLN B 1 28  12.496 10.968  9.087  B 28  ? 1.00 59.88  1 
+ATOM   2167 C CA  . GLN B 1 28  12.800 9.945   10.086 B 28  ? 1.00 61.78  1 
+ATOM   2168 C C   . GLN B 1 28  11.521 9.669   10.885 B 28  ? 1.00 61.12  1 
+ATOM   2169 O O   . GLN B 1 28  10.899 10.585  11.427 B 28  ? 1.00 64.12  1 
+ATOM   2170 C CB  . GLN B 1 28  13.937 10.449  11.024 B 28  ? 1.00 60.26  1 
+ATOM   2171 C CG  . GLN B 1 28  14.373 9.546   12.192 B 28  ? 1.00 65.40  1 
+ATOM   2172 C CD  . GLN B 1 28  15.089 10.216  13.380 B 28  ? 1.00 70.59  1 
+ATOM   2173 O OE1 . GLN B 1 28  15.294 11.528  13.541 B 28  ? 1.00 70.04  1 
+ATOM   2174 N NE2 . GLN B 1 28  15.483 9.498   14.298 B 28  ? 1.00 75.58  1 
+ATOM   2175 N N   . ILE B 1 29  11.086 8.429   10.990 B 29  ? 1.00 60.46  1 
+ATOM   2176 C CA  . ILE B 1 29  9.920  8.082   11.769 B 29  ? 1.00 53.15  1 
+ATOM   2177 C C   . ILE B 1 29  10.517 7.211   12.854 B 29  ? 1.00 46.16  1 
+ATOM   2178 O O   . ILE B 1 29  10.844 6.054   12.613 B 29  ? 1.00 49.12  1 
+ATOM   2179 C CB  . ILE B 1 29  8.960  7.369   10.808 B 29  ? 1.00 51.44  1 
+ATOM   2180 C CG1 . ILE B 1 29  8.476  8.369   9.762  B 29  ? 1.00 55.41  1 
+ATOM   2181 C CG2 . ILE B 1 29  7.765  6.817   11.548 B 29  ? 1.00 49.58  1 
+ATOM   2182 C CD1 . ILE B 1 29  7.649  7.677   8.664  B 29  ? 1.00 63.15  1 
+ATOM   2183 N N   . SER B 1 30  10.761 7.798   14.008 B 30  ? 1.00 38.43  1 
+ATOM   2184 C CA  . SER B 1 30  11.332 7.135   15.151 B 30  ? 1.00 41.27  1 
+ATOM   2185 C C   . SER B 1 30  10.293 6.883   16.240 B 30  ? 1.00 47.30  1 
+ATOM   2186 O O   . SER B 1 30  9.831  7.812   16.932 B 30  ? 1.00 50.43  1 
+ATOM   2187 C CB  . SER B 1 30  12.486 8.009   15.664 B 30  ? 1.00 47.63  1 
+ATOM   2188 O OG  . SER B 1 30  12.863 7.872   17.046 B 30  ? 1.00 52.30  1 
+ATOM   2189 N N   . THR B 1 31  9.905  5.621   16.468 B 31  ? 1.00 43.77  1 
+ATOM   2190 C CA  . THR B 1 31  8.911  5.306   17.473 B 31  ? 1.00 40.92  1 
+ATOM   2191 C C   . THR B 1 31  9.309  5.682   18.870 B 31  ? 1.00 35.41  1 
+ATOM   2192 O O   . THR B 1 31  8.414  5.905   19.663 B 31  ? 1.00 41.35  1 
+ATOM   2193 C CB  . THR B 1 31  8.583  3.831   17.460 B 31  ? 1.00 45.07  1 
+ATOM   2194 O OG1 . THR B 1 31  9.767  3.088   17.284 B 31  ? 1.00 51.53  1 
+ATOM   2195 C CG2 . THR B 1 31  7.681  3.521   16.314 B 31  ? 1.00 47.35  1 
+ATOM   2196 N N   . GLY B 1 32  10.580 5.793   19.220 B 32  ? 1.00 35.14  1 
+ATOM   2197 C CA  . GLY B 1 32  10.958 6.188   20.552 B 32  ? 1.00 33.98  1 
+ATOM   2198 C C   . GLY B 1 32  10.749 7.689   20.740 B 32  ? 1.00 46.60  1 
+ATOM   2199 O O   . GLY B 1 32  10.201 8.174   21.744 B 32  ? 1.00 42.70  1 
+ATOM   2200 N N   . ASP B 1 33  11.152 8.457   19.730 B 33  ? 1.00 47.09  1 
+ATOM   2201 C CA  . ASP B 1 33  10.994 9.894   19.767 B 33  ? 1.00 51.78  1 
+ATOM   2202 C C   . ASP B 1 33  9.496  10.192  19.774 B 33  ? 1.00 52.51  1 
+ATOM   2203 O O   . ASP B 1 33  9.056  11.057  20.535 B 33  ? 1.00 54.04  1 
+ATOM   2204 C CB  . ASP B 1 33  11.707 10.528  18.538 B 33  ? 1.00 60.32  1 
+ATOM   2205 C CG  . ASP B 1 33  13.263 10.632  18.532 B 33  ? 1.00 66.90  1 
+ATOM   2206 O OD1 . ASP B 1 33  13.922 10.356  19.548 B 33  ? 1.00 62.29  1 
+ATOM   2207 O OD2 . ASP B 1 33  13.828 11.004  17.487 B 33  ? 1.00 67.91  1 
+ATOM   2208 N N   . MET B 1 34  8.671  9.451   19.020 B 34  ? 1.00 52.93  1 
+ATOM   2209 C CA  . MET B 1 34  7.221  9.637   19.070 B 34  ? 1.00 50.32  1 
+ATOM   2210 C C   . MET B 1 34  6.636  9.262   20.413 B 34  ? 1.00 50.68  1 
+ATOM   2211 O O   . MET B 1 34  5.726  9.945   20.879 B 34  ? 1.00 55.00  1 
+ATOM   2212 C CB  . MET B 1 34  6.461  8.809   18.056 B 34  ? 1.00 44.43  1 
+ATOM   2213 C CG  . MET B 1 34  6.756  9.341   16.691 B 34  ? 1.00 50.01  1 
+ATOM   2214 S SD  . MET B 1 34  5.799  8.544   15.390 B 34  ? 1.00 66.03  1 
+ATOM   2215 C CE  . MET B 1 34  7.099  7.506   14.808 B 34  ? 1.00 62.54  1 
+ATOM   2216 N N   . LEU B 1 35  7.104  8.194   21.055 B 35  ? 1.00 55.68  1 
+ATOM   2217 C CA  . LEU B 1 35  6.569  7.770   22.340 B 35  ? 1.00 52.31  1 
+ATOM   2218 C C   . LEU B 1 35  6.937  8.754   23.435 B 35  ? 1.00 47.03  1 
+ATOM   2219 O O   . LEU B 1 35  6.074  9.184   24.198 B 35  ? 1.00 44.69  1 
+ATOM   2220 C CB  . LEU B 1 35  7.097  6.375   22.686 B 35  ? 1.00 50.83  1 
+ATOM   2221 C CG  . LEU B 1 35  6.388  5.204   22.029 B 35  ? 1.00 48.18  1 
+ATOM   2222 C CD1 . LEU B 1 35  7.211  3.945   22.230 B 35  ? 1.00 47.33  1 
+ATOM   2223 C CD2 . LEU B 1 35  4.986  5.061   22.624 B 35  ? 1.00 39.86  1 
+ATOM   2224 N N   . ARG B 1 36  8.198  9.161   23.466 B 36  ? 1.00 39.83  1 
+ATOM   2225 C CA  . ARG B 1 36  8.667  10.117  24.416 B 36  ? 1.00 39.71  1 
+ATOM   2226 C C   . ARG B 1 36  7.979  11.474  24.392 B 36  ? 1.00 43.36  1 
+ATOM   2227 O O   . ARG B 1 36  7.697  12.078  25.452 B 36  ? 1.00 42.12  1 
+ATOM   2228 C CB  . ARG B 1 36  10.143 10.267  24.207 B 36  ? 1.00 43.10  1 
+ATOM   2229 C CG  . ARG B 1 36  10.814 9.212   25.063 B 36  ? 1.00 47.33  1 
+ATOM   2230 C CD  . ARG B 1 36  12.282 9.577   25.135 B 36  ? 1.00 52.87  1 
+ATOM   2231 N NE  . ARG B 1 36  12.877 9.364   23.836 B 36  ? 1.00 51.47  1 
+ATOM   2232 C CZ  . ARG B 1 36  13.272 8.150   23.436 B 36  ? 1.00 61.11  1 
+ATOM   2233 N NH1 . ARG B 1 36  13.234 7.081   24.267 B 36  ? 1.00 56.72  1 
+ATOM   2234 N NH2 . ARG B 1 36  13.729 8.029   22.179 B 36  ? 1.00 58.02  1 
+ATOM   2235 N N   . ALA B 1 37  7.701  11.931  23.172 B 37  ? 1.00 38.58  1 
+ATOM   2236 C CA  . ALA B 1 37  6.975  13.176  22.941 B 37  ? 1.00 46.05  1 
+ATOM   2237 C C   . ALA B 1 37  5.509  13.082  23.384 B 37  ? 1.00 51.87  1 
+ATOM   2238 O O   . ALA B 1 37  5.050  13.907  24.176 B 37  ? 1.00 53.11  1 
+ATOM   2239 C CB  . ALA B 1 37  6.990  13.540  21.458 B 37  ? 1.00 46.56  1 
+ATOM   2240 N N   . ALA B 1 38  4.775  12.045  22.956 B 38  ? 1.00 54.55  1 
+ATOM   2241 C CA  . ALA B 1 38  3.400  11.801  23.354 B 38  ? 1.00 47.35  1 
+ATOM   2242 C C   . ALA B 1 38  3.314  11.682  24.854 B 38  ? 1.00 41.41  1 
+ATOM   2243 O O   . ALA B 1 38  2.391  12.202  25.447 B 38  ? 1.00 44.57  1 
+ATOM   2244 C CB  . ALA B 1 38  2.875  10.516  22.745 B 38  ? 1.00 44.78  1 
+ATOM   2245 N N   . VAL B 1 39  4.292  11.129  25.525 B 39  ? 1.00 43.63  1 
+ATOM   2246 C CA  . VAL B 1 39  4.238  11.005  26.952 B 39  ? 1.00 47.67  1 
+ATOM   2247 C C   . VAL B 1 39  4.357  12.370  27.603 B 39  ? 1.00 60.59  1 
+ATOM   2248 O O   . VAL B 1 39  3.553  12.697  28.481 B 39  ? 1.00 63.13  1 
+ATOM   2249 C CB  . VAL B 1 39  5.356  10.051  27.348 B 39  ? 1.00 46.76  1 
+ATOM   2250 C CG1 . VAL B 1 39  5.677  10.089  28.836 B 39  ? 1.00 47.93  1 
+ATOM   2251 C CG2 . VAL B 1 39  4.877  8.665   26.992 B 39  ? 1.00 41.86  1 
+ATOM   2252 N N   . LYS B 1 40  5.289  13.199  27.126 B 40  ? 1.00 66.45  1 
+ATOM   2253 C CA  . LYS B 1 40  5.546  14.510  27.721 B 40  ? 1.00 74.18  1 
+ATOM   2254 C C   . LYS B 1 40  4.438  15.511  27.407 B 40  ? 1.00 73.08  1 
+ATOM   2255 O O   . LYS B 1 40  3.980  16.237  28.289 B 40  ? 1.00 76.24  1 
+ATOM   2256 C CB  . LYS B 1 40  6.898  15.004  27.210 B 40  ? 1.00 79.82  1 
+ATOM   2257 C CG  . LYS B 1 40  7.519  16.263  27.791 B 40  ? 1.00 79.90  1 
+ATOM   2258 C CD  . LYS B 1 40  8.835  16.514  27.057 B 40  ? 1.00 91.47  1 
+ATOM   2259 C CE  . LYS B 1 40  8.650  16.761  25.545 B 40  ? 1.00 97.22  1 
+ATOM   2260 N NZ  . LYS B 1 40  9.293  15.742  24.715 B 40  ? 1.00 99.33  1 
+ATOM   2261 N N   . SER B 1 41  3.968  15.591  26.168 B 41  ? 1.00 69.02  1 
+ATOM   2262 C CA  . SER B 1 41  2.819  16.413  25.859 B 41  ? 1.00 70.05  1 
+ATOM   2263 C C   . SER B 1 41  1.571  15.797  26.495 B 41  ? 1.00 74.27  1 
+ATOM   2264 O O   . SER B 1 41  0.571  16.489  26.698 B 41  ? 1.00 86.86  1 
+ATOM   2265 C CB  . SER B 1 41  2.627  16.523  24.332 B 41  ? 1.00 71.22  1 
+ATOM   2266 O OG  . SER B 1 41  2.808  15.317  23.584 B 41  ? 1.00 73.63  1 
+ATOM   2267 N N   . GLY B 1 42  1.596  14.512  26.853 B 42  ? 1.00 70.13  1 
+ATOM   2268 C CA  . GLY B 1 42  0.438  13.857  27.405 B 42  ? 1.00 63.47  1 
+ATOM   2269 C C   . GLY B 1 42  -0.532 13.598  26.266 B 42  ? 1.00 59.44  1 
+ATOM   2270 O O   . GLY B 1 42  -1.731 13.779  26.429 B 42  ? 1.00 69.31  1 
+ATOM   2271 N N   . SER B 1 43  -0.070 13.240  25.071 B 43  ? 1.00 56.71  1 
+ATOM   2272 C CA  . SER B 1 43  -0.939 12.910  23.957 B 43  ? 1.00 60.57  1 
+ATOM   2273 C C   . SER B 1 43  -1.754 11.654  24.247 B 43  ? 1.00 58.95  1 
+ATOM   2274 O O   . SER B 1 43  -1.260 10.659  24.783 B 43  ? 1.00 55.79  1 
+ATOM   2275 C CB  . SER B 1 43  -0.109 12.688  22.705 B 43  ? 1.00 67.21  1 
+ATOM   2276 O OG  . SER B 1 43  0.685  13.818  22.337 B 43  ? 1.00 76.32  1 
+ATOM   2277 N N   . GLU B 1 44  -3.028 11.687  23.872 B 44  ? 1.00 64.11  1 
+ATOM   2278 C CA  . GLU B 1 44  -3.914 10.574  24.145 B 44  ? 1.00 66.43  1 
+ATOM   2279 C C   . GLU B 1 44  -3.350 9.314   23.546 B 44  ? 1.00 61.02  1 
+ATOM   2280 O O   . GLU B 1 44  -3.311 8.312   24.250 B 44  ? 1.00 61.56  1 
+ATOM   2281 C CB  . GLU B 1 44  -5.301 10.879  23.579 B 44  ? 1.00 75.35  1 
+ATOM   2282 C CG  . GLU B 1 44  -6.371 9.765   23.612 B 44  ? 1.00 82.72  1 
+ATOM   2283 C CD  . GLU B 1 44  -6.927 9.266   24.950 B 44  ? 1.00 85.35  1 
+ATOM   2284 O OE1 . GLU B 1 44  -7.222 10.088  25.819 B 44  ? 1.00 89.96  1 
+ATOM   2285 O OE2 . GLU B 1 44  -7.105 8.050   25.099 B 44  ? 1.00 85.12  1 
+ATOM   2286 N N   . LEU B 1 45  -2.848 9.360   22.309 B 45  ? 1.00 55.20  1 
+ATOM   2287 C CA  . LEU B 1 45  -2.279 8.167   21.707 B 45  ? 1.00 51.44  1 
+ATOM   2288 C C   . LEU B 1 45  -0.802 8.174   22.016 B 45  ? 1.00 47.13  1 
+ATOM   2289 O O   . LEU B 1 45  -0.068 8.944   21.391 B 45  ? 1.00 53.87  1 
+ATOM   2290 C CB  . LEU B 1 45  -2.454 8.169   20.207 B 45  ? 1.00 49.88  1 
+ATOM   2291 C CG  . LEU B 1 45  -1.929 6.973   19.433 B 45  ? 1.00 46.27  1 
+ATOM   2292 C CD1 . LEU B 1 45  -2.779 5.761   19.740 B 45  ? 1.00 40.05  1 
+ATOM   2293 C CD2 . LEU B 1 45  -1.925 7.306   17.946 B 45  ? 1.00 41.09  1 
+ATOM   2294 N N   . GLY B 1 46  -0.397 7.440   23.040 B 46  ? 1.00 44.11  1 
+ATOM   2295 C CA  . GLY B 1 46  0.994  7.330   23.385 B 46  ? 1.00 39.68  1 
+ATOM   2296 C C   . GLY B 1 46  1.269  7.591   24.845 B 46  ? 1.00 40.86  1 
+ATOM   2297 O O   . GLY B 1 46  2.190  6.959   25.366 B 46  ? 1.00 40.86  1 
+ATOM   2298 N N   . LYS B 1 47  0.516  8.409   25.583 B 47  ? 1.00 42.99  1 
+ATOM   2299 C CA  . LYS B 1 47  0.896  8.739   26.955 B 47  ? 1.00 51.12  1 
+ATOM   2300 C C   . LYS B 1 47  0.986  7.551   27.909 B 47  ? 1.00 55.14  1 
+ATOM   2301 O O   . LYS B 1 47  1.601  7.636   28.977 B 47  ? 1.00 60.46  1 
+ATOM   2302 C CB  . LYS B 1 47  -0.083 9.749   27.598 B 47  ? 1.00 61.32  1 
+ATOM   2303 C CG  . LYS B 1 47  -1.349 9.152   28.257 B 47  ? 1.00 65.74  1 
+ATOM   2304 C CD  . LYS B 1 47  -2.120 10.148  29.094 B 47  ? 1.00 62.73  1 
+ATOM   2305 C CE  . LYS B 1 47  -3.090 10.878  28.186 B 47  ? 1.00 67.14  1 
+ATOM   2306 N NZ  . LYS B 1 47  -4.131 9.974   27.738 B 47  ? 1.00 72.35  1 
+ATOM   2307 N N   . GLN B 1 48  0.329  6.442   27.545 B 48  ? 1.00 55.99  1 
+ATOM   2308 C CA  . GLN B 1 48  0.249  5.192   28.309 B 48  ? 1.00 52.09  1 
+ATOM   2309 C C   . GLN B 1 48  1.612  4.507   28.445 B 48  ? 1.00 50.39  1 
+ATOM   2310 O O   . GLN B 1 48  1.938  3.797   29.409 B 48  ? 1.00 50.13  1 
+ATOM   2311 C CB  . GLN B 1 48  -0.726 4.229   27.614 B 48  ? 1.00 53.90  1 
+ATOM   2312 C CG  . GLN B 1 48  -2.144 4.711   27.249 B 48  ? 1.00 54.06  1 
+ATOM   2313 C CD  . GLN B 1 48  -2.333 5.574   25.995 B 48  ? 1.00 56.42  1 
+ATOM   2314 O OE1 . GLN B 1 48  -1.390 5.994   25.310 B 48  ? 1.00 52.39  1 
+ATOM   2315 N NE2 . GLN B 1 48  -3.569 5.901   25.655 B 48  ? 1.00 50.42  1 
+ATOM   2316 N N   . ALA B 1 49  2.453  4.788   27.452 B 49  ? 1.00 53.61  1 
+ATOM   2317 C CA  . ALA B 1 49  3.783  4.237   27.335 B 49  ? 1.00 52.41  1 
+ATOM   2318 C C   . ALA B 1 49  4.777  4.553   28.453 B 49  ? 1.00 48.13  1 
+ATOM   2319 O O   . ALA B 1 49  5.685  3.765   28.719 B 49  ? 1.00 54.18  1 
+ATOM   2320 C CB  . ALA B 1 49  4.312  4.711   26.016 B 49  ? 1.00 41.39  1 
+ATOM   2321 N N   . LYS B 1 50  4.582  5.631   29.194 B 50  ? 1.00 52.36  1 
+ATOM   2322 C CA  . LYS B 1 50  5.489  6.087   30.234 B 50  ? 1.00 59.68  1 
+ATOM   2323 C C   . LYS B 1 50  6.086  5.036   31.138 B 50  ? 1.00 60.83  1 
+ATOM   2324 O O   . LYS B 1 50  7.301  4.954   31.288 B 50  ? 1.00 70.28  1 
+ATOM   2325 C CB  . LYS B 1 50  4.783  7.096   31.108 B 50  ? 1.00 66.94  1 
+ATOM   2326 C CG  . LYS B 1 50  5.626  7.789   32.161 B 50  ? 1.00 74.82  1 
+ATOM   2327 C CD  . LYS B 1 50  4.632  8.683   32.840 B 50  ? 1.00 83.47  1 
+ATOM   2328 C CE  . LYS B 1 50  5.178  9.299   34.103 B 50  ? 1.00 92.84  1 
+ATOM   2329 N NZ  . LYS B 1 50  4.081  9.929   34.828 B 50  ? 1.00 103.03 1 
+ATOM   2330 N N   . ASP B 1 51  5.260  4.164   31.669 B 51  ? 1.00 59.52  1 
+ATOM   2331 C CA  . ASP B 1 51  5.736  3.198   32.630 B 51  ? 1.00 61.64  1 
+ATOM   2332 C C   . ASP B 1 51  6.553  2.095   32.011 B 51  ? 1.00 57.62  1 
+ATOM   2333 O O   . ASP B 1 51  7.607  1.717   32.519 B 51  ? 1.00 57.42  1 
+ATOM   2334 C CB  . ASP B 1 51  4.541  2.635   33.335 B 51  ? 1.00 74.95  1 
+ATOM   2335 C CG  . ASP B 1 51  3.647  3.750   33.845 B 51  ? 1.00 86.22  1 
+ATOM   2336 O OD1 . ASP B 1 51  4.113  4.530   34.688 B 51  ? 1.00 88.32  1 
+ATOM   2337 O OD2 . ASP B 1 51  2.511  3.838   33.359 B 51  ? 1.00 91.88  1 
+ATOM   2338 N N   . ILE B 1 52  6.092  1.683   30.844 B 52  ? 1.00 57.61  1 
+ATOM   2339 C CA  . ILE B 1 52  6.692  0.600   30.082 B 52  ? 1.00 58.79  1 
+ATOM   2340 C C   . ILE B 1 52  8.089  1.046   29.623 B 52  ? 1.00 50.34  1 
+ATOM   2341 O O   . ILE B 1 52  9.080  0.350   29.847 B 52  ? 1.00 48.35  1 
+ATOM   2342 C CB  . ILE B 1 52  5.754  0.262   28.869 B 52  ? 1.00 58.30  1 
+ATOM   2343 C CG1 . ILE B 1 52  4.294  -0.025  29.286 B 52  ? 1.00 61.62  1 
+ATOM   2344 C CG2 . ILE B 1 52  6.323  -0.968  28.208 B 52  ? 1.00 49.09  1 
+ATOM   2345 C CD1 . ILE B 1 52  3.223  -0.134  28.157 B 52  ? 1.00 61.15  1 
+ATOM   2346 N N   . MET B 1 53  8.216  2.245   29.064 B 53  ? 1.00 45.18  1 
+ATOM   2347 C CA  . MET B 1 53  9.509  2.727   28.650 B 53  ? 1.00 46.88  1 
+ATOM   2348 C C   . MET B 1 53  10.389 2.778   29.871 B 53  ? 1.00 55.17  1 
+ATOM   2349 O O   . MET B 1 53  11.467 2.196   29.842 B 53  ? 1.00 63.31  1 
+ATOM   2350 C CB  . MET B 1 53  9.432  4.104   28.065 B 53  ? 1.00 40.49  1 
+ATOM   2351 C CG  . MET B 1 53  8.669  4.061   26.775 B 53  ? 1.00 44.19  1 
+ATOM   2352 S SD  . MET B 1 53  8.836  5.554   25.762 B 53  ? 1.00 59.80  1 
+ATOM   2353 C CE  . MET B 1 53  8.063  6.762   26.802 B 53  ? 1.00 57.81  1 
+ATOM   2354 N N   . ASP B 1 54  9.915  3.315   30.994 B 54  ? 1.00 61.18  1 
+ATOM   2355 C CA  . ASP B 1 54  10.705 3.391   32.218 B 54  ? 1.00 69.24  1 
+ATOM   2356 C C   . ASP B 1 54  11.149 2.033   32.755 B 54  ? 1.00 68.36  1 
+ATOM   2357 O O   . ASP B 1 54  12.149 1.951   33.468 B 54  ? 1.00 63.31  1 
+ATOM   2358 C CB  . ASP B 1 54  9.923  4.099   33.359 B 54  ? 1.00 86.87  1 
+ATOM   2359 C CG  . ASP B 1 54  9.581  5.599   33.232 B 54  ? 1.00 99.69  1 
+ATOM   2360 O OD1 . ASP B 1 54  9.976  6.243   32.249 B 54  ? 1.00 98.19  1 
+ATOM   2361 O OD2 . ASP B 1 54  8.904  6.122   34.135 B 54  ? 1.00 104.85 1 
+ATOM   2362 N N   . ALA B 1 55  10.424 0.945   32.456 B 55  ? 1.00 67.00  1 
+ATOM   2363 C CA  . ALA B 1 55  10.773 -0.390  32.953 B 55  ? 1.00 61.13  1 
+ATOM   2364 C C   . ALA B 1 55  11.801 -1.140  32.117 B 55  ? 1.00 55.99  1 
+ATOM   2365 O O   . ALA B 1 55  12.313 -2.195  32.516 B 55  ? 1.00 45.73  1 
+ATOM   2366 C CB  . ALA B 1 55  9.520  -1.262  33.034 B 55  ? 1.00 58.56  1 
+ATOM   2367 N N   . GLY B 1 56  12.033 -0.566  30.923 B 56  ? 1.00 53.86  1 
+ATOM   2368 C CA  . GLY B 1 56  12.958 -1.089  29.927 B 56  ? 1.00 47.14  1 
+ATOM   2369 C C   . GLY B 1 56  12.318 -2.202  29.137 B 56  ? 1.00 39.31  1 
+ATOM   2370 O O   . GLY B 1 56  12.985 -3.089  28.638 B 56  ? 1.00 37.04  1 
+ATOM   2371 N N   . LYS B 1 57  11.002 -2.152  29.032 B 57  ? 1.00 49.01  1 
+ATOM   2372 C CA  . LYS B 1 57  10.224 -3.170  28.370 B 57  ? 1.00 49.99  1 
+ATOM   2373 C C   . LYS B 1 57  9.640  -2.444  27.192 B 57  ? 1.00 48.14  1 
+ATOM   2374 O O   . LYS B 1 57  9.420  -1.227  27.247 B 57  ? 1.00 46.86  1 
+ATOM   2375 C CB  . LYS B 1 57  9.088  -3.641  29.225 B 57  ? 1.00 57.87  1 
+ATOM   2376 C CG  . LYS B 1 57  9.416  -4.276  30.563 B 57  ? 1.00 72.30  1 
+ATOM   2377 C CD  . LYS B 1 57  8.061  -4.546  31.235 B 57  ? 1.00 90.69  1 
+ATOM   2378 C CE  . LYS B 1 57  8.138  -5.684  32.268 B 57  ? 1.00 104.95 1 
+ATOM   2379 N NZ  . LYS B 1 57  6.831  -6.094  32.775 B 57  ? 1.00 109.66 1 
+ATOM   2380 N N   . LEU B 1 58  9.365  -3.223  26.158 B 58  ? 1.00 49.74  1 
+ATOM   2381 C CA  . LEU B 1 58  8.770  -2.710  24.929 B 58  ? 1.00 47.55  1 
+ATOM   2382 C C   . LEU B 1 58  7.281  -2.432  25.132 B 58  ? 1.00 47.77  1 
+ATOM   2383 O O   . LEU B 1 58  6.558  -3.036  25.947 B 58  ? 1.00 46.23  1 
+ATOM   2384 C CB  . LEU B 1 58  8.884  -3.712  23.801 B 58  ? 1.00 42.98  1 
+ATOM   2385 C CG  . LEU B 1 58  10.140 -4.492  23.547 B 58  ? 1.00 40.31  1 
+ATOM   2386 C CD1 . LEU B 1 58  9.792  -5.698  22.701 B 58  ? 1.00 39.11  1 
+ATOM   2387 C CD2 . LEU B 1 58  11.170 -3.594  22.932 B 58  ? 1.00 45.38  1 
+ATOM   2388 N N   . VAL B 1 59  6.813  -1.491  24.345 B 59  ? 1.00 41.05  1 
+ATOM   2389 C CA  . VAL B 1 59  5.426  -1.105  24.382 B 59  ? 1.00 41.20  1 
+ATOM   2390 C C   . VAL B 1 59  4.610  -2.098  23.555 B 59  ? 1.00 46.30  1 
+ATOM   2391 O O   . VAL B 1 59  5.188  -2.787  22.697 B 59  ? 1.00 47.85  1 
+ATOM   2392 C CB  . VAL B 1 59  5.419  0.333   23.862 B 59  ? 1.00 39.36  1 
+ATOM   2393 C CG1 . VAL B 1 59  4.086  0.900   23.403 B 59  ? 1.00 39.48  1 
+ATOM   2394 C CG2 . VAL B 1 59  5.898  1.110   25.053 B 59  ? 1.00 35.45  1 
+ATOM   2395 N N   . THR B 1 60  3.276  -2.161  23.760 B 60  ? 1.00 40.63  1 
+ATOM   2396 C CA  . THR B 1 60  2.428  -3.065  23.022 B 60  ? 1.00 41.19  1 
+ATOM   2397 C C   . THR B 1 60  2.498  -2.787  21.527 B 60  ? 1.00 40.58  1 
+ATOM   2398 O O   . THR B 1 60  2.586  -1.653  21.042 B 60  ? 1.00 48.43  1 
+ATOM   2399 C CB  . THR B 1 60  0.940  -2.955  23.496 B 60  ? 1.00 49.53  1 
+ATOM   2400 O OG1 . THR B 1 60  0.443  -1.640  23.240 B 60  ? 1.00 50.99  1 
+ATOM   2401 C CG2 . THR B 1 60  0.829  -3.289  24.961 B 60  ? 1.00 48.56  1 
+ATOM   2402 N N   . ASP B 1 61  2.416  -3.852  20.770 B 61  ? 1.00 35.24  1 
+ATOM   2403 C CA  . ASP B 1 61  2.464  -3.706  19.347 B 61  ? 1.00 40.31  1 
+ATOM   2404 C C   . ASP B 1 61  1.340  -2.865  18.766 B 61  ? 1.00 37.61  1 
+ATOM   2405 O O   . ASP B 1 61  1.680  -1.998  17.962 B 61  ? 1.00 37.50  1 
+ATOM   2406 C CB  . ASP B 1 61  2.466  -5.089  18.713 B 61  ? 1.00 44.33  1 
+ATOM   2407 C CG  . ASP B 1 61  3.722  -5.934  18.938 B 61  ? 1.00 51.23  1 
+ATOM   2408 O OD1 . ASP B 1 61  4.842  -5.458  18.798 B 61  ? 1.00 45.62  1 
+ATOM   2409 O OD2 . ASP B 1 61  3.571  -7.099  19.262 B 61  ? 1.00 55.61  1 
+ATOM   2410 N N   . GLU B 1 62  0.054  -3.007  19.131 B 62  ? 1.00 39.71  1 
+ATOM   2411 C CA  . GLU B 1 62  -0.980 -2.262  18.431 B 62  ? 1.00 36.29  1 
+ATOM   2412 C C   . GLU B 1 62  -0.812 -0.781  18.674 B 62  ? 1.00 40.52  1 
+ATOM   2413 O O   . GLU B 1 62  -0.981 -0.001  17.725 B 62  ? 1.00 40.20  1 
+ATOM   2414 C CB  . GLU B 1 62  -2.398 -2.652  18.856 B 62  ? 1.00 34.65  1 
+ATOM   2415 C CG  . GLU B 1 62  -2.906 -2.294  20.251 B 62  ? 1.00 42.68  1 
+ATOM   2416 C CD  . GLU B 1 62  -4.401 -2.550  20.536 B 62  ? 1.00 48.62  1 
+ATOM   2417 O OE1 . GLU B 1 62  -5.277 -2.371  19.675 B 62  ? 1.00 46.42  1 
+ATOM   2418 O OE2 . GLU B 1 62  -4.698 -2.909  21.669 B 62  ? 1.00 43.96  1 
+ATOM   2419 N N   . LEU B 1 63  -0.379 -0.403  19.890 B 63  ? 1.00 34.62  1 
+ATOM   2420 C CA  . LEU B 1 63  -0.167 1.001   20.252 B 63  ? 1.00 38.93  1 
+ATOM   2421 C C   . LEU B 1 63  0.882  1.632   19.355 B 63  ? 1.00 44.33  1 
+ATOM   2422 O O   . LEU B 1 63  0.627  2.675   18.728 B 63  ? 1.00 43.64  1 
+ATOM   2423 C CB  . LEU B 1 63  0.252  1.089   21.740 B 63  ? 1.00 39.23  1 
+ATOM   2424 C CG  . LEU B 1 63  0.344  2.398   22.544 B 63  ? 1.00 44.47  1 
+ATOM   2425 C CD1 . LEU B 1 63  -0.817 3.360   22.227 B 63  ? 1.00 44.57  1 
+ATOM   2426 C CD2 . LEU B 1 63  0.329  2.022   24.022 B 63  ? 1.00 42.25  1 
+ATOM   2427 N N   . VAL B 1 64  2.023  0.949   19.202 B 64  ? 1.00 42.68  1 
+ATOM   2428 C CA  . VAL B 1 64  3.083  1.437   18.332 B 64  ? 1.00 45.33  1 
+ATOM   2429 C C   . VAL B 1 64  2.649  1.396   16.859 B 64  ? 1.00 50.45  1 
+ATOM   2430 O O   . VAL B 1 64  2.973  2.312   16.079 B 64  ? 1.00 54.92  1 
+ATOM   2431 C CB  . VAL B 1 64  4.359  0.583   18.528 B 64  ? 1.00 47.26  1 
+ATOM   2432 C CG1 . VAL B 1 64  5.473  1.079   17.666 B 64  ? 1.00 45.27  1 
+ATOM   2433 C CG2 . VAL B 1 64  4.894  0.763   19.910 B 64  ? 1.00 44.50  1 
+ATOM   2434 N N   . ILE B 1 65  1.881  0.382   16.430 B 65  ? 1.00 47.87  1 
+ATOM   2435 C CA  . ILE B 1 65  1.493  0.261   15.027 B 65  ? 1.00 43.32  1 
+ATOM   2436 C C   . ILE B 1 65  0.553  1.381   14.622 B 65  ? 1.00 44.40  1 
+ATOM   2437 O O   . ILE B 1 65  0.658  1.929   13.521 B 65  ? 1.00 47.81  1 
+ATOM   2438 C CB  . ILE B 1 65  0.871  -1.127  14.814 B 65  ? 1.00 35.45  1 
+ATOM   2439 C CG1 . ILE B 1 65  2.025  -2.107  14.691 B 65  ? 1.00 40.80  1 
+ATOM   2440 C CG2 . ILE B 1 65  0.009  -1.191  13.583 B 65  ? 1.00 42.11  1 
+ATOM   2441 C CD1 . ILE B 1 65  1.611  -3.587  14.634 B 65  ? 1.00 36.21  1 
+ATOM   2442 N N   . ALA B 1 66  -0.334 1.772   15.519 B 66  ? 1.00 42.96  1 
+ATOM   2443 C CA  . ALA B 1 66  -1.205 2.906   15.276 B 66  ? 1.00 43.18  1 
+ATOM   2444 C C   . ALA B 1 66  -0.348 4.153   15.135 B 66  ? 1.00 45.50  1 
+ATOM   2445 O O   . ALA B 1 66  -0.538 4.883   14.161 B 66  ? 1.00 47.47  1 
+ATOM   2446 C CB  . ALA B 1 66  -2.155 3.117   16.436 B 66  ? 1.00 38.56  1 
+ATOM   2447 N N   . LEU B 1 67  0.631  4.370   16.040 B 67  ? 1.00 45.88  1 
+ATOM   2448 C CA  . LEU B 1 67  1.480  5.552   16.017 B 67  ? 1.00 40.88  1 
+ATOM   2449 C C   . LEU B 1 67  2.198  5.689   14.711 B 67  ? 1.00 42.91  1 
+ATOM   2450 O O   . LEU B 1 67  2.193  6.771   14.123 B 67  ? 1.00 50.28  1 
+ATOM   2451 C CB  . LEU B 1 67  2.538  5.540   17.131 B 67  ? 1.00 47.28  1 
+ATOM   2452 C CG  . LEU B 1 67  2.243  6.252   18.471 B 67  ? 1.00 43.39  1 
+ATOM   2453 C CD1 . LEU B 1 67  3.540  6.387   19.240 B 67  ? 1.00 42.26  1 
+ATOM   2454 C CD2 . LEU B 1 67  1.732  7.674   18.263 B 67  ? 1.00 37.14  1 
+ATOM   2455 N N   . VAL B 1 68  2.724  4.565   14.231 B 68  ? 1.00 46.93  1 
+ATOM   2456 C CA  . VAL B 1 68  3.397  4.540   12.946 B 68  ? 1.00 47.81  1 
+ATOM   2457 C C   . VAL B 1 68  2.403  4.764   11.833 B 68  ? 1.00 48.25  1 
+ATOM   2458 O O   . VAL B 1 68  2.696  5.626   11.010 B 68  ? 1.00 58.34  1 
+ATOM   2459 C CB  . VAL B 1 68  4.140  3.197   12.725 B 68  ? 1.00 43.84  1 
+ATOM   2460 C CG1 . VAL B 1 68  4.774  3.092   11.339 B 68  ? 1.00 38.12  1 
+ATOM   2461 C CG2 . VAL B 1 68  5.274  3.135   13.726 B 68  ? 1.00 41.82  1 
+ATOM   2462 N N   . LYS B 1 69  1.230  4.119   11.778 B 69  ? 1.00 52.29  1 
+ATOM   2463 C CA  . LYS B 1 69  0.274  4.312   10.686 B 69  ? 1.00 55.24  1 
+ATOM   2464 C C   . LYS B 1 69  -0.219 5.748   10.539 B 69  ? 1.00 52.30  1 
+ATOM   2465 O O   . LYS B 1 69  -0.409 6.260   9.427  B 69  ? 1.00 59.99  1 
+ATOM   2466 C CB  . LYS B 1 69  -0.915 3.383   10.880 B 69  ? 1.00 55.72  1 
+ATOM   2467 C CG  . LYS B 1 69  -0.573 1.977   10.417 B 69  ? 1.00 65.34  1 
+ATOM   2468 C CD  . LYS B 1 69  -1.631 0.969   10.859 B 69  ? 1.00 67.77  1 
+ATOM   2469 C CE  . LYS B 1 69  -1.179 -0.415  10.424 B 69  ? 1.00 69.72  1 
+ATOM   2470 N NZ  . LYS B 1 69  -2.032 -1.424  11.012 B 69  ? 1.00 69.22  1 
+ATOM   2471 N N   . GLU B 1 70  -0.361 6.430   11.662 B 70  ? 1.00 46.34  1 
+ATOM   2472 C CA  . GLU B 1 70  -0.744 7.814   11.654 B 70  ? 1.00 49.90  1 
+ATOM   2473 C C   . GLU B 1 70  0.393  8.510   10.946 B 70  ? 1.00 54.20  1 
+ATOM   2474 O O   . GLU B 1 70  0.194  8.940   9.819  B 70  ? 1.00 55.85  1 
+ATOM   2475 C CB  . GLU B 1 70  -0.877 8.402   13.071 B 70  ? 1.00 60.24  1 
+ATOM   2476 C CG  . GLU B 1 70  -1.886 7.798   14.038 B 70  ? 1.00 69.87  1 
+ATOM   2477 C CD  . GLU B 1 70  -3.344 7.828   13.579 B 70  ? 1.00 80.64  1 
+ATOM   2478 O OE1 . GLU B 1 70  -3.979 8.887   13.710 B 70  ? 1.00 81.32  1 
+ATOM   2479 O OE2 . GLU B 1 70  -3.835 6.783   13.116 B 70  ? 1.00 84.33  1 
+ATOM   2480 N N   . ARG B 1 71  1.610  8.498   11.506 B 71  ? 1.00 59.89  1 
+ATOM   2481 C CA  . ARG B 1 71  2.741  9.226   10.944 B 71  ? 1.00 61.90  1 
+ATOM   2482 C C   . ARG B 1 71  2.938  9.030   9.448  B 71  ? 1.00 63.69  1 
+ATOM   2483 O O   . ARG B 1 71  3.167  10.007  8.747  B 71  ? 1.00 64.67  1 
+ATOM   2484 C CB  . ARG B 1 71  4.030  8.824   11.654 B 71  ? 1.00 60.93  1 
+ATOM   2485 C CG  . ARG B 1 71  5.246  9.639   11.205 B 71  ? 1.00 64.59  1 
+ATOM   2486 C CD  . ARG B 1 71  5.084  11.108  11.608 B 71  ? 1.00 68.28  1 
+ATOM   2487 N NE  . ARG B 1 71  6.132  11.968  11.080 B 71  ? 1.00 73.43  1 
+ATOM   2488 C CZ  . ARG B 1 71  6.120  12.405  9.814  B 71  ? 1.00 71.37  1 
+ATOM   2489 N NH1 . ARG B 1 71  5.166  12.031  8.972  B 71  ? 1.00 67.91  1 
+ATOM   2490 N NH2 . ARG B 1 71  7.082  13.218  9.381  B 71  ? 1.00 68.81  1 
+ATOM   2491 N N   . ILE B 1 72  2.769  7.813   8.945  B 72  ? 1.00 67.64  1 
+ATOM   2492 C CA  . ILE B 1 72  2.974  7.510   7.546  B 72  ? 1.00 75.41  1 
+ATOM   2493 C C   . ILE B 1 72  1.957  8.186   6.652  B 72  ? 1.00 81.21  1 
+ATOM   2494 O O   . ILE B 1 72  2.263  8.508   5.495  B 72  ? 1.00 86.53  1 
+ATOM   2495 C CB  . ILE B 1 72  2.968  5.962   7.404  B 72  ? 1.00 78.00  1 
+ATOM   2496 C CG1 . ILE B 1 72  4.304  5.477   7.952  B 72  ? 1.00 81.03  1 
+ATOM   2497 C CG2 . ILE B 1 72  2.813  5.482   5.964  B 72  ? 1.00 83.22  1 
+ATOM   2498 C CD1 . ILE B 1 72  4.571  3.975   7.791  B 72  ? 1.00 84.61  1 
+ATOM   2499 N N   . ALA B 1 73  0.741  8.430   7.128  B 73  ? 1.00 86.64  1 
+ATOM   2500 C CA  . ALA B 1 73  -0.224 9.153   6.314  B 73  ? 1.00 94.44  1 
+ATOM   2501 C C   . ALA B 1 73  0.275  10.549  5.889  B 73  ? 1.00 99.43  1 
+ATOM   2502 O O   . ALA B 1 73  -0.004 10.996  4.761  B 73  ? 1.00 100.06 1 
+ATOM   2503 C CB  . ALA B 1 73  -1.515 9.314   7.091  B 73  ? 1.00 94.36  1 
+ATOM   2504 N N   . GLN B 1 74  1.085  11.194  6.753  B 74  ? 1.00 100.49 1 
+ATOM   2505 C CA  . GLN B 1 74  1.632  12.531  6.561  B 74  ? 1.00 97.33  1 
+ATOM   2506 C C   . GLN B 1 74  2.406  12.700  5.272  B 74  ? 1.00 98.96  1 
+ATOM   2507 O O   . GLN B 1 74  3.483  12.122  5.105  B 74  ? 1.00 91.79  1 
+ATOM   2508 C CB  . GLN B 1 74  2.573  12.906  7.674  B 74  ? 1.00 98.54  1 
+ATOM   2509 C CG  . GLN B 1 74  2.035  13.685  8.854  B 74  ? 1.00 104.81 1 
+ATOM   2510 C CD  . GLN B 1 74  1.076  12.930  9.751  B 74  ? 1.00 108.40 1 
+ATOM   2511 O OE1 . GLN B 1 74  -0.080 12.694  9.407  B 74  ? 1.00 110.41 1 
+ATOM   2512 N NE2 . GLN B 1 74  1.513  12.547  10.942 B 74  ? 1.00 107.95 1 
+ATOM   2513 N N   . GLU B 1 75  1.857  13.593  4.428  B 75  ? 1.00 103.66 1 
+ATOM   2514 C CA  . GLU B 1 75  2.316  13.888  3.064  B 75  ? 1.00 102.68 1 
+ATOM   2515 C C   . GLU B 1 75  3.815  13.877  2.779  B 75  ? 1.00 102.58 1 
+ATOM   2516 O O   . GLU B 1 75  4.265  13.478  1.697  B 75  ? 1.00 105.22 1 
+ATOM   2517 C CB  . GLU B 1 75  1.796  15.253  2.598  B 75  ? 1.00 97.90  1 
+ATOM   2518 C CG  . GLU B 1 75  1.590  15.166  1.080  B 75  ? 1.00 92.22  1 
+ATOM   2519 C CD  . GLU B 1 75  1.966  16.317  0.151  B 75  ? 1.00 88.06  1 
+ATOM   2520 O OE1 . GLU B 1 75  1.986  17.495  0.533  B 75  ? 1.00 83.87  1 
+ATOM   2521 O OE2 . GLU B 1 75  2.219  15.994  -1.007 B 75  ? 1.00 82.49  1 
+ATOM   2522 N N   . ASP B 1 76  4.619  14.367  3.713  B 76  ? 1.00 102.35 1 
+ATOM   2523 C CA  . ASP B 1 76  6.069  14.325  3.608  B 76  ? 1.00 102.20 1 
+ATOM   2524 C C   . ASP B 1 76  6.611  12.948  3.165  B 76  ? 1.00 105.04 1 
+ATOM   2525 O O   . ASP B 1 76  7.319  12.811  2.148  B 76  ? 1.00 107.55 1 
+ATOM   2526 C CB  . ASP B 1 76  6.635  14.769  4.995  B 76  ? 1.00 98.39  1 
+ATOM   2527 C CG  . ASP B 1 76  6.000  14.159  6.257  B 76  ? 1.00 90.97  1 
+ATOM   2528 O OD1 . ASP B 1 76  6.331  13.036  6.608  B 76  ? 1.00 81.22  1 
+ATOM   2529 O OD2 . ASP B 1 76  5.177  14.804  6.899  B 76  ? 1.00 93.21  1 
+ATOM   2530 N N   . CYS B 1 77  6.102  11.912  3.853  B 77  ? 1.00 103.03 1 
+ATOM   2531 C CA  . CYS B 1 77  6.504  10.515  3.695  B 77  ? 1.00 96.29  1 
+ATOM   2532 C C   . CYS B 1 77  6.252  9.939   2.323  B 77  ? 1.00 94.12  1 
+ATOM   2533 O O   . CYS B 1 77  6.795  8.873   2.025  B 77  ? 1.00 90.44  1 
+ATOM   2534 C CB  . CYS B 1 77  5.769  9.601   4.668  B 77  ? 1.00 91.91  1 
+ATOM   2535 S SG  . CYS B 1 77  5.734  10.200  6.370  B 77  ? 1.00 99.64  1 
+ATOM   2536 N N   . ARG B 1 78  5.488  10.627  1.453  B 78  ? 1.00 95.44  1 
+ATOM   2537 C CA  . ARG B 1 78  5.130  10.084  0.154  B 78  ? 1.00 94.64  1 
+ATOM   2538 C C   . ARG B 1 78  6.365  9.702   -0.635 B 78  ? 1.00 92.25  1 
+ATOM   2539 O O   . ARG B 1 78  6.292  8.810   -1.477 B 78  ? 1.00 96.97  1 
+ATOM   2540 C CB  . ARG B 1 78  4.298  11.085  -0.660 B 78  ? 1.00 97.27  1 
+ATOM   2541 C CG  . ARG B 1 78  5.035  12.328  -1.138 B 78  ? 1.00 102.42 1 
+ATOM   2542 C CD  . ARG B 1 78  4.185  13.041  -2.177 B 78  ? 1.00 108.33 1 
+ATOM   2543 N NE  . ARG B 1 78  4.955  14.053  -2.895 B 78  ? 1.00 114.76 1 
+ATOM   2544 C CZ  . ARG B 1 78  4.419  14.868  -3.824 B 78  ? 1.00 118.63 1 
+ATOM   2545 N NH1 . ARG B 1 78  3.116  14.827  -4.134 B 78  ? 1.00 122.84 1 
+ATOM   2546 N NH2 . ARG B 1 78  5.197  15.760  -4.448 B 78  ? 1.00 117.49 1 
+ATOM   2547 N N   . ASN B 1 79  7.530  10.285  -0.343 B 79  ? 1.00 92.94  1 
+ATOM   2548 C CA  . ASN B 1 79  8.736  9.884   -1.063 B 79  ? 1.00 95.50  1 
+ATOM   2549 C C   . ASN B 1 79  9.784  9.053   -0.323 B 79  ? 1.00 87.58  1 
+ATOM   2550 O O   . ASN B 1 79  10.985 8.945   -0.651 B 79  ? 1.00 79.29  1 
+ATOM   2551 C CB  . ASN B 1 79  9.353  11.143  -1.637 B 79  ? 1.00 104.04 1 
+ATOM   2552 C CG  . ASN B 1 79  8.667  11.358  -2.977 B 79  ? 1.00 111.35 1 
+ATOM   2553 O OD1 . ASN B 1 79  8.837  10.570  -3.905 B 79  ? 1.00 112.22 1 
+ATOM   2554 N ND2 . ASN B 1 79  7.827  12.376  -3.147 B 79  ? 1.00 117.21 1 
+ATOM   2555 N N   . GLY B 1 80  9.251  8.280   0.608  B 80  ? 1.00 81.39  1 
+ATOM   2556 C CA  . GLY B 1 80  10.068 7.470   1.453  B 80  ? 1.00 68.75  1 
+ATOM   2557 C C   . GLY B 1 80  10.187 8.180   2.776  B 80  ? 1.00 66.46  1 
+ATOM   2558 O O   . GLY B 1 80  9.901  9.373   2.958  B 80  ? 1.00 61.55  1 
+ATOM   2559 N N   . PHE B 1 81  10.719 7.328   3.636  B 81  ? 1.00 61.53  1 
+ATOM   2560 C CA  . PHE B 1 81  10.833 7.550   5.056  B 81  ? 1.00 52.83  1 
+ATOM   2561 C C   . PHE B 1 81  11.969 6.653   5.523  B 81  ? 1.00 49.29  1 
+ATOM   2562 O O   . PHE B 1 81  12.493 5.775   4.826  B 81  ? 1.00 47.07  1 
+ATOM   2563 C CB  . PHE B 1 81  9.539  7.153   5.746  B 81  ? 1.00 48.35  1 
+ATOM   2564 C CG  . PHE B 1 81  9.045  5.786   5.292  B 81  ? 1.00 56.97  1 
+ATOM   2565 C CD1 . PHE B 1 81  8.279  5.682   4.145  B 81  ? 1.00 59.24  1 
+ATOM   2566 C CD2 . PHE B 1 81  9.384  4.641   5.984  B 81  ? 1.00 59.56  1 
+ATOM   2567 C CE1 . PHE B 1 81  7.857  4.453   3.685  B 81  ? 1.00 63.76  1 
+ATOM   2568 C CE2 . PHE B 1 81  8.957  3.412   5.518  B 81  ? 1.00 62.40  1 
+ATOM   2569 C CZ  . PHE B 1 81  8.199  3.315   4.372  B 81  ? 1.00 63.43  1 
+ATOM   2570 N N   . LEU B 1 82  12.312 6.876   6.760  B 82  ? 1.00 51.62  1 
+ATOM   2571 C CA  . LEU B 1 82  13.355 6.159   7.442  B 82  ? 1.00 50.07  1 
+ATOM   2572 C C   . LEU B 1 82  12.555 5.719   8.633  B 82  ? 1.00 46.15  1 
+ATOM   2573 O O   . LEU B 1 82  11.788 6.504   9.200  B 82  ? 1.00 48.31  1 
+ATOM   2574 C CB  . LEU B 1 82  14.439 7.148   7.791  B 82  ? 1.00 53.03  1 
+ATOM   2575 C CG  . LEU B 1 82  15.647 6.746   8.563  B 82  ? 1.00 51.14  1 
+ATOM   2576 C CD1 . LEU B 1 82  16.451 5.698   7.822  B 82  ? 1.00 50.92  1 
+ATOM   2577 C CD2 . LEU B 1 82  16.485 7.985   8.743  B 82  ? 1.00 52.17  1 
+ATOM   2578 N N   . LEU B 1 83  12.681 4.457   8.964  B 83  ? 1.00 44.27  1 
+ATOM   2579 C CA  . LEU B 1 83  11.948 3.880   10.053 B 83  ? 1.00 45.32  1 
+ATOM   2580 C C   . LEU B 1 83  13.062 3.526   11.000 B 83  ? 1.00 44.06  1 
+ATOM   2581 O O   . LEU B 1 83  14.007 2.831   10.612 B 83  ? 1.00 46.14  1 
+ATOM   2582 C CB  . LEU B 1 83  11.184 2.659   9.556  B 83  ? 1.00 45.72  1 
+ATOM   2583 C CG  . LEU B 1 83  9.743  2.935   9.132  B 83  ? 1.00 44.21  1 
+ATOM   2584 C CD1 . LEU B 1 83  9.077  1.657   8.722  B 83  ? 1.00 48.57  1 
+ATOM   2585 C CD2 . LEU B 1 83  8.918  3.419   10.298 B 83  ? 1.00 45.02  1 
+ATOM   2586 N N   . ASP B 1 84  12.970 4.035   12.218 B 84  ? 1.00 38.59  1 
+ATOM   2587 C CA  . ASP B 1 84  14.011 3.954   13.209 B 84  ? 1.00 39.92  1 
+ATOM   2588 C C   . ASP B 1 84  13.350 3.462   14.465 B 84  ? 1.00 46.79  1 
+ATOM   2589 O O   . ASP B 1 84  12.627 4.208   15.132 B 84  ? 1.00 44.69  1 
+ATOM   2590 C CB  . ASP B 1 84  14.591 5.354   13.432 B 84  ? 1.00 43.74  1 
+ATOM   2591 C CG  . ASP B 1 84  15.772 5.476   14.380 B 84  ? 1.00 46.25  1 
+ATOM   2592 O OD1 . ASP B 1 84  16.560 4.538   14.440 B 84  ? 1.00 49.47  1 
+ATOM   2593 O OD2 . ASP B 1 84  15.905 6.514   15.041 B 84  ? 1.00 47.22  1 
+ATOM   2594 N N   . GLY B 1 85  13.579 2.204   14.796 B 85  ? 1.00 52.75  1 
+ATOM   2595 C CA  . GLY B 1 85  12.986 1.631   15.992 B 85  ? 1.00 53.50  1 
+ATOM   2596 C C   . GLY B 1 85  11.720 0.821   15.721 B 85  ? 1.00 50.37  1 
+ATOM   2597 O O   . GLY B 1 85  11.130 0.257   16.651 B 85  ? 1.00 56.20  1 
+ATOM   2598 N N   . PHE B 1 86  11.249 0.732   14.486 B 86  ? 1.00 37.31  1 
+ATOM   2599 C CA  . PHE B 1 86  10.080 -0.063  14.184 B 86  ? 1.00 42.89  1 
+ATOM   2600 C C   . PHE B 1 86  10.480 -0.682  12.861 B 86  ? 1.00 41.02  1 
+ATOM   2601 O O   . PHE B 1 86  11.115 0.017   12.061 B 86  ? 1.00 41.57  1 
+ATOM   2602 C CB  . PHE B 1 86  8.800  0.806   14.011 B 86  ? 1.00 41.29  1 
+ATOM   2603 C CG  . PHE B 1 86  7.480  0.079   13.638 B 86  ? 1.00 41.56  1 
+ATOM   2604 C CD1 . PHE B 1 86  7.161  -0.218  12.328 B 86  ? 1.00 40.40  1 
+ATOM   2605 C CD2 . PHE B 1 86  6.551  -0.266  14.595 B 86  ? 1.00 43.57  1 
+ATOM   2606 C CE1 . PHE B 1 86  5.960  -0.825  12.009 B 86  ? 1.00 41.71  1 
+ATOM   2607 C CE2 . PHE B 1 86  5.351  -0.873  14.264 B 86  ? 1.00 41.64  1 
+ATOM   2608 C CZ  . PHE B 1 86  5.049  -1.157  12.965 B 86  ? 1.00 38.23  1 
+ATOM   2609 N N   . PRO B 1 87  10.152 -1.940  12.545 B 87  ? 1.00 37.40  1 
+ATOM   2610 C CA  . PRO B 1 87  9.584  -2.868  13.486 B 87  ? 1.00 38.27  1 
+ATOM   2611 C C   . PRO B 1 87  10.624 -3.366  14.488 B 87  ? 1.00 44.11  1 
+ATOM   2612 O O   . PRO B 1 87  11.818 -3.504  14.206 B 87  ? 1.00 42.51  1 
+ATOM   2613 C CB  . PRO B 1 87  8.986  -3.921  12.606 B 87  ? 1.00 34.37  1 
+ATOM   2614 C CG  . PRO B 1 87  9.854  -3.907  11.376 B 87  ? 1.00 38.06  1 
+ATOM   2615 C CD  . PRO B 1 87  10.129 -2.446  11.184 B 87  ? 1.00 34.72  1 
+ATOM   2616 N N   . ARG B 1 88  10.094 -3.503  15.698 B 88  ? 1.00 38.39  1 
+ATOM   2617 C CA  . ARG B 1 88  10.800 -3.986  16.884 B 88  ? 1.00 43.83  1 
+ATOM   2618 C C   . ARG B 1 88  10.410 -5.434  17.227 B 88  ? 1.00 47.78  1 
+ATOM   2619 O O   . ARG B 1 88  11.021 -6.026  18.130 B 88  ? 1.00 46.59  1 
+ATOM   2620 C CB  . ARG B 1 88  10.441 -3.098  18.067 B 88  ? 1.00 43.75  1 
+ATOM   2621 C CG  . ARG B 1 88  11.463 -2.941  19.138 B 88  ? 1.00 38.76  1 
+ATOM   2622 C CD  . ARG B 1 88  12.614 -2.060  18.703 B 88  ? 1.00 41.21  1 
+ATOM   2623 N NE  . ARG B 1 88  13.239 -1.644  19.945 B 88  ? 1.00 47.62  1 
+ATOM   2624 C CZ  . ARG B 1 88  13.296 -0.370  20.370 B 88  ? 1.00 49.01  1 
+ATOM   2625 N NH1 . ARG B 1 88  12.849 0.642   19.630 B 88  ? 1.00 43.44  1 
+ATOM   2626 N NH2 . ARG B 1 88  13.841 -0.111  21.570 B 88  ? 1.00 51.64  1 
+ATOM   2627 N N   . THR B 1 89  9.318  -5.984  16.639 B 89  ? 1.00 48.49  1 
+ATOM   2628 C CA  . THR B 1 89  8.893  -7.377  16.798 B 89  ? 1.00 37.55  1 
+ATOM   2629 C C   . THR B 1 89  8.407  -7.917  15.421 B 89  ? 1.00 39.80  1 
+ATOM   2630 O O   . THR B 1 89  8.100  -7.202  14.441 B 89  ? 1.00 36.56  1 
+ATOM   2631 C CB  . THR B 1 89  7.738  -7.516  17.885 B 89  ? 1.00 36.58  1 
+ATOM   2632 O OG1 . THR B 1 89  6.574  -6.891  17.319 B 89  ? 1.00 36.55  1 
+ATOM   2633 C CG2 . THR B 1 89  8.067  -6.865  19.259 B 89  ? 1.00 28.52  1 
+ATOM   2634 N N   . ILE B 1 90  8.352  -9.248  15.336 B 90  ? 1.00 46.49  1 
+ATOM   2635 C CA  . ILE B 1 90  7.803  -10.005 14.204 B 90  ? 1.00 45.33  1 
+ATOM   2636 C C   . ILE B 1 90  6.344  -9.527  13.953 B 90  ? 1.00 44.83  1 
+ATOM   2637 O O   . ILE B 1 90  6.021  -9.250  12.794 B 90  ? 1.00 38.90  1 
+ATOM   2638 C CB  . ILE B 1 90  7.898  -11.567 14.583 B 90  ? 1.00 49.03  1 
+ATOM   2639 C CG1 . ILE B 1 90  9.359  -12.029 14.754 B 90  ? 1.00 50.13  1 
+ATOM   2640 C CG2 . ILE B 1 90  7.179  -12.403 13.523 B 90  ? 1.00 48.83  1 
+ATOM   2641 C CD1 . ILE B 1 90  10.124 -12.434 13.471 B 90  ? 1.00 57.73  1 
+ATOM   2642 N N   . PRO B 1 91  5.406  -9.382  14.922 B 91  ? 1.00 39.19  1 
+ATOM   2643 C CA  . PRO B 1 91  4.084  -8.813  14.682 B 91  ? 1.00 40.59  1 
+ATOM   2644 C C   . PRO B 1 91  4.147  -7.490  13.901 B 91  ? 1.00 45.57  1 
+ATOM   2645 O O   . PRO B 1 91  3.482  -7.324  12.869 B 91  ? 1.00 39.53  1 
+ATOM   2646 C CB  . PRO B 1 91  3.525  -8.681  16.083 B 91  ? 1.00 40.09  1 
+ATOM   2647 C CG  . PRO B 1 91  4.114  -9.839  16.882 B 91  ? 1.00 36.32  1 
+ATOM   2648 C CD  . PRO B 1 91  5.512  -9.832  16.325 B 91  ? 1.00 35.44  1 
+ATOM   2649 N N   . GLN B 1 92  5.016  -6.575  14.362 B 92  ? 1.00 42.20  1 
+ATOM   2650 C CA  . GLN B 1 92  5.130  -5.250  13.791 B 92  ? 1.00 38.30  1 
+ATOM   2651 C C   . GLN B 1 92  5.677  -5.292  12.386 B 92  ? 1.00 38.16  1 
+ATOM   2652 O O   . GLN B 1 92  5.292  -4.478  11.543 B 92  ? 1.00 36.19  1 
+ATOM   2653 C CB  . GLN B 1 92  6.016  -4.388  14.686 B 92  ? 1.00 39.89  1 
+ATOM   2654 C CG  . GLN B 1 92  5.447  -3.995  16.061 B 92  ? 1.00 34.24  1 
+ATOM   2655 C CD  . GLN B 1 92  6.437  -3.247  16.944 B 92  ? 1.00 39.00  1 
+ATOM   2656 O OE1 . GLN B 1 92  7.404  -2.698  16.430 B 92  ? 1.00 40.67  1 
+ATOM   2657 N NE2 . GLN B 1 92  6.363  -3.131  18.261 B 92  ? 1.00 42.39  1 
+ATOM   2658 N N   . ALA B 1 93  6.562  -6.247  12.113 B 93  ? 1.00 37.34  1 
+ATOM   2659 C CA  . ALA B 1 93  7.076  -6.402  10.769 B 93  ? 1.00 42.76  1 
+ATOM   2660 C C   . ALA B 1 93  5.974  -6.950  9.897  B 93  ? 1.00 41.20  1 
+ATOM   2661 O O   . ALA B 1 93  5.808  -6.504  8.773  B 93  ? 1.00 47.95  1 
+ATOM   2662 C CB  . ALA B 1 93  8.229  -7.372  10.723 B 93  ? 1.00 40.16  1 
+ATOM   2663 N N   . ASP B 1 94  5.168  -7.864  10.421 B 94  ? 1.00 44.46  1 
+ATOM   2664 C CA  . ASP B 1 94  4.066  -8.436  9.691  B 94  ? 1.00 50.15  1 
+ATOM   2665 C C   . ASP B 1 94  3.023  -7.418  9.348  B 94  ? 1.00 52.80  1 
+ATOM   2666 O O   . ASP B 1 94  2.535  -7.409  8.215  B 94  ? 1.00 56.26  1 
+ATOM   2667 C CB  . ASP B 1 94  3.400  -9.528  10.487 B 94  ? 1.00 57.90  1 
+ATOM   2668 C CG  . ASP B 1 94  4.127  -10.865 10.392 B 94  ? 1.00 65.10  1 
+ATOM   2669 O OD1 . ASP B 1 94  4.729  -11.152 9.351  B 94  ? 1.00 59.94  1 
+ATOM   2670 O OD2 . ASP B 1 94  4.062  -11.630 11.362 B 94  ? 1.00 71.87  1 
+ATOM   2671 N N   . ALA B 1 95  2.721  -6.549  10.310 B 95  ? 1.00 49.12  1 
+ATOM   2672 C CA  . ALA B 1 95  1.768  -5.465  10.117 B 95  ? 1.00 50.67  1 
+ATOM   2673 C C   . ALA B 1 95  2.197  -4.560  8.970  B 95  ? 1.00 52.59  1 
+ATOM   2674 O O   . ALA B 1 95  1.348  -4.042  8.239  B 95  ? 1.00 64.78  1 
+ATOM   2675 C CB  . ALA B 1 95  1.659  -4.606  11.347 B 95  ? 1.00 39.10  1 
+ATOM   2676 N N   . MET B 1 96  3.495  -4.367  8.750  B 96  ? 1.00 50.67  1 
+ATOM   2677 C CA  . MET B 1 96  3.926  -3.591  7.615  B 96  ? 1.00 54.45  1 
+ATOM   2678 C C   . MET B 1 96  3.616  -4.384  6.362  B 96  ? 1.00 57.08  1 
+ATOM   2679 O O   . MET B 1 96  3.193  -3.771  5.386  B 96  ? 1.00 52.44  1 
+ATOM   2680 C CB  . MET B 1 96  5.410  -3.331  7.608  B 96  ? 1.00 55.67  1 
+ATOM   2681 C CG  . MET B 1 96  5.979  -2.390  8.640  B 96  ? 1.00 56.88  1 
+ATOM   2682 S SD  . MET B 1 96  7.776  -2.407  8.402  B 96  ? 1.00 60.26  1 
+ATOM   2683 C CE  . MET B 1 96  8.009  -1.756  6.771  B 96  ? 1.00 57.70  1 
+ATOM   2684 N N   . LYS B 1 97  3.768  -5.718  6.368  B 97  ? 1.00 63.90  1 
+ATOM   2685 C CA  . LYS B 1 97  3.507  -6.545  5.186  B 97  ? 1.00 80.27  1 
+ATOM   2686 C C   . LYS B 1 97  2.079  -6.452  4.649  B 97  ? 1.00 89.81  1 
+ATOM   2687 O O   . LYS B 1 97  1.875  -6.282  3.438  B 97  ? 1.00 93.22  1 
+ATOM   2688 C CB  . LYS B 1 97  3.731  -8.023  5.429  B 97  ? 1.00 77.42  1 
+ATOM   2689 C CG  . LYS B 1 97  5.067  -8.366  5.979  B 97  ? 1.00 77.92  1 
+ATOM   2690 C CD  . LYS B 1 97  5.414  -9.710  5.426  B 97  ? 1.00 78.17  1 
+ATOM   2691 C CE  . LYS B 1 97  5.974  -9.497  4.041  B 97  ? 1.00 80.95  1 
+ATOM   2692 N NZ  . LYS B 1 97  6.795  -10.642 3.713  B 97  ? 1.00 87.25  1 
+ATOM   2693 N N   . GLU B 1 98  1.074  -6.618  5.524  B 98  ? 1.00 92.38  1 
+ATOM   2694 C CA  . GLU B 1 98  -0.293 -6.477  5.069  B 98  ? 1.00 91.45  1 
+ATOM   2695 C C   . GLU B 1 98  -0.558 -5.026  4.755  B 98  ? 1.00 84.08  1 
+ATOM   2696 O O   . GLU B 1 98  -0.957 -4.785  3.625  B 98  ? 1.00 85.55  1 
+ATOM   2697 C CB  . GLU B 1 98  -1.335 -6.936  6.099  B 98  ? 1.00 100.58 1 
+ATOM   2698 C CG  . GLU B 1 98  -1.102 -6.640  7.569  B 98  ? 1.00 109.98 1 
+ATOM   2699 C CD  . GLU B 1 98  -0.708 -7.871  8.384  B 98  ? 1.00 118.05 1 
+ATOM   2700 O OE1 . GLU B 1 98  0.079  -8.702  7.914  B 98  ? 1.00 121.67 1 
+ATOM   2701 O OE2 . GLU B 1 98  -1.195 -7.995  9.508  B 98  ? 1.00 124.15 1 
+ATOM   2702 N N   . ALA B 1 99  -0.285 -4.030  5.612  B 99  ? 1.00 74.32  1 
+ATOM   2703 C CA  . ALA B 1 99  -0.570 -2.637  5.287  B 99  ? 1.00 65.79  1 
+ATOM   2704 C C   . ALA B 1 99  0.129  -2.066  4.041  B 99  ? 1.00 65.80  1 
+ATOM   2705 O O   . ALA B 1 99  0.049  -0.851  3.841  B 99  ? 1.00 72.27  1 
+ATOM   2706 C CB  . ALA B 1 99  -0.222 -1.770  6.503  B 99  ? 1.00 58.17  1 
+ATOM   2707 N N   . GLY B 1 100 0.849  -2.863  3.217  B 100 ? 1.00 69.76  1 
+ATOM   2708 C CA  . GLY B 1 100 1.413  -2.494  1.905  B 100 ? 1.00 75.80  1 
+ATOM   2709 C C   . GLY B 1 100 2.809  -1.860  1.794  B 100 ? 1.00 77.82  1 
+ATOM   2710 O O   . GLY B 1 100 3.414  -1.819  0.711  B 100 ? 1.00 73.32  1 
+ATOM   2711 N N   . ILE B 1 101 3.336  -1.388  2.930  B 101 ? 1.00 78.45  1 
+ATOM   2712 C CA  . ILE B 1 101 4.595  -0.652  3.078  B 101 ? 1.00 75.09  1 
+ATOM   2713 C C   . ILE B 1 101 5.810  -1.543  2.802  B 101 ? 1.00 69.04  1 
+ATOM   2714 O O   . ILE B 1 101 6.139  -2.414  3.610  B 101 ? 1.00 70.36  1 
+ATOM   2715 C CB  . ILE B 1 101 4.635  -0.076  4.536  B 101 ? 1.00 77.18  1 
+ATOM   2716 C CG1 . ILE B 1 101 3.362  0.695   4.915  B 101 ? 1.00 73.91  1 
+ATOM   2717 C CG2 . ILE B 1 101 5.829  0.855   4.621  B 101 ? 1.00 79.35  1 
+ATOM   2718 C CD1 . ILE B 1 101 3.007  0.577   6.411  B 101 ? 1.00 72.20  1 
+ATOM   2719 N N   . ASN B 1 102 6.524  -1.412  1.702  B 102 ? 1.00 66.44  1 
+ATOM   2720 C CA  . ASN B 1 102 7.652  -2.290  1.495  B 102 ? 1.00 72.40  1 
+ATOM   2721 C C   . ASN B 1 102 8.915  -1.437  1.481  B 102 ? 1.00 74.03  1 
+ATOM   2722 O O   . ASN B 1 102 8.813  -0.256  1.150  B 102 ? 1.00 79.28  1 
+ATOM   2723 C CB  . ASN B 1 102 7.395  -3.057  0.190  B 102 ? 1.00 78.17  1 
+ATOM   2724 C CG  . ASN B 1 102 7.033  -4.535  0.424  B 102 ? 1.00 86.90  1 
+ATOM   2725 O OD1 . ASN B 1 102 7.494  -5.414  -0.317 B 102 ? 1.00 89.69  1 
+ATOM   2726 N ND2 . ASN B 1 102 6.248  -4.936  1.429  B 102 ? 1.00 83.21  1 
+ATOM   2727 N N   . VAL B 1 103 10.106 -1.918  1.877  B 103 ? 1.00 70.60  1 
+ATOM   2728 C CA  . VAL B 1 103 11.319 -1.096  1.926  B 103 ? 1.00 61.80  1 
+ATOM   2729 C C   . VAL B 1 103 12.344 -1.510  0.891  B 103 ? 1.00 60.21  1 
+ATOM   2730 O O   . VAL B 1 103 12.331 -2.627  0.360  B 103 ? 1.00 62.17  1 
+ATOM   2731 C CB  . VAL B 1 103 12.053 -1.133  3.313  B 103 ? 1.00 65.17  1 
+ATOM   2732 C CG1 . VAL B 1 103 11.144 -0.479  4.336  B 103 ? 1.00 65.78  1 
+ATOM   2733 C CG2 . VAL B 1 103 12.417 -2.553  3.751  B 103 ? 1.00 60.81  1 
+ATOM   2734 N N   . ASP B 1 104 13.277 -0.603  0.644  B 104 ? 1.00 56.76  1 
+ATOM   2735 C CA  . ASP B 1 104 14.312 -0.823  -0.343 B 104 ? 1.00 65.01  1 
+ATOM   2736 C C   . ASP B 1 104 15.606 -1.218  0.402  B 104 ? 1.00 61.65  1 
+ATOM   2737 O O   . ASP B 1 104 16.433 -2.007  -0.071 B 104 ? 1.00 59.10  1 
+ATOM   2738 C CB  . ASP B 1 104 14.404 0.508   -1.196 B 104 ? 1.00 74.71  1 
+ATOM   2739 C CG  . ASP B 1 104 13.138 0.894   -2.019 B 104 ? 1.00 80.19  1 
+ATOM   2740 O OD1 . ASP B 1 104 12.965 0.416   -3.144 B 104 ? 1.00 77.73  1 
+ATOM   2741 O OD2 . ASP B 1 104 12.304 1.672   -1.544 B 104 ? 1.00 83.94  1 
+ATOM   2742 N N   . TYR B 1 105 15.800 -0.719  1.617  B 105 ? 1.00 58.12  1 
+ATOM   2743 C CA  . TYR B 1 105 16.959 -1.061  2.412  B 105 ? 1.00 52.14  1 
+ATOM   2744 C C   . TYR B 1 105 16.556 -1.402  3.813  B 105 ? 1.00 47.27  1 
+ATOM   2745 O O   . TYR B 1 105 15.613 -0.818  4.374  B 105 ? 1.00 45.43  1 
+ATOM   2746 C CB  . TYR B 1 105 17.906 0.056   2.575  B 105 ? 1.00 52.57  1 
+ATOM   2747 C CG  . TYR B 1 105 18.581 0.343   1.284  B 105 ? 1.00 54.39  1 
+ATOM   2748 C CD1 . TYR B 1 105 19.722 -0.361  0.957  B 105 ? 1.00 54.08  1 
+ATOM   2749 C CD2 . TYR B 1 105 18.034 1.306   0.469  B 105 ? 1.00 58.54  1 
+ATOM   2750 C CE1 . TYR B 1 105 20.351 -0.090  -0.235 B 105 ? 1.00 60.34  1 
+ATOM   2751 C CE2 . TYR B 1 105 18.662 1.577   -0.727 B 105 ? 1.00 65.03  1 
+ATOM   2752 C CZ  . TYR B 1 105 19.813 0.880   -1.070 B 105 ? 1.00 65.96  1 
+ATOM   2753 O OH  . TYR B 1 105 20.447 1.201   -2.259 B 105 ? 1.00 70.23  1 
+ATOM   2754 N N   . VAL B 1 106 17.291 -2.389  4.299  B 106 ? 1.00 36.81  1 
+ATOM   2755 C CA  . VAL B 1 106 17.284 -2.747  5.686  B 106 ? 1.00 42.39  1 
+ATOM   2756 C C   . VAL B 1 106 18.760 -2.588  6.110  B 106 ? 1.00 42.74  1 
+ATOM   2757 O O   . VAL B 1 106 19.643 -3.228  5.509  B 106 ? 1.00 38.45  1 
+ATOM   2758 C CB  . VAL B 1 106 16.816 -4.195  5.893  B 106 ? 1.00 44.09  1 
+ATOM   2759 C CG1 . VAL B 1 106 16.648 -4.367  7.406  B 106 ? 1.00 39.96  1 
+ATOM   2760 C CG2 . VAL B 1 106 15.483 -4.508  5.246  B 106 ? 1.00 33.48  1 
+ATOM   2761 N N   . LEU B 1 107 19.099 -1.712  7.079  B 107 ? 1.00 45.16  1 
+ATOM   2762 C CA  . LEU B 1 107 20.493 -1.515  7.508  B 107 ? 1.00 45.88  1 
+ATOM   2763 C C   . LEU B 1 107 20.603 -1.926  8.990  B 107 ? 1.00 42.43  1 
+ATOM   2764 O O   . LEU B 1 107 19.865 -1.405  9.840  B 107 ? 1.00 44.70  1 
+ATOM   2765 C CB  . LEU B 1 107 20.885 -0.022  7.259  B 107 ? 1.00 37.93  1 
+ATOM   2766 C CG  . LEU B 1 107 20.726 0.431   5.773  B 107 ? 1.00 40.47  1 
+ATOM   2767 C CD1 . LEU B 1 107 20.850 1.917   5.624  B 107 ? 1.00 35.44  1 
+ATOM   2768 C CD2 . LEU B 1 107 21.783 -0.222  4.932  B 107 ? 1.00 39.79  1 
+ATOM   2769 N N   . GLU B 1 108 21.483 -2.907  9.264  B 108 ? 1.00 34.51  1 
+ATOM   2770 C CA  . GLU B 1 108 21.731 -3.555  10.555 B 108 ? 1.00 29.01  1 
+ATOM   2771 C C   . GLU B 1 108 22.957 -2.949  11.187 B 108 ? 1.00 30.22  1 
+ATOM   2772 O O   . GLU B 1 108 24.027 -3.103  10.613 B 108 ? 1.00 35.65  1 
+ATOM   2773 C CB  . GLU B 1 108 22.032 -5.027  10.389 B 108 ? 1.00 31.54  1 
+ATOM   2774 C CG  . GLU B 1 108 21.858 -5.893  11.607 B 108 ? 1.00 39.52  1 
+ATOM   2775 C CD  . GLU B 1 108 22.557 -7.238  11.487 B 108 ? 1.00 47.20  1 
+ATOM   2776 O OE1 . GLU B 1 108 22.493 -7.901  10.446 B 108 ? 1.00 39.42  1 
+ATOM   2777 O OE2 . GLU B 1 108 23.200 -7.623  12.461 B 108 ? 1.00 44.24  1 
+ATOM   2778 N N   . PHE B 1 109 22.934 -2.279  12.324 B 109 ? 1.00 35.28  1 
+ATOM   2779 C CA  . PHE B 1 109 24.139 -1.689  12.885 B 109 ? 1.00 35.65  1 
+ATOM   2780 C C   . PHE B 1 109 24.705 -2.732  13.815 B 109 ? 1.00 40.32  1 
+ATOM   2781 O O   . PHE B 1 109 24.063 -3.072  14.798 B 109 ? 1.00 43.33  1 
+ATOM   2782 C CB  . PHE B 1 109 23.772 -0.415  13.615 B 109 ? 1.00 35.16  1 
+ATOM   2783 C CG  . PHE B 1 109 23.404 0.679   12.598 B 109 ? 1.00 46.81  1 
+ATOM   2784 C CD1 . PHE B 1 109 22.303 0.549   11.752 B 109 ? 1.00 46.18  1 
+ATOM   2785 C CD2 . PHE B 1 109 24.206 1.797   12.469 B 109 ? 1.00 50.43  1 
+ATOM   2786 C CE1 . PHE B 1 109 22.019 1.499   10.804 B 109 ? 1.00 33.60  1 
+ATOM   2787 C CE2 . PHE B 1 109 23.911 2.745   11.516 B 109 ? 1.00 42.21  1 
+ATOM   2788 C CZ  . PHE B 1 109 22.826 2.594   10.690 B 109 ? 1.00 39.24  1 
+ATOM   2789 N N   . ASP B 1 110 25.850 -3.347  13.547 B 110 ? 1.00 40.99  1 
+ATOM   2790 C CA  . ASP B 1 110 26.364 -4.400  14.404 B 110 ? 1.00 37.31  1 
+ATOM   2791 C C   . ASP B 1 110 27.362 -3.876  15.402 B 110 ? 1.00 39.30  1 
+ATOM   2792 O O   . ASP B 1 110 28.427 -3.360  15.052 B 110 ? 1.00 40.47  1 
+ATOM   2793 C CB  . ASP B 1 110 27.035 -5.468  13.597 B 110 ? 1.00 44.13  1 
+ATOM   2794 C CG  . ASP B 1 110 27.481 -6.621  14.476 B 110 ? 1.00 51.16  1 
+ATOM   2795 O OD1 . ASP B 1 110 26.665 -7.388  14.986 B 110 ? 1.00 52.49  1 
+ATOM   2796 O OD2 . ASP B 1 110 28.677 -6.722  14.676 B 110 ? 1.00 61.49  1 
+ATOM   2797 N N   . VAL B 1 111 26.972 -4.007  16.652 B 111 ? 1.00 34.65  1 
+ATOM   2798 C CA  . VAL B 1 111 27.765 -3.574  17.767 B 111 ? 1.00 37.99  1 
+ATOM   2799 C C   . VAL B 1 111 27.721 -4.752  18.741 B 111 ? 1.00 44.36  1 
+ATOM   2800 O O   . VAL B 1 111 26.686 -5.418  18.898 B 111 ? 1.00 45.73  1 
+ATOM   2801 C CB  . VAL B 1 111 27.120 -2.322  18.348 B 111 ? 1.00 41.44  1 
+ATOM   2802 C CG1 . VAL B 1 111 27.816 -1.913  19.612 B 111 ? 1.00 43.09  1 
+ATOM   2803 C CG2 . VAL B 1 111 27.302 -1.163  17.416 B 111 ? 1.00 43.61  1 
+ATOM   2804 N N   . PRO B 1 112 28.838 -5.062  19.393 B 112 ? 1.00 39.17  1 
+ATOM   2805 C CA  . PRO B 1 112 28.904 -5.942  20.550 B 112 ? 1.00 39.72  1 
+ATOM   2806 C C   . PRO B 1 112 28.248 -5.465  21.844 B 112 ? 1.00 40.17  1 
+ATOM   2807 O O   . PRO B 1 112 28.478 -4.365  22.322 B 112 ? 1.00 44.00  1 
+ATOM   2808 C CB  . PRO B 1 112 30.400 -6.196  20.699 B 112 ? 1.00 37.13  1 
+ATOM   2809 C CG  . PRO B 1 112 31.031 -4.953  20.133 B 112 ? 1.00 38.33  1 
+ATOM   2810 C CD  . PRO B 1 112 30.168 -4.699  18.919 B 112 ? 1.00 41.01  1 
+ATOM   2811 N N   . ASP B 1 113 27.502 -6.321  22.522 B 113 ? 1.00 44.43  1 
+ATOM   2812 C CA  . ASP B 1 113 26.836 -6.066  23.786 B 113 ? 1.00 41.82  1 
+ATOM   2813 C C   . ASP B 1 113 27.585 -5.303  24.851 B 113 ? 1.00 39.40  1 
+ATOM   2814 O O   . ASP B 1 113 27.063 -4.437  25.543 B 113 ? 1.00 31.96  1 
+ATOM   2815 C CB  . ASP B 1 113 26.428 -7.383  24.401 B 113 ? 1.00 50.30  1 
+ATOM   2816 C CG  . ASP B 1 113 25.099 -7.967  23.964 B 113 ? 1.00 51.82  1 
+ATOM   2817 O OD1 . ASP B 1 113 24.582 -7.629  22.898 B 113 ? 1.00 49.56  1 
+ATOM   2818 O OD2 . ASP B 1 113 24.583 -8.762  24.746 B 113 ? 1.00 55.49  1 
+ATOM   2819 N N   . GLU B 1 114 28.849 -5.690  24.958 B 114 ? 1.00 45.80  1 
+ATOM   2820 C CA  . GLU B 1 114 29.805 -5.138  25.908 B 114 ? 1.00 48.55  1 
+ATOM   2821 C C   . GLU B 1 114 29.936 -3.642  25.827 B 114 ? 1.00 47.30  1 
+ATOM   2822 O O   . GLU B 1 114 30.258 -3.013  26.837 B 114 ? 1.00 47.89  1 
+ATOM   2823 C CB  . GLU B 1 114 31.216 -5.661  25.716 B 114 ? 1.00 43.34  1 
+ATOM   2824 C CG  . GLU B 1 114 31.324 -7.141  25.950 B 114 ? 1.00 51.65  1 
+ATOM   2825 C CD  . GLU B 1 114 30.922 -8.063  24.809 B 114 ? 1.00 53.14  1 
+ATOM   2826 O OE1 . GLU B 1 114 30.830 -7.654  23.645 B 114 ? 1.00 55.58  1 
+ATOM   2827 O OE2 . GLU B 1 114 30.717 -9.231  25.115 B 114 ? 1.00 59.07  1 
+ATOM   2828 N N   . LEU B 1 115 29.722 -3.086  24.632 B 115 ? 1.00 44.11  1 
+ATOM   2829 C CA  . LEU B 1 115 29.837 -1.653  24.430 B 115 ? 1.00 44.14  1 
+ATOM   2830 C C   . LEU B 1 115 28.589 -0.832  24.760 B 115 ? 1.00 43.83  1 
+ATOM   2831 O O   . LEU B 1 115 28.705 0.408   24.842 B 115 ? 1.00 36.40  1 
+ATOM   2832 C CB  . LEU B 1 115 30.230 -1.384  22.979 B 115 ? 1.00 43.08  1 
+ATOM   2833 C CG  . LEU B 1 115 31.679 -1.341  22.558 B 115 ? 1.00 44.40  1 
+ATOM   2834 C CD1 . LEU B 1 115 32.461 -2.517  23.072 B 115 ? 1.00 42.84  1 
+ATOM   2835 C CD2 . LEU B 1 115 31.685 -1.282  21.059 B 115 ? 1.00 40.99  1 
+ATOM   2836 N N   . ILE B 1 116 27.439 -1.517  24.989 B 116 ? 1.00 42.25  1 
+ATOM   2837 C CA  . ILE B 1 116 26.136 -0.851  25.127 B 116 ? 1.00 41.31  1 
+ATOM   2838 C C   . ILE B 1 116 25.960 -0.014  26.404 B 116 ? 1.00 40.76  1 
+ATOM   2839 O O   . ILE B 1 116 25.580 1.155   26.262 B 116 ? 1.00 39.57  1 
+ATOM   2840 C CB  . ILE B 1 116 24.963 -1.929  25.001 B 116 ? 1.00 38.78  1 
+ATOM   2841 C CG1 . ILE B 1 116 24.946 -2.722  23.690 B 116 ? 1.00 35.40  1 
+ATOM   2842 C CG2 . ILE B 1 116 23.651 -1.192  25.058 B 116 ? 1.00 42.66  1 
+ATOM   2843 C CD1 . ILE B 1 116 24.965 -2.006  22.348 B 116 ? 1.00 37.28  1 
+ATOM   2844 N N   . VAL B 1 117 26.242 -0.477  27.634 B 117 ? 1.00 36.96  1 
+ATOM   2845 C CA  . VAL B 1 117 25.998 0.330   28.836 B 117 ? 1.00 38.82  1 
+ATOM   2846 C C   . VAL B 1 117 26.735 1.675   28.805 B 117 ? 1.00 37.24  1 
+ATOM   2847 O O   . VAL B 1 117 26.097 2.730   28.939 B 117 ? 1.00 34.67  1 
+ATOM   2848 C CB  . VAL B 1 117 26.393 -0.501  30.095 B 117 ? 1.00 38.72  1 
+ATOM   2849 C CG1 . VAL B 1 117 26.148 0.214   31.414 B 117 ? 1.00 36.94  1 
+ATOM   2850 C CG2 . VAL B 1 117 25.474 -1.690  30.144 B 117 ? 1.00 40.55  1 
+ATOM   2851 N N   . ASP B 1 118 28.046 1.727   28.549 B 118 ? 1.00 39.01  1 
+ATOM   2852 C CA  . ASP B 1 118 28.753 2.997   28.479 B 118 ? 1.00 41.79  1 
+ATOM   2853 C C   . ASP B 1 118 28.377 3.911   27.317 B 118 ? 1.00 42.50  1 
+ATOM   2854 O O   . ASP B 1 118 28.543 5.144   27.382 B 118 ? 1.00 42.04  1 
+ATOM   2855 C CB  . ASP B 1 118 30.238 2.724   28.454 B 118 ? 1.00 44.34  1 
+ATOM   2856 C CG  . ASP B 1 118 30.729 2.204   29.793 B 118 ? 1.00 49.23  1 
+ATOM   2857 O OD1 . ASP B 1 118 30.114 2.451   30.837 B 118 ? 1.00 52.77  1 
+ATOM   2858 O OD2 . ASP B 1 118 31.752 1.537   29.781 B 118 ? 1.00 59.67  1 
+ATOM   2859 N N   . ARG B 1 119 27.834 3.341   26.240 B 119 ? 1.00 37.51  1 
+ATOM   2860 C CA  . ARG B 1 119 27.335 4.163   25.177 B 119 ? 1.00 32.79  1 
+ATOM   2861 C C   . ARG B 1 119 26.099 4.819   25.696 B 119 ? 1.00 35.60  1 
+ATOM   2862 O O   . ARG B 1 119 26.014 6.044   25.686 B 119 ? 1.00 40.47  1 
+ATOM   2863 C CB  . ARG B 1 119 26.990 3.363   23.976 B 119 ? 1.00 30.74  1 
+ATOM   2864 C CG  . ARG B 1 119 28.238 3.282   23.186 B 119 ? 1.00 32.54  1 
+ATOM   2865 C CD  . ARG B 1 119 27.762 2.761   21.860 B 119 ? 1.00 30.16  1 
+ATOM   2866 N NE  . ARG B 1 119 28.903 2.525   21.011 B 119 ? 1.00 34.70  1 
+ATOM   2867 C CZ  . ARG B 1 119 28.756 2.418   19.687 B 119 ? 1.00 35.59  1 
+ATOM   2868 N NH1 . ARG B 1 119 27.544 2.424   19.126 B 119 ? 1.00 37.92  1 
+ATOM   2869 N NH2 . ARG B 1 119 29.821 2.271   18.900 B 119 ? 1.00 28.74  1 
+ATOM   2870 N N   . ILE B 1 120 25.180 4.073   26.266 B 120 ? 1.00 42.54  1 
+ATOM   2871 C CA  . ILE B 1 120 23.983 4.699   26.749 B 120 ? 1.00 46.01  1 
+ATOM   2872 C C   . ILE B 1 120 24.114 5.525   28.037 B 120 ? 1.00 42.56  1 
+ATOM   2873 O O   . ILE B 1 120 23.376 6.512   28.201 B 120 ? 1.00 37.32  1 
+ATOM   2874 C CB  . ILE B 1 120 22.961 3.564   26.805 B 120 ? 1.00 51.93  1 
+ATOM   2875 C CG1 . ILE B 1 120 22.588 3.262   25.343 B 120 ? 1.00 49.97  1 
+ATOM   2876 C CG2 . ILE B 1 120 21.735 3.941   27.617 B 120 ? 1.00 56.43  1 
+ATOM   2877 C CD1 . ILE B 1 120 21.428 2.286   25.088 B 120 ? 1.00 57.70  1 
+ATOM   2878 N N   . VAL B 1 121 25.052 5.302   28.935 B 121 ? 1.00 42.44  1 
+ATOM   2879 C CA  . VAL B 1 121 25.135 6.233   30.063 B 121 ? 1.00 52.27  1 
+ATOM   2880 C C   . VAL B 1 121 25.763 7.593   29.702 B 121 ? 1.00 46.67  1 
+ATOM   2881 O O   . VAL B 1 121 25.629 8.576   30.434 B 121 ? 1.00 52.52  1 
+ATOM   2882 C CB  . VAL B 1 121 25.918 5.582   31.259 B 121 ? 1.00 55.87  1 
+ATOM   2883 C CG1 . VAL B 1 121 25.216 4.263   31.593 B 121 ? 1.00 61.21  1 
+ATOM   2884 C CG2 . VAL B 1 121 27.389 5.348   30.954 B 121 ? 1.00 66.37  1 
+ATOM   2885 N N   . GLY B 1 122 26.465 7.746   28.585 B 122 ? 1.00 43.23  1 
+ATOM   2886 C CA  . GLY B 1 122 27.035 9.055   28.248 B 122 ? 1.00 40.35  1 
+ATOM   2887 C C   . GLY B 1 122 26.214 9.840   27.224 B 122 ? 1.00 37.75  1 
+ATOM   2888 O O   . GLY B 1 122 26.672 10.873  26.679 B 122 ? 1.00 34.72  1 
+ATOM   2889 N N   . ARG B 1 123 25.030 9.294   26.930 B 123 ? 1.00 32.84  1 
+ATOM   2890 C CA  . ARG B 1 123 24.140 9.867   25.935 B 123 ? 1.00 35.16  1 
+ATOM   2891 C C   . ARG B 1 123 23.374 11.020  26.529 B 123 ? 1.00 38.12  1 
+ATOM   2892 O O   . ARG B 1 123 22.845 10.909  27.650 B 123 ? 1.00 38.89  1 
+ATOM   2893 C CB  . ARG B 1 123 23.138 8.817   25.421 B 123 ? 1.00 36.62  1 
+ATOM   2894 C CG  . ARG B 1 123 22.053 9.254   24.411 B 123 ? 1.00 29.37  1 
+ATOM   2895 C CD  . ARG B 1 123 21.391 8.062   23.694 B 123 ? 1.00 34.24  1 
+ATOM   2896 N NE  . ARG B 1 123 20.478 7.240   24.478 B 123 ? 1.00 34.98  1 
+ATOM   2897 C CZ  . ARG B 1 123 19.871 6.156   23.971 B 123 ? 1.00 36.89  1 
+ATOM   2898 N NH1 . ARG B 1 123 20.080 5.741   22.722 B 123 ? 1.00 33.26  1 
+ATOM   2899 N NH2 . ARG B 1 123 19.040 5.452   24.747 B 123 ? 1.00 40.18  1 
+ATOM   2900 N N   . ARG B 1 124 23.303 12.066  25.701 B 124 ? 1.00 32.31  1 
+ATOM   2901 C CA  . ARG B 1 124 22.607 13.305  25.984 B 124 ? 1.00 32.45  1 
+ATOM   2902 C C   . ARG B 1 124 21.782 13.602  24.736 B 124 ? 1.00 31.11  1 
+ATOM   2903 O O   . ARG B 1 124 22.257 13.394  23.603 B 124 ? 1.00 33.70  1 
+ATOM   2904 C CB  . ARG B 1 124 23.605 14.441  26.221 B 124 ? 1.00 35.66  1 
+ATOM   2905 C CG  . ARG B 1 124 24.593 14.247  27.367 B 124 ? 1.00 36.65  1 
+ATOM   2906 C CD  . ARG B 1 124 23.828 14.216  28.659 B 124 ? 1.00 34.70  1 
+ATOM   2907 N NE  . ARG B 1 124 24.734 13.927  29.751 B 124 ? 1.00 36.42  1 
+ATOM   2908 C CZ  . ARG B 1 124 25.078 12.686  30.158 B 124 ? 1.00 43.40  1 
+ATOM   2909 N NH1 . ARG B 1 124 24.557 11.551  29.679 B 124 ? 1.00 41.83  1 
+ATOM   2910 N NH2 . ARG B 1 124 25.962 12.562  31.148 B 124 ? 1.00 47.44  1 
+ATOM   2911 N N   . VAL B 1 125 20.540 14.065  24.919 B 125 ? 1.00 31.78  1 
+ATOM   2912 C CA  . VAL B 1 125 19.590 14.301  23.845 B 125 ? 1.00 34.06  1 
+ATOM   2913 C C   . VAL B 1 125 19.139 15.755  23.760 B 125 ? 1.00 36.92  1 
+ATOM   2914 O O   . VAL B 1 125 19.062 16.483  24.766 B 125 ? 1.00 33.45  1 
+ATOM   2915 C CB  . VAL B 1 125 18.289 13.448  23.977 B 125 ? 1.00 36.29  1 
+ATOM   2916 C CG1 . VAL B 1 125 18.653 11.999  23.812 B 125 ? 1.00 47.05  1 
+ATOM   2917 C CG2 . VAL B 1 125 17.638 13.577  25.336 B 125 ? 1.00 39.15  1 
+ATOM   2918 N N   . HIS B 1 126 18.876 16.219  22.526 B 126 ? 1.00 35.01  1 
+ATOM   2919 C CA  . HIS B 1 126 18.272 17.509  22.302 B 126 ? 1.00 31.55  1 
+ATOM   2920 C C   . HIS B 1 126 16.845 17.001  22.198 B 126 ? 1.00 40.68  1 
+ATOM   2921 O O   . HIS B 1 126 16.393 16.660  21.097 B 126 ? 1.00 36.55  1 
+ATOM   2922 C CB  . HIS B 1 126 18.685 18.188  20.972 B 126 ? 1.00 30.29  1 
+ATOM   2923 C CG  . HIS B 1 126 17.915 19.500  20.737 B 126 ? 1.00 34.68  1 
+ATOM   2924 N ND1 . HIS B 1 126 17.300 19.946  19.649 B 126 ? 1.00 32.94  1 
+ATOM   2925 C CD2 . HIS B 1 126 17.676 20.445  21.702 B 126 ? 1.00 35.24  1 
+ATOM   2926 C CE1 . HIS B 1 126 16.699 21.070  19.893 B 126 ? 1.00 30.07  1 
+ATOM   2927 N NE2 . HIS B 1 126 16.934 21.357  21.130 B 126 ? 1.00 32.25  1 
+ATOM   2928 N N   . ALA B 1 127 16.142 16.928  23.335 B 127 ? 1.00 41.63  1 
+ATOM   2929 C CA  . ALA B 1 127 14.792 16.394  23.401 B 127 ? 1.00 45.59  1 
+ATOM   2930 C C   . ALA B 1 127 13.877 16.966  22.319 B 127 ? 1.00 47.98  1 
+ATOM   2931 O O   . ALA B 1 127 13.399 16.134  21.540 B 127 ? 1.00 48.09  1 
+ATOM   2932 C CB  . ALA B 1 127 14.196 16.666  24.773 B 127 ? 1.00 43.14  1 
+ATOM   2933 N N   . PRO B 1 128 13.721 18.288  22.061 B 128 ? 1.00 42.86  1 
+ATOM   2934 C CA  . PRO B 1 128 12.902 18.822  20.986 B 128 ? 1.00 40.95  1 
+ATOM   2935 C C   . PRO B 1 128 13.081 18.205  19.595 B 128 ? 1.00 47.85  1 
+ATOM   2936 O O   . PRO B 1 128 12.116 18.126  18.824 B 128 ? 1.00 55.52  1 
+ATOM   2937 C CB  . PRO B 1 128 13.215 20.282  20.966 B 128 ? 1.00 33.02  1 
+ATOM   2938 C CG  . PRO B 1 128 13.567 20.562  22.379 B 128 ? 1.00 31.27  1 
+ATOM   2939 C CD  . PRO B 1 128 14.412 19.389  22.716 B 128 ? 1.00 39.33  1 
+ATOM   2940 N N   . SER B 1 129 14.296 17.787  19.236 B 129 ? 1.00 41.92  1 
+ATOM   2941 C CA  . SER B 1 129 14.521 17.305  17.886 B 129 ? 1.00 44.68  1 
+ATOM   2942 C C   . SER B 1 129 14.991 15.838  17.898 B 129 ? 1.00 48.54  1 
+ATOM   2943 O O   . SER B 1 129 15.152 15.197  16.845 B 129 ? 1.00 47.07  1 
+ATOM   2944 C CB  . SER B 1 129 15.554 18.239  17.225 B 129 ? 1.00 38.70  1 
+ATOM   2945 O OG  . SER B 1 129 16.855 18.188  17.836 B 129 ? 1.00 39.44  1 
+ATOM   2946 N N   . GLY B 1 130 15.239 15.279  19.083 B 130 ? 1.00 39.86  1 
+ATOM   2947 C CA  . GLY B 1 130 15.742 13.931  19.193 B 130 ? 1.00 41.24  1 
+ATOM   2948 C C   . GLY B 1 130 17.189 13.834  18.794 B 130 ? 1.00 40.68  1 
+ATOM   2949 O O   . GLY B 1 130 17.622 12.707  18.632 B 130 ? 1.00 42.99  1 
+ATOM   2950 N N   . ARG B 1 131 17.964 14.927  18.674 B 131 ? 1.00 38.18  1 
+ATOM   2951 C CA  . ARG B 1 131 19.364 14.806  18.256 B 131 ? 1.00 36.24  1 
+ATOM   2952 C C   . ARG B 1 131 20.167 14.217  19.397 B 131 ? 1.00 34.76  1 
+ATOM   2953 O O   . ARG B 1 131 19.945 14.558  20.566 B 131 ? 1.00 34.31  1 
+ATOM   2954 C CB  . ARG B 1 131 19.996 16.164  17.868 B 131 ? 1.00 41.13  1 
+ATOM   2955 C CG  . ARG B 1 131 19.943 16.482  16.356 B 131 ? 1.00 31.92  1 
+ATOM   2956 C CD  . ARG B 1 131 20.590 17.820  15.973 B 131 ? 1.00 30.92  1 
+ATOM   2957 N NE  . ARG B 1 131 19.891 18.947  16.591 B 131 ? 1.00 33.63  1 
+ATOM   2958 C CZ  . ARG B 1 131 18.871 19.640  16.074 B 131 ? 1.00 33.60  1 
+ATOM   2959 N NH1 . ARG B 1 131 18.421 19.392  14.866 B 131 ? 1.00 38.80  1 
+ATOM   2960 N NH2 . ARG B 1 131 18.260 20.585  16.782 B 131 ? 1.00 29.10  1 
+ATOM   2961 N N   . VAL B 1 132 21.112 13.339  19.084 B 132 ? 1.00 35.52  1 
+ATOM   2962 C CA  . VAL B 1 132 21.838 12.646  20.118 B 132 ? 1.00 29.51  1 
+ATOM   2963 C C   . VAL B 1 132 23.356 12.824  20.074 B 132 ? 1.00 32.42  1 
+ATOM   2964 O O   . VAL B 1 132 23.951 13.112  19.043 B 132 ? 1.00 28.80  1 
+ATOM   2965 C CB  . VAL B 1 132 21.302 11.219  19.990 B 132 ? 1.00 33.75  1 
+ATOM   2966 C CG1 . VAL B 1 132 21.630 10.620  18.649 B 132 ? 1.00 43.53  1 
+ATOM   2967 C CG2 . VAL B 1 132 21.894 10.390  21.082 B 132 ? 1.00 44.88  1 
+ATOM   2968 N N   . TYR B 1 133 23.972 12.853  21.255 B 133 ? 1.00 33.86  1 
+ATOM   2969 C CA  . TYR B 1 133 25.388 13.170  21.440 B 133 ? 1.00 32.17  1 
+ATOM   2970 C C   . TYR B 1 133 25.885 12.214  22.476 B 133 ? 1.00 28.42  1 
+ATOM   2971 O O   . TYR B 1 133 25.074 11.497  23.085 B 133 ? 1.00 28.65  1 
+ATOM   2972 C CB  . TYR B 1 133 25.564 14.592  21.977 B 133 ? 1.00 25.03  1 
+ATOM   2973 C CG  . TYR B 1 133 24.999 15.668  21.044 B 133 ? 1.00 30.28  1 
+ATOM   2974 C CD1 . TYR B 1 133 23.691 16.096  21.128 B 133 ? 1.00 27.62  1 
+ATOM   2975 C CD2 . TYR B 1 133 25.814 16.230  20.099 B 133 ? 1.00 28.36  1 
+ATOM   2976 C CE1 . TYR B 1 133 23.196 17.078  20.277 B 133 ? 1.00 27.70  1 
+ATOM   2977 C CE2 . TYR B 1 133 25.331 17.203  19.258 B 133 ? 1.00 25.41  1 
+ATOM   2978 C CZ  . TYR B 1 133 24.029 17.631  19.339 B 133 ? 1.00 25.49  1 
+ATOM   2979 O OH  . TYR B 1 133 23.571 18.597  18.442 B 133 ? 1.00 31.77  1 
+ATOM   2980 N N   . HIS B 1 134 27.178 12.177  22.747 B 134 ? 1.00 30.17  1 
+ATOM   2981 C CA  . HIS B 1 134 27.706 11.313  23.813 B 134 ? 1.00 33.03  1 
+ATOM   2982 C C   . HIS B 1 134 28.769 12.148  24.506 B 134 ? 1.00 36.60  1 
+ATOM   2983 O O   . HIS B 1 134 29.676 12.574  23.782 B 134 ? 1.00 38.09  1 
+ATOM   2984 C CB  . HIS B 1 134 28.364 10.010  23.238 B 134 ? 1.00 30.50  1 
+ATOM   2985 C CG  . HIS B 1 134 28.741 8.968   24.284 B 134 ? 1.00 38.26  1 
+ATOM   2986 N ND1 . HIS B 1 134 29.740 8.911   25.177 B 134 ? 1.00 43.35  1 
+ATOM   2987 C CD2 . HIS B 1 134 27.936 7.896   24.553 B 134 ? 1.00 45.97  1 
+ATOM   2988 C CE1 . HIS B 1 134 29.537 7.883   25.969 B 134 ? 1.00 45.39  1 
+ATOM   2989 N NE2 . HIS B 1 134 28.454 7.281   25.581 B 134 ? 1.00 48.15  1 
+ATOM   2990 N N   . VAL B 1 135 28.846 12.384  25.822 B 135 ? 1.00 34.09  1 
+ATOM   2991 C CA  . VAL B 1 135 29.908 13.254  26.376 B 135 ? 1.00 37.63  1 
+ATOM   2992 C C   . VAL B 1 135 31.381 12.953  26.141 B 135 ? 1.00 35.03  1 
+ATOM   2993 O O   . VAL B 1 135 32.258 13.816  26.262 B 135 ? 1.00 41.29  1 
+ATOM   2994 C CB  . VAL B 1 135 29.781 13.422  27.902 B 135 ? 1.00 34.35  1 
+ATOM   2995 C CG1 . VAL B 1 135 28.515 14.181  28.186 B 135 ? 1.00 35.57  1 
+ATOM   2996 C CG2 . VAL B 1 135 29.802 12.078  28.593 B 135 ? 1.00 34.66  1 
+ATOM   2997 N N   . LYS B 1 136 31.622 11.679  25.876 B 136 ? 1.00 39.51  1 
+ATOM   2998 C CA  . LYS B 1 136 32.946 11.172  25.557 B 136 ? 1.00 39.39  1 
+ATOM   2999 C C   . LYS B 1 136 33.166 10.760  24.108 B 136 ? 1.00 35.32  1 
+ATOM   3000 O O   . LYS B 1 136 34.252 11.018  23.615 B 136 ? 1.00 44.61  1 
+ATOM   3001 C CB  . LYS B 1 136 33.267 9.960   26.456 B 136 ? 1.00 43.05  1 
+ATOM   3002 C CG  . LYS B 1 136 33.536 10.300  27.921 B 136 ? 1.00 52.63  1 
+ATOM   3003 C CD  . LYS B 1 136 32.832 9.334   28.858 B 136 ? 1.00 62.42  1 
+ATOM   3004 C CE  . LYS B 1 136 33.353 7.907   28.723 B 136 ? 1.00 70.68  1 
+ATOM   3005 N NZ  . LYS B 1 136 32.519 7.004   29.495 B 136 ? 1.00 78.33  1 
+ATOM   3006 N N   . PHE B 1 137 32.216 10.164  23.345 B 137 ? 1.00 36.72  1 
+ATOM   3007 C CA  . PHE B 1 137 32.538 9.569   22.025 B 137 ? 1.00 38.28  1 
+ATOM   3008 C C   . PHE B 1 137 32.005 10.344  20.843 B 137 ? 1.00 39.39  1 
+ATOM   3009 O O   . PHE B 1 137 32.415 10.145  19.704 B 137 ? 1.00 42.01  1 
+ATOM   3010 C CB  . PHE B 1 137 31.992 8.139   21.864 B 137 ? 1.00 43.72  1 
+ATOM   3011 C CG  . PHE B 1 137 32.371 7.151   22.971 B 137 ? 1.00 48.21  1 
+ATOM   3012 C CD1 . PHE B 1 137 33.554 7.288   23.693 B 137 ? 1.00 44.68  1 
+ATOM   3013 C CD2 . PHE B 1 137 31.469 6.153   23.298 B 137 ? 1.00 50.95  1 
+ATOM   3014 C CE1 . PHE B 1 137 33.832 6.450   24.746 B 137 ? 1.00 48.49  1 
+ATOM   3015 C CE2 . PHE B 1 137 31.754 5.308   24.359 B 137 ? 1.00 53.15  1 
+ATOM   3016 C CZ  . PHE B 1 137 32.928 5.461   25.079 B 137 ? 1.00 56.71  1 
+ATOM   3017 N N   . ASN B 1 138 31.030 11.205  21.093 B 138 ? 1.00 40.46  1 
+ATOM   3018 C CA  . ASN B 1 138 30.466 12.065  20.072 B 138 ? 1.00 38.14  1 
+ATOM   3019 C C   . ASN B 1 138 29.951 13.366  20.733 B 138 ? 1.00 34.75  1 
+ATOM   3020 O O   . ASN B 1 138 28.750 13.588  20.862 B 138 ? 1.00 28.61  1 
+ATOM   3021 C CB  . ASN B 1 138 29.335 11.326  19.348 B 138 ? 1.00 38.91  1 
+ATOM   3022 C CG  . ASN B 1 138 28.924 12.115  18.108 B 138 ? 1.00 46.05  1 
+ATOM   3023 O OD1 . ASN B 1 138 27.803 12.025  17.614 B 138 ? 1.00 47.69  1 
+ATOM   3024 N ND2 . ASN B 1 138 29.776 12.920  17.473 B 138 ? 1.00 50.62  1 
+ATOM   3025 N N   . PRO B 1 139 30.828 14.224  21.266 B 139 ? 1.00 34.31  1 
+ATOM   3026 C CA  . PRO B 1 139 30.443 15.390  22.040 B 139 ? 1.00 36.64  1 
+ATOM   3027 C C   . PRO B 1 139 29.913 16.537  21.186 B 139 ? 1.00 37.60  1 
+ATOM   3028 O O   . PRO B 1 139 30.223 16.700  20.002 B 139 ? 1.00 35.56  1 
+ATOM   3029 C CB  . PRO B 1 139 31.686 15.772  22.829 B 139 ? 1.00 33.59  1 
+ATOM   3030 C CG  . PRO B 1 139 32.578 14.577  22.627 B 139 ? 1.00 38.89  1 
+ATOM   3031 C CD  . PRO B 1 139 32.277 14.112  21.209 B 139 ? 1.00 32.43  1 
+ATOM   3032 N N   . PRO B 1 140 29.051 17.359  21.776 B 140 ? 1.00 38.12  1 
+ATOM   3033 C CA  . PRO B 1 140 28.602 18.595  21.180 B 140 ? 1.00 31.10  1 
+ATOM   3034 C C   . PRO B 1 140 29.760 19.550  21.096 B 140 ? 1.00 33.53  1 
+ATOM   3035 O O   . PRO B 1 140 30.818 19.372  21.733 B 140 ? 1.00 34.53  1 
+ATOM   3036 C CB  . PRO B 1 140 27.507 19.042  22.087 B 140 ? 1.00 34.36  1 
+ATOM   3037 C CG  . PRO B 1 140 27.945 18.520  23.440 B 140 ? 1.00 39.15  1 
+ATOM   3038 C CD  . PRO B 1 140 28.454 17.143  23.099 B 140 ? 1.00 35.38  1 
+ATOM   3039 N N   . LYS B 1 141 29.464 20.637  20.403 B 141 ? 1.00 36.96  1 
+ATOM   3040 C CA  . LYS B 1 141 30.475 21.610  20.043 B 141 ? 1.00 45.60  1 
+ATOM   3041 C C   . LYS B 1 141 30.850 22.385  21.278 B 141 ? 1.00 42.21  1 
+ATOM   3042 O O   . LYS B 1 141 32.027 22.616  21.522 B 141 ? 1.00 46.49  1 
+ATOM   3043 C CB  . LYS B 1 141 29.934 22.563  18.957 B 141 ? 1.00 64.40  1 
+ATOM   3044 C CG  . LYS B 1 141 30.883 23.559  18.263 B 141 ? 1.00 79.45  1 
+ATOM   3045 C CD  . LYS B 1 141 30.248 24.182  16.995 B 141 ? 1.00 92.11  1 
+ATOM   3046 C CE  . LYS B 1 141 29.980 23.128  15.890 B 141 ? 1.00 96.98  1 
+ATOM   3047 N NZ  . LYS B 1 141 29.267 23.674  14.747 B 141 ? 1.00 98.10  1 
+ATOM   3048 N N   . VAL B 1 142 29.832 22.751  22.041 B 142 ? 1.00 40.93  1 
+ATOM   3049 C CA  . VAL B 1 142 29.911 23.495  23.270 B 142 ? 1.00 30.77  1 
+ATOM   3050 C C   . VAL B 1 142 29.234 22.499  24.171 B 142 ? 1.00 34.12  1 
+ATOM   3051 O O   . VAL B 1 142 28.174 21.971  23.824 B 142 ? 1.00 33.67  1 
+ATOM   3052 C CB  . VAL B 1 142 29.118 24.792  23.113 B 142 ? 1.00 33.86  1 
+ATOM   3053 C CG1 . VAL B 1 142 28.884 25.453  24.478 B 142 ? 1.00 27.94  1 
+ATOM   3054 C CG2 . VAL B 1 142 29.883 25.678  22.101 B 142 ? 1.00 28.21  1 
+ATOM   3055 N N   . GLU B 1 143 29.874 22.230  25.302 B 143 ? 1.00 34.35  1 
+ATOM   3056 C CA  . GLU B 1 143 29.446 21.224  26.254 B 143 ? 1.00 35.58  1 
+ATOM   3057 C C   . GLU B 1 143 28.045 21.449  26.699 B 143 ? 1.00 26.97  1 
+ATOM   3058 O O   . GLU B 1 143 27.754 22.594  27.000 B 143 ? 1.00 37.21  1 
+ATOM   3059 C CB  . GLU B 1 143 30.333 21.240  27.486 B 143 ? 1.00 50.15  1 
+ATOM   3060 C CG  . GLU B 1 143 29.889 20.258  28.600 B 143 ? 1.00 70.51  1 
+ATOM   3061 C CD  . GLU B 1 143 30.834 20.004  29.787 B 143 ? 1.00 82.45  1 
+ATOM   3062 O OE1 . GLU B 1 143 31.778 20.773  30.004 B 143 ? 1.00 89.45  1 
+ATOM   3063 O OE2 . GLU B 1 143 30.618 19.016  30.502 B 143 ? 1.00 89.41  1 
+ATOM   3064 N N   . GLY B 1 144 27.213 20.408  26.690 B 144 ? 1.00 30.90  1 
+ATOM   3065 C CA  . GLY B 1 144 25.846 20.427  27.192 B 144 ? 1.00 25.54  1 
+ATOM   3066 C C   . GLY B 1 144 24.869 21.255  26.379 B 144 ? 1.00 30.82  1 
+ATOM   3067 O O   . GLY B 1 144 23.755 21.498  26.851 B 144 ? 1.00 32.61  1 
+ATOM   3068 N N   . LYS B 1 145 25.196 21.720  25.168 B 145 ? 1.00 35.88  1 
+ATOM   3069 C CA  . LYS B 1 145 24.281 22.525  24.346 B 145 ? 1.00 29.20  1 
+ATOM   3070 C C   . LYS B 1 145 24.153 21.818  23.020 B 145 ? 1.00 28.47  1 
+ATOM   3071 O O   . LYS B 1 145 25.057 21.096  22.616 B 145 ? 1.00 28.26  1 
+ATOM   3072 C CB  . LYS B 1 145 24.833 23.878  24.089 B 145 ? 1.00 25.45  1 
+ATOM   3073 C CG  . LYS B 1 145 25.291 24.655  25.316 B 145 ? 1.00 30.24  1 
+ATOM   3074 C CD  . LYS B 1 145 24.107 25.003  26.163 B 145 ? 1.00 25.15  1 
+ATOM   3075 C CE  . LYS B 1 145 24.742 25.629  27.384 B 145 ? 1.00 31.09  1 
+ATOM   3076 N NZ  . LYS B 1 145 23.677 26.437  27.909 B 145 ? 1.00 40.29  1 
+ATOM   3077 N N   . ASP B 1 146 23.048 21.968  22.326 B 146 ? 1.00 32.95  1 
+ATOM   3078 C CA  . ASP B 1 146 22.827 21.388  21.006 B 146 ? 1.00 29.78  1 
+ATOM   3079 C C   . ASP B 1 146 23.612 22.216  19.961 B 146 ? 1.00 30.01  1 
+ATOM   3080 O O   . ASP B 1 146 23.630 23.469  19.938 B 146 ? 1.00 27.81  1 
+ATOM   3081 C CB  . ASP B 1 146 21.323 21.429  20.754 B 146 ? 1.00 28.61  1 
+ATOM   3082 C CG  . ASP B 1 146 20.879 20.889  19.419 B 146 ? 1.00 33.42  1 
+ATOM   3083 O OD1 . ASP B 1 146 21.223 19.771  19.110 B 146 ? 1.00 33.47  1 
+ATOM   3084 O OD2 . ASP B 1 146 20.197 21.579  18.682 B 146 ? 1.00 35.14  1 
+ATOM   3085 N N   . ASP B 1 147 24.208 21.508  19.001 B 147 ? 1.00 31.64  1 
+ATOM   3086 C CA  . ASP B 1 147 25.028 22.183  17.990 B 147 ? 1.00 38.60  1 
+ATOM   3087 C C   . ASP B 1 147 24.154 23.088  17.114 B 147 ? 1.00 32.60  1 
+ATOM   3088 O O   . ASP B 1 147 24.425 24.252  16.843 B 147 ? 1.00 37.74  1 
+ATOM   3089 C CB  . ASP B 1 147 25.775 21.140  17.087 B 147 ? 1.00 39.26  1 
+ATOM   3090 C CG  . ASP B 1 147 27.007 20.454  17.664 B 147 ? 1.00 37.04  1 
+ATOM   3091 O OD1 . ASP B 1 147 27.418 20.835  18.734 B 147 ? 1.00 31.21  1 
+ATOM   3092 O OD2 . ASP B 1 147 27.571 19.544  17.057 B 147 ? 1.00 42.25  1 
+ATOM   3093 N N   . VAL B 1 148 23.003 22.568  16.758 B 148 ? 1.00 32.83  1 
+ATOM   3094 C CA  . VAL B 1 148 22.139 23.263  15.847 B 148 ? 1.00 31.98  1 
+ATOM   3095 C C   . VAL B 1 148 21.385 24.438  16.457 B 148 ? 1.00 31.15  1 
+ATOM   3096 O O   . VAL B 1 148 21.281 25.467  15.796 B 148 ? 1.00 27.58  1 
+ATOM   3097 C CB  . VAL B 1 148 21.238 22.125  15.242 B 148 ? 1.00 40.57  1 
+ATOM   3098 C CG1 . VAL B 1 148 20.046 22.730  14.500 B 148 ? 1.00 42.08  1 
+ATOM   3099 C CG2 . VAL B 1 148 22.068 21.257  14.271 B 148 ? 1.00 30.00  1 
+ATOM   3100 N N   . THR B 1 149 20.840 24.323  17.680 B 149 ? 1.00 32.78  1 
+ATOM   3101 C CA  . THR B 1 149 20.057 25.380  18.293 B 149 ? 1.00 27.56  1 
+ATOM   3102 C C   . THR B 1 149 20.768 26.113  19.440 B 149 ? 1.00 31.04  1 
+ATOM   3103 O O   . THR B 1 149 20.324 27.172  19.895 B 149 ? 1.00 24.71  1 
+ATOM   3104 C CB  . THR B 1 149 18.709 24.816  18.829 B 149 ? 1.00 27.00  1 
+ATOM   3105 O OG1 . THR B 1 149 18.992 23.739  19.702 B 149 ? 1.00 28.99  1 
+ATOM   3106 C CG2 . THR B 1 149 17.832 24.189  17.768 B 149 ? 1.00 30.51  1 
+ATOM   3107 N N   . GLY B 1 150 21.860 25.539  19.930 B 150 ? 1.00 29.55  1 
+ATOM   3108 C CA  . GLY B 1 150 22.493 26.051  21.123 B 150 ? 1.00 35.34  1 
+ATOM   3109 C C   . GLY B 1 150 21.703 25.719  22.405 B 150 ? 1.00 32.07  1 
+ATOM   3110 O O   . GLY B 1 150 22.092 26.144  23.493 B 150 ? 1.00 29.49  1 
+ATOM   3111 N N   . GLU B 1 151 20.598 24.968  22.318 B 151 ? 1.00 29.29  1 
+ATOM   3112 C CA  . GLU B 1 151 19.745 24.695  23.463 B 151 ? 1.00 33.55  1 
+ATOM   3113 C C   . GLU B 1 151 20.320 23.634  24.393 B 151 ? 1.00 36.80  1 
+ATOM   3114 O O   . GLU B 1 151 21.089 22.760  23.954 B 151 ? 1.00 30.85  1 
+ATOM   3115 C CB  . GLU B 1 151 18.391 24.248  22.976 B 151 ? 1.00 37.12  1 
+ATOM   3116 C CG  . GLU B 1 151 17.493 25.339  22.380 B 151 ? 1.00 46.04  1 
+ATOM   3117 C CD  . GLU B 1 151 16.198 24.780  21.786 B 151 ? 1.00 53.15  1 
+ATOM   3118 O OE1 . GLU B 1 151 15.615 23.895  22.415 B 151 ? 1.00 62.90  1 
+ATOM   3119 O OE2 . GLU B 1 151 15.763 25.210  20.709 B 151 ? 1.00 54.09  1 
+ATOM   3120 N N   . GLU B 1 152 19.915 23.692  25.662 B 152 ? 1.00 31.95  1 
+ATOM   3121 C CA  . GLU B 1 152 20.404 22.756  26.668 B 152 ? 1.00 45.21  1 
+ATOM   3122 C C   . GLU B 1 152 20.117 21.261  26.416 B 152 ? 1.00 39.83  1 
+ATOM   3123 O O   . GLU B 1 152 19.004 20.855  26.091 B 152 ? 1.00 34.09  1 
+ATOM   3124 C CB  . GLU B 1 152 19.816 23.206  28.015 B 152 ? 1.00 65.08  1 
+ATOM   3125 C CG  . GLU B 1 152 20.623 22.930  29.324 B 152 ? 1.00 84.28  1 
+ATOM   3126 C CD  . GLU B 1 152 21.785 23.886  29.666 B 152 ? 1.00 91.64  1 
+ATOM   3127 O OE1 . GLU B 1 152 21.514 25.015  30.098 B 152 ? 1.00 90.46  1 
+ATOM   3128 O OE2 . GLU B 1 152 22.956 23.492  29.523 B 152 ? 1.00 94.30  1 
+ATOM   3129 N N   . LEU B 1 153 21.077 20.362  26.524 B 153 ? 1.00 37.34  1 
+ATOM   3130 C CA  . LEU B 1 153 20.847 18.946  26.292 B 153 ? 1.00 38.51  1 
+ATOM   3131 C C   . LEU B 1 153 20.431 18.233  27.574 B 153 ? 1.00 44.46  1 
+ATOM   3132 O O   . LEU B 1 153 20.893 18.604  28.659 B 153 ? 1.00 51.83  1 
+ATOM   3133 C CB  . LEU B 1 153 22.105 18.300  25.787 B 153 ? 1.00 33.60  1 
+ATOM   3134 C CG  . LEU B 1 153 22.803 18.847  24.580 B 153 ? 1.00 33.27  1 
+ATOM   3135 C CD1 . LEU B 1 153 24.156 18.190  24.532 B 153 ? 1.00 28.42  1 
+ATOM   3136 C CD2 . LEU B 1 153 22.005 18.588  23.317 B 153 ? 1.00 30.71  1 
+ATOM   3137 N N   . THR B 1 154 19.612 17.181  27.494 B 154 ? 1.00 42.04  1 
+ATOM   3138 C CA  . THR B 1 154 19.166 16.487  28.672 B 154 ? 1.00 37.52  1 
+ATOM   3139 C C   . THR B 1 154 19.550 15.014  28.642 B 154 ? 1.00 41.72  1 
+ATOM   3140 O O   . THR B 1 154 20.181 14.534  27.695 B 154 ? 1.00 29.22  1 
+ATOM   3141 C CB  . THR B 1 154 17.653 16.662  28.776 B 154 ? 1.00 32.83  1 
+ATOM   3142 O OG1 . THR B 1 154 16.995 16.186  27.592 B 154 ? 1.00 38.82  1 
+ATOM   3143 C CG2 . THR B 1 154 17.365 18.127  29.040 B 154 ? 1.00 34.83  1 
+ATOM   3144 N N   . THR B 1 155 19.185 14.296  29.710 B 155 ? 1.00 42.96  1 
+ATOM   3145 C CA  . THR B 1 155 19.397 12.867  29.824 B 155 ? 1.00 41.45  1 
+ATOM   3146 C C   . THR B 1 155 18.040 12.186  29.714 B 155 ? 1.00 44.17  1 
+ATOM   3147 O O   . THR B 1 155 17.044 12.702  30.243 B 155 ? 1.00 49.13  1 
+ATOM   3148 C CB  . THR B 1 155 20.069 12.552  31.184 B 155 ? 1.00 43.91  1 
+ATOM   3149 O OG1 . THR B 1 155 19.251 13.032  32.270 B 155 ? 1.00 54.98  1 
+ATOM   3150 C CG2 . THR B 1 155 21.416 13.246  31.264 B 155 ? 1.00 35.97  1 
+ATOM   3151 N N   . ARG B 1 156 17.922 11.068  29.011 B 156 ? 1.00 43.58  1 
+ATOM   3152 C CA  . ARG B 1 156 16.674 10.333  28.929 B 156 ? 1.00 42.87  1 
+ATOM   3153 C C   . ARG B 1 156 16.485 9.530   30.207 B 156 ? 1.00 44.97  1 
+ATOM   3154 O O   . ARG B 1 156 17.411 8.882   30.702 B 156 ? 1.00 41.18  1 
+ATOM   3155 C CB  . ARG B 1 156 16.710 9.399   27.735 B 156 ? 1.00 39.27  1 
+ATOM   3156 C CG  . ARG B 1 156 16.310 10.053  26.426 B 156 ? 1.00 37.84  1 
+ATOM   3157 C CD  . ARG B 1 156 16.517 9.095   25.251 B 156 ? 1.00 43.16  1 
+ATOM   3158 N NE  . ARG B 1 156 16.025 7.760   25.551 B 156 ? 1.00 42.32  1 
+ATOM   3159 C CZ  . ARG B 1 156 16.214 6.733   24.736 B 156 ? 1.00 38.58  1 
+ATOM   3160 N NH1 . ARG B 1 156 16.626 6.898   23.497 B 156 ? 1.00 43.63  1 
+ATOM   3161 N NH2 . ARG B 1 156 15.885 5.514   25.108 B 156 ? 1.00 37.85  1 
+ATOM   3162 N N   . LYS B 1 157 15.259 9.633   30.714 B 157 ? 1.00 54.96  1 
+ATOM   3163 C CA  . LYS B 1 157 14.694 8.965   31.896 B 157 ? 1.00 62.67  1 
+ATOM   3164 C C   . LYS B 1 157 15.167 7.522   32.015 B 157 ? 1.00 60.68  1 
+ATOM   3165 O O   . LYS B 1 157 15.755 7.112   33.017 B 157 ? 1.00 58.71  1 
+ATOM   3166 C CB  . LYS B 1 157 13.152 8.873   31.856 B 157 ? 1.00 72.40  1 
+ATOM   3167 C CG  . LYS B 1 157 12.188 10.078  31.762 B 157 ? 1.00 85.60  1 
+ATOM   3168 C CD  . LYS B 1 157 12.290 11.037  30.548 B 157 ? 1.00 91.39  1 
+ATOM   3169 C CE  . LYS B 1 157 12.116 10.478  29.139 B 157 ? 1.00 88.15  1 
+ATOM   3170 N NZ  . LYS B 1 157 12.446 11.518  28.179 B 157 ? 1.00 88.05  1 
+ATOM   3171 N N   . ASP B 1 158 14.918 6.767   30.949 B 158 ? 1.00 51.75  1 
+ATOM   3172 C CA  . ASP B 1 158 15.297 5.383   30.894 B 158 ? 1.00 45.75  1 
+ATOM   3173 C C   . ASP B 1 158 16.790 5.104   30.770 B 158 ? 1.00 47.61  1 
+ATOM   3174 O O   . ASP B 1 158 17.196 3.942   30.761 B 158 ? 1.00 47.08  1 
+ATOM   3175 C CB  . ASP B 1 158 14.512 4.761   29.730 B 158 ? 1.00 44.29  1 
+ATOM   3176 C CG  . ASP B 1 158 14.760 5.292   28.320 B 158 ? 1.00 42.57  1 
+ATOM   3177 O OD1 . ASP B 1 158 15.547 6.211   28.136 B 158 ? 1.00 45.91  1 
+ATOM   3178 O OD2 . ASP B 1 158 14.146 4.776   27.390 B 158 ? 1.00 42.38  1 
+ATOM   3179 N N   . ASP B 1 159 17.706 6.068   30.699 B 159 ? 1.00 52.80  1 
+ATOM   3180 C CA  . ASP B 1 159 19.097 5.725   30.419 B 159 ? 1.00 50.22  1 
+ATOM   3181 C C   . ASP B 1 159 19.989 5.377   31.570 B 159 ? 1.00 49.07  1 
+ATOM   3182 O O   . ASP B 1 159 20.870 6.157   31.926 B 159 ? 1.00 61.90  1 
+ATOM   3183 C CB  . ASP B 1 159 19.760 6.857   29.627 B 159 ? 1.00 47.08  1 
+ATOM   3184 C CG  . ASP B 1 159 19.439 6.912   28.148 B 159 ? 1.00 37.86  1 
+ATOM   3185 O OD1 . ASP B 1 159 18.840 5.994   27.583 B 159 ? 1.00 46.15  1 
+ATOM   3186 O OD2 . ASP B 1 159 19.817 7.904   27.552 B 159 ? 1.00 42.96  1 
+ATOM   3187 N N   . GLN B 1 160 19.804 4.259   32.239 B 160 ? 1.00 55.64  1 
+ATOM   3188 C CA  . GLN B 1 160 20.776 3.883   33.253 B 160 ? 1.00 62.07  1 
+ATOM   3189 C C   . GLN B 1 160 21.076 2.402   33.110 B 160 ? 1.00 58.32  1 
+ATOM   3190 O O   . GLN B 1 160 20.263 1.698   32.497 B 160 ? 1.00 58.76  1 
+ATOM   3191 C CB  . GLN B 1 160 20.257 4.215   34.668 B 160 ? 1.00 76.10  1 
+ATOM   3192 C CG  . GLN B 1 160 18.855 3.771   35.123 B 160 ? 1.00 90.51  1 
+ATOM   3193 C CD  . GLN B 1 160 17.686 4.680   34.751 B 160 ? 1.00 94.79  1 
+ATOM   3194 O OE1 . GLN B 1 160 16.530 4.251   34.735 B 160 ? 1.00 95.56  1 
+ATOM   3195 N NE2 . GLN B 1 160 17.903 5.958   34.457 B 160 ? 1.00 98.96  1 
+ATOM   3196 N N   . GLU B 1 161 22.240 1.959   33.620 B 161 ? 1.00 50.75  1 
+ATOM   3197 C CA  . GLU B 1 161 22.768 0.606   33.508 B 161 ? 1.00 50.64  1 
+ATOM   3198 C C   . GLU B 1 161 21.725 -0.489  33.583 B 161 ? 1.00 50.61  1 
+ATOM   3199 O O   . GLU B 1 161 21.591 -1.266  32.636 B 161 ? 1.00 45.78  1 
+ATOM   3200 C CB  . GLU B 1 161 23.803 0.424   34.604 B 161 ? 1.00 59.01  1 
+ATOM   3201 C CG  . GLU B 1 161 24.375 -0.969  34.875 B 161 ? 1.00 75.32  1 
+ATOM   3202 C CD  . GLU B 1 161 25.309 -1.090  36.094 B 161 ? 1.00 85.47  1 
+ATOM   3203 O OE1 . GLU B 1 161 26.277 -0.334  36.139 B 161 ? 1.00 89.92  1 
+ATOM   3204 O OE2 . GLU B 1 161 25.093 -1.934  36.983 B 161 ? 1.00 88.22  1 
+ATOM   3205 N N   . GLU B 1 162 20.920 -0.481  34.655 B 162 ? 1.00 52.95  1 
+ATOM   3206 C CA  . GLU B 1 162 19.908 -1.502  34.881 B 162 ? 1.00 54.78  1 
+ATOM   3207 C C   . GLU B 1 162 18.739 -1.492  33.908 B 162 ? 1.00 46.44  1 
+ATOM   3208 O O   . GLU B 1 162 18.377 -2.571  33.421 B 162 ? 1.00 46.02  1 
+ATOM   3209 C CB  . GLU B 1 162 19.392 -1.405  36.350 B 162 ? 1.00 63.77  1 
+ATOM   3210 C CG  . GLU B 1 162 20.480 -1.758  37.428 B 162 ? 1.00 75.38  1 
+ATOM   3211 C CD  . GLU B 1 162 21.249 -3.110  37.410 B 162 ? 1.00 80.75  1 
+ATOM   3212 O OE1 . GLU B 1 162 20.616 -4.173  37.456 B 162 ? 1.00 83.47  1 
+ATOM   3213 O OE2 . GLU B 1 162 22.488 -3.105  37.383 B 162 ? 1.00 77.04  1 
+ATOM   3214 N N   . THR B 1 163 18.165 -0.337  33.564 B 163 ? 1.00 42.25  1 
+ATOM   3215 C CA  . THR B 1 163 17.121 -0.240  32.544 B 163 ? 1.00 39.90  1 
+ATOM   3216 C C   . THR B 1 163 17.735 -0.685  31.195 B 163 ? 1.00 45.40  1 
+ATOM   3217 O O   . THR B 1 163 17.141 -1.495  30.477 B 163 ? 1.00 45.06  1 
+ATOM   3218 C CB  . THR B 1 163 16.630 1.209   32.498 B 163 ? 1.00 36.70  1 
+ATOM   3219 O OG1 . THR B 1 163 16.605 1.626   33.852 B 163 ? 1.00 46.91  1 
+ATOM   3220 C CG2 . THR B 1 163 15.248 1.407   31.965 B 163 ? 1.00 38.72  1 
+ATOM   3221 N N   . VAL B 1 164 18.978 -0.299  30.841 B 164 ? 1.00 47.52  1 
+ATOM   3222 C CA  . VAL B 1 164 19.632 -0.704  29.595 B 164 ? 1.00 42.00  1 
+ATOM   3223 C C   . VAL B 1 164 19.774 -2.216  29.565 B 164 ? 1.00 44.67  1 
+ATOM   3224 O O   . VAL B 1 164 19.489 -2.848  28.541 B 164 ? 1.00 48.44  1 
+ATOM   3225 C CB  . VAL B 1 164 21.019 -0.070  29.476 B 164 ? 1.00 44.97  1 
+ATOM   3226 C CG1 . VAL B 1 164 21.717 -0.396  28.155 B 164 ? 1.00 43.33  1 
+ATOM   3227 C CG2 . VAL B 1 164 20.816 1.411   29.543 B 164 ? 1.00 50.80  1 
+ATOM   3228 N N   . ARG B 1 165 20.161 -2.839  30.681 B 165 ? 1.00 43.25  1 
+ATOM   3229 C CA  . ARG B 1 165 20.266 -4.286  30.739 B 165 ? 1.00 39.09  1 
+ATOM   3230 C C   . ARG B 1 165 18.939 -4.951  30.454 B 165 ? 1.00 43.70  1 
+ATOM   3231 O O   . ARG B 1 165 18.881 -5.828  29.582 B 165 ? 1.00 42.32  1 
+ATOM   3232 C CB  . ARG B 1 165 20.775 -4.648  32.073 B 165 ? 1.00 49.27  1 
+ATOM   3233 C CG  . ARG B 1 165 22.230 -4.255  31.945 B 165 ? 1.00 63.64  1 
+ATOM   3234 C CD  . ARG B 1 165 22.947 -4.202  33.268 B 165 ? 1.00 76.99  1 
+ATOM   3235 N NE  . ARG B 1 165 24.351 -4.016  32.956 B 165 ? 1.00 89.11  1 
+ATOM   3236 C CZ  . ARG B 1 165 25.333 -4.245  33.834 B 165 ? 1.00 95.74  1 
+ATOM   3237 N NH1 . ARG B 1 165 25.101 -4.613  35.108 B 165 ? 1.00 97.66  1 
+ATOM   3238 N NH2 . ARG B 1 165 26.582 -4.060  33.403 B 165 ? 1.00 98.02  1 
+ATOM   3239 N N   . LYS B 1 166 17.847 -4.450  31.047 B 166 ? 1.00 45.10  1 
+ATOM   3240 C CA  . LYS B 1 166 16.527 -4.992  30.774 B 166 ? 1.00 44.51  1 
+ATOM   3241 C C   . LYS B 1 166 16.263 -4.838  29.286 B 166 ? 1.00 39.52  1 
+ATOM   3242 O O   . LYS B 1 166 15.883 -5.832  28.651 B 166 ? 1.00 41.62  1 
+ATOM   3243 C CB  . LYS B 1 166 15.468 -4.243  31.587 B 166 ? 1.00 56.14  1 
+ATOM   3244 C CG  . LYS B 1 166 15.721 -4.374  33.096 B 166 ? 1.00 72.40  1 
+ATOM   3245 C CD  . LYS B 1 166 14.807 -3.560  34.043 B 166 ? 1.00 82.46  1 
+ATOM   3246 C CE  . LYS B 1 166 15.236 -3.762  35.523 B 166 ? 1.00 90.50  1 
+ATOM   3247 N NZ  . LYS B 1 166 14.363 -3.132  36.513 B 166 ? 1.00 92.49  1 
+ATOM   3248 N N   . ARG B 1 167 16.614 -3.678  28.697 B 167 ? 1.00 34.18  1 
+ATOM   3249 C CA  . ARG B 1 167 16.402 -3.432  27.250 B 167 ? 1.00 42.17  1 
+ATOM   3250 C C   . ARG B 1 167 17.162 -4.370  26.330 B 167 ? 1.00 41.05  1 
+ATOM   3251 O O   . ARG B 1 167 16.655 -4.736  25.259 B 167 ? 1.00 36.15  1 
+ATOM   3252 C CB  . ARG B 1 167 16.824 -2.030  26.767 B 167 ? 1.00 37.06  1 
+ATOM   3253 C CG  . ARG B 1 167 15.963 -0.902  27.298 B 167 ? 1.00 42.92  1 
+ATOM   3254 C CD  . ARG B 1 167 15.803 0.245   26.305 B 167 ? 1.00 41.72  1 
+ATOM   3255 N NE  . ARG B 1 167 16.926 1.143   26.242 B 167 ? 1.00 44.97  1 
+ATOM   3256 C CZ  . ARG B 1 167 17.062 2.174   27.084 B 167 ? 1.00 50.83  1 
+ATOM   3257 N NH1 . ARG B 1 167 16.189 2.400   28.060 B 167 ? 1.00 58.08  1 
+ATOM   3258 N NH2 . ARG B 1 167 18.107 2.990   26.955 B 167 ? 1.00 49.65  1 
+ATOM   3259 N N   . LEU B 1 168 18.399 -4.730  26.705 B 168 ? 1.00 36.25  1 
+ATOM   3260 C CA  . LEU B 1 168 19.127 -5.686  25.920 B 168 ? 1.00 32.19  1 
+ATOM   3261 C C   . LEU B 1 168 18.567 -7.085  26.031 B 168 ? 1.00 34.90  1 
+ATOM   3262 O O   . LEU B 1 168 18.509 -7.794  25.011 B 168 ? 1.00 36.46  1 
+ATOM   3263 C CB  . LEU B 1 168 20.568 -5.699  26.315 B 168 ? 1.00 43.47  1 
+ATOM   3264 C CG  . LEU B 1 168 21.512 -4.997  25.333 B 168 ? 1.00 51.57  1 
+ATOM   3265 C CD1 . LEU B 1 168 22.912 -5.091  25.882 B 168 ? 1.00 52.48  1 
+ATOM   3266 C CD2 . LEU B 1 168 21.505 -5.658  23.960 B 168 ? 1.00 54.68  1 
+ATOM   3267 N N   . VAL B 1 169 18.066 -7.542  27.177 B 169 ? 1.00 36.34  1 
+ATOM   3268 C CA  . VAL B 1 169 17.445 -8.859  27.179 B 169 ? 1.00 37.70  1 
+ATOM   3269 C C   . VAL B 1 169 16.229 -8.870  26.253 B 169 ? 1.00 40.36  1 
+ATOM   3270 O O   . VAL B 1 169 16.058 -9.815  25.479 B 169 ? 1.00 38.39  1 
+ATOM   3271 C CB  . VAL B 1 169 17.045 -9.235  28.617 B 169 ? 1.00 40.29  1 
+ATOM   3272 C CG1 . VAL B 1 169 16.407 -10.621 28.678 B 169 ? 1.00 34.16  1 
+ATOM   3273 C CG2 . VAL B 1 169 18.300 -9.262  29.461 B 169 ? 1.00 39.20  1 
+ATOM   3274 N N   . GLU B 1 170 15.375 -7.833  26.261 B 170 ? 1.00 47.88  1 
+ATOM   3275 C CA  . GLU B 1 170 14.175 -7.773  25.410 B 170 ? 1.00 42.49  1 
+ATOM   3276 C C   . GLU B 1 170 14.595 -7.737  23.968 B 170 ? 1.00 43.32  1 
+ATOM   3277 O O   . GLU B 1 170 13.938 -8.334  23.116 B 170 ? 1.00 49.06  1 
+ATOM   3278 C CB  . GLU B 1 170 13.325 -6.521  25.607 B 170 ? 1.00 46.83  1 
+ATOM   3279 C CG  . GLU B 1 170 12.694 -6.349  26.968 B 170 ? 1.00 65.51  1 
+ATOM   3280 C CD  . GLU B 1 170 11.476 -7.230  27.207 B 170 ? 1.00 73.41  1 
+ATOM   3281 O OE1 . GLU B 1 170 10.420 -6.927  26.645 B 170 ? 1.00 80.40  1 
+ATOM   3282 O OE2 . GLU B 1 170 11.583 -8.202  27.960 B 170 ? 1.00 74.66  1 
+ATOM   3283 N N   . TYR B 1 171 15.695 -7.067  23.656 B 171 ? 1.00 40.50  1 
+ATOM   3284 C CA  . TYR B 1 171 16.181 -7.037  22.299 B 171 ? 1.00 35.65  1 
+ATOM   3285 C C   . TYR B 1 171 16.488 -8.460  21.860 B 171 ? 1.00 39.53  1 
+ATOM   3286 O O   . TYR B 1 171 16.046 -8.902  20.798 B 171 ? 1.00 34.57  1 
+ATOM   3287 C CB  . TYR B 1 171 17.434 -6.179  22.239 B 171 ? 1.00 33.25  1 
+ATOM   3288 C CG  . TYR B 1 171 18.030 -6.237  20.851 B 171 ? 1.00 32.35  1 
+ATOM   3289 C CD1 . TYR B 1 171 17.442 -5.542  19.821 B 171 ? 1.00 35.62  1 
+ATOM   3290 C CD2 . TYR B 1 171 19.118 -7.043  20.623 B 171 ? 1.00 33.07  1 
+ATOM   3291 C CE1 . TYR B 1 171 17.931 -5.685  18.542 B 171 ? 1.00 35.44  1 
+ATOM   3292 C CE2 . TYR B 1 171 19.617 -7.191  19.362 B 171 ? 1.00 26.79  1 
+ATOM   3293 C CZ  . TYR B 1 171 19.015 -6.507  18.327 B 171 ? 1.00 37.06  1 
+ATOM   3294 O OH  . TYR B 1 171 19.480 -6.710  17.035 B 171 ? 1.00 38.74  1 
+ATOM   3295 N N   . HIS B 1 172 17.238 -9.183  22.689 B 172 ? 1.00 39.64  1 
+ATOM   3296 C CA  . HIS B 1 172 17.653 -10.524 22.354 B 172 ? 1.00 42.09  1 
+ATOM   3297 C C   . HIS B 1 172 16.519 -11.497 22.118 B 172 ? 1.00 46.79  1 
+ATOM   3298 O O   . HIS B 1 172 16.570 -12.267 21.146 B 172 ? 1.00 53.39  1 
+ATOM   3299 C CB  . HIS B 1 172 18.555 -11.049 23.446 B 172 ? 1.00 46.86  1 
+ATOM   3300 C CG  . HIS B 1 172 19.918 -10.417 23.251 B 172 ? 1.00 55.08  1 
+ATOM   3301 N ND1 . HIS B 1 172 20.713 -10.500 22.183 B 172 ? 1.00 56.84  1 
+ATOM   3302 C CD2 . HIS B 1 172 20.511 -9.560  24.147 B 172 ? 1.00 56.82  1 
+ATOM   3303 C CE1 . HIS B 1 172 21.747 -9.710  22.401 B 172 ? 1.00 59.08  1 
+ATOM   3304 N NE2 . HIS B 1 172 21.614 -9.151  23.585 B 172 ? 1.00 56.29  1 
+ATOM   3305 N N   . GLN B 1 173 15.461 -11.422 22.932 B 173 ? 1.00 41.67  1 
+ATOM   3306 C CA  . GLN B 1 173 14.325 -12.339 22.789 B 173 ? 1.00 48.59  1 
+ATOM   3307 C C   . GLN B 1 173 13.291 -11.967 21.746 B 173 ? 1.00 42.11  1 
+ATOM   3308 O O   . GLN B 1 173 12.684 -12.844 21.134 B 173 ? 1.00 37.79  1 
+ATOM   3309 C CB  . GLN B 1 173 13.510 -12.493 24.059 B 173 ? 1.00 60.01  1 
+ATOM   3310 C CG  . GLN B 1 173 14.167 -13.057 25.296 B 173 ? 1.00 76.38  1 
+ATOM   3311 C CD  . GLN B 1 173 13.243 -12.826 26.474 B 173 ? 1.00 82.48  1 
+ATOM   3312 O OE1 . GLN B 1 173 12.343 -13.616 26.747 B 173 ? 1.00 91.60  1 
+ATOM   3313 N NE2 . GLN B 1 173 13.399 -11.716 27.179 B 173 ? 1.00 81.25  1 
+ATOM   3314 N N   . MET B 1 174 13.037 -10.666 21.618 B 174 ? 1.00 41.16  1 
+ATOM   3315 C CA  . MET B 1 174 12.005 -10.129 20.759 B 174 ? 1.00 44.59  1 
+ATOM   3316 C C   . MET B 1 174 12.443 -9.507  19.433 B 174 ? 1.00 43.41  1 
+ATOM   3317 O O   . MET B 1 174 11.829 -9.763  18.390 B 174 ? 1.00 42.69  1 
+ATOM   3318 C CB  . MET B 1 174 11.227 -9.085  21.549 B 174 ? 1.00 45.47  1 
+ATOM   3319 C CG  . MET B 1 174 10.681 -9.519  22.897 B 174 ? 1.00 48.43  1 
+ATOM   3320 S SD  . MET B 1 174 9.632  -10.957 22.656 B 174 ? 1.00 61.69  1 
+ATOM   3321 C CE  . MET B 1 174 8.369  -10.191 21.679 B 174 ? 1.00 60.46  1 
+ATOM   3322 N N   . THR B 1 175 13.484 -8.680  19.449 B 175 ? 1.00 42.94  1 
+ATOM   3323 C CA  . THR B 1 175 13.901 -7.950  18.269 B 175 ? 1.00 38.36  1 
+ATOM   3324 C C   . THR B 1 175 14.925 -8.700  17.460 B 175 ? 1.00 37.16  1 
+ATOM   3325 O O   . THR B 1 175 14.844 -8.626  16.235 B 175 ? 1.00 40.67  1 
+ATOM   3326 C CB  . THR B 1 175 14.461 -6.595  18.693 B 175 ? 1.00 34.70  1 
+ATOM   3327 O OG1 . THR B 1 175 13.698 -6.128  19.797 B 175 ? 1.00 34.25  1 
+ATOM   3328 C CG2 . THR B 1 175 14.397 -5.596  17.562 B 175 ? 1.00 37.04  1 
+ATOM   3329 N N   . ALA B 1 176 15.864 -9.451  18.061 B 176 ? 1.00 32.51  1 
+ATOM   3330 C CA  . ALA B 1 176 16.843 -10.199 17.307 B 176 ? 1.00 31.54  1 
+ATOM   3331 C C   . ALA B 1 176 16.242 -11.067 16.189 B 176 ? 1.00 32.00  1 
+ATOM   3332 O O   . ALA B 1 176 16.835 -11.022 15.106 B 176 ? 1.00 36.96  1 
+ATOM   3333 C CB  . ALA B 1 176 17.633 -11.078 18.267 B 176 ? 1.00 33.81  1 
+ATOM   3334 N N   . PRO B 1 177 15.098 -11.788 16.208 B 177 ? 1.00 32.33  1 
+ATOM   3335 C CA  . PRO B 1 177 14.607 -12.567 15.058 B 177 ? 1.00 37.50  1 
+ATOM   3336 C C   . PRO B 1 177 14.355 -11.782 13.776 B 177 ? 1.00 34.85  1 
+ATOM   3337 O O   . PRO B 1 177 14.255 -12.362 12.693 B 177 ? 1.00 42.47  1 
+ATOM   3338 C CB  . PRO B 1 177 13.343 -13.251 15.549 B 177 ? 1.00 36.10  1 
+ATOM   3339 C CG  . PRO B 1 177 13.628 -13.393 17.031 B 177 ? 1.00 36.27  1 
+ATOM   3340 C CD  . PRO B 1 177 14.222 -12.041 17.348 B 177 ? 1.00 30.46  1 
+ATOM   3341 N N   . LEU B 1 178 14.268 -10.462 13.861 B 178 ? 1.00 32.26  1 
+ATOM   3342 C CA  . LEU B 1 178 14.019 -9.640  12.710 B 178 ? 1.00 33.76  1 
+ATOM   3343 C C   . LEU B 1 178 15.190 -9.639  11.760 B 178 ? 1.00 38.81  1 
+ATOM   3344 O O   . LEU B 1 178 14.945 -9.383  10.581 B 178 ? 1.00 41.67  1 
+ATOM   3345 C CB  . LEU B 1 178 13.679 -8.202  13.146 B 178 ? 1.00 38.52  1 
+ATOM   3346 C CG  . LEU B 1 178 12.275 -7.954  13.699 B 178 ? 1.00 35.50  1 
+ATOM   3347 C CD1 . LEU B 1 178 12.098 -6.486  14.011 B 178 ? 1.00 31.03  1 
+ATOM   3348 C CD2 . LEU B 1 178 11.243 -8.389  12.660 B 178 ? 1.00 34.09  1 
+ATOM   3349 N N   . ILE B 1 179 16.429 -9.975  12.170 B 179 ? 1.00 39.80  1 
+ATOM   3350 C CA  . ILE B 1 179 17.573 -10.058 11.236 B 179 ? 1.00 38.84  1 
+ATOM   3351 C C   . ILE B 1 179 17.335 -11.178 10.198 B 179 ? 1.00 43.32  1 
+ATOM   3352 O O   . ILE B 1 179 17.488 -11.020 8.971  B 179 ? 1.00 40.13  1 
+ATOM   3353 C CB  . ILE B 1 179 18.854 -10.289 12.098 B 179 ? 1.00 31.91  1 
+ATOM   3354 C CG1 . ILE B 1 179 19.098 -9.010  12.878 B 179 ? 1.00 35.72  1 
+ATOM   3355 C CG2 . ILE B 1 179 20.069 -10.678 11.263 B 179 ? 1.00 27.69  1 
+ATOM   3356 C CD1 . ILE B 1 179 20.025 -9.320  14.055 B 179 ? 1.00 36.39  1 
+ATOM   3357 N N   . GLY B 1 180 16.929 -12.340 10.721 B 180 ? 1.00 42.11  1 
+ATOM   3358 C CA  . GLY B 1 180 16.545 -13.482 9.909  B 180 ? 1.00 42.78  1 
+ATOM   3359 C C   . GLY B 1 180 15.340 -13.184 9.033  B 180 ? 1.00 37.36  1 
+ATOM   3360 O O   . GLY B 1 180 15.316 -13.596 7.867  B 180 ? 1.00 40.42  1 
+ATOM   3361 N N   . TYR B 1 181 14.385 -12.422 9.564  B 181 ? 1.00 30.34  1 
+ATOM   3362 C CA  . TYR B 1 181 13.187 -12.028 8.833  B 181 ? 1.00 38.82  1 
+ATOM   3363 C C   . TYR B 1 181 13.573 -11.209 7.599  B 181 ? 1.00 47.26  1 
+ATOM   3364 O O   . TYR B 1 181 13.094 -11.535 6.495  B 181 ? 1.00 55.98  1 
+ATOM   3365 C CB  . TYR B 1 181 12.325 -11.226 9.765  B 181 ? 1.00 38.26  1 
+ATOM   3366 C CG  . TYR B 1 181 10.953 -10.839 9.278  B 181 ? 1.00 46.12  1 
+ATOM   3367 C CD1 . TYR B 1 181 10.811 -9.870  8.305  B 181 ? 1.00 49.42  1 
+ATOM   3368 C CD2 . TYR B 1 181 9.857  -11.478 9.808  B 181 ? 1.00 45.31  1 
+ATOM   3369 C CE1 . TYR B 1 181 9.568  -9.531  7.844  B 181 ? 1.00 46.78  1 
+ATOM   3370 C CE2 . TYR B 1 181 8.602  -11.142 9.354  B 181 ? 1.00 47.51  1 
+ATOM   3371 C CZ  . TYR B 1 181 8.482  -10.175 8.377  B 181 ? 1.00 46.61  1 
+ATOM   3372 O OH  . TYR B 1 181 7.246  -9.825  7.918  B 181 ? 1.00 45.71  1 
+ATOM   3373 N N   . TYR B 1 182 14.426 -10.174 7.690  B 182 ? 1.00 44.20  1 
+ATOM   3374 C CA  . TYR B 1 182 14.753 -9.392  6.499  B 182 ? 1.00 47.78  1 
+ATOM   3375 C C   . TYR B 1 182 15.852 -9.972  5.611  B 182 ? 1.00 49.97  1 
+ATOM   3376 O O   . TYR B 1 182 15.966 -9.659  4.416  B 182 ? 1.00 45.63  1 
+ATOM   3377 C CB  . TYR B 1 182 15.069 -7.958  6.953  B 182 ? 1.00 42.86  1 
+ATOM   3378 C CG  . TYR B 1 182 13.775 -7.321  7.462  B 182 ? 1.00 45.91  1 
+ATOM   3379 C CD1 . TYR B 1 182 12.767 -7.023  6.568  B 182 ? 1.00 43.06  1 
+ATOM   3380 C CD2 . TYR B 1 182 13.578 -7.087  8.822  B 182 ? 1.00 47.20  1 
+ATOM   3381 C CE1 . TYR B 1 182 11.572 -6.504  7.028  B 182 ? 1.00 43.58  1 
+ATOM   3382 C CE2 . TYR B 1 182 12.386 -6.568  9.292  B 182 ? 1.00 43.33  1 
+ATOM   3383 C CZ  . TYR B 1 182 11.385 -6.283  8.379  B 182 ? 1.00 49.85  1 
+ATOM   3384 O OH  . TYR B 1 182 10.162 -5.801  8.822  B 182 ? 1.00 50.75  1 
+ATOM   3385 N N   . SER B 1 183 16.662 -10.877 6.157  B 183 ? 1.00 51.68  1 
+ATOM   3386 C CA  . SER B 1 183 17.601 -11.622 5.333  B 183 ? 1.00 48.81  1 
+ATOM   3387 C C   . SER B 1 183 16.747 -12.501 4.427  B 183 ? 1.00 43.84  1 
+ATOM   3388 O O   . SER B 1 183 17.052 -12.660 3.255  B 183 ? 1.00 43.23  1 
+ATOM   3389 C CB  . SER B 1 183 18.502 -12.499 6.199  B 183 ? 1.00 51.07  1 
+ATOM   3390 O OG  . SER B 1 183 19.345 -11.740 7.071  B 183 ? 1.00 58.60  1 
+ATOM   3391 N N   . LYS B 1 184 15.635 -13.044 4.927  B 184 ? 1.00 43.13  1 
+ATOM   3392 C CA  . LYS B 1 184 14.749 -13.857 4.124  B 184 ? 1.00 51.50  1 
+ATOM   3393 C C   . LYS B 1 184 14.102 -13.024 3.010  B 184 ? 1.00 52.75  1 
+ATOM   3394 O O   . LYS B 1 184 14.030 -13.471 1.857  B 184 ? 1.00 49.50  1 
+ATOM   3395 C CB  . LYS B 1 184 13.717 -14.454 5.044  B 184 ? 1.00 51.29  1 
+ATOM   3396 C CG  . LYS B 1 184 13.582 -15.907 4.672  B 184 ? 1.00 62.88  1 
+ATOM   3397 C CD  . LYS B 1 184 12.570 -16.571 5.581  B 184 ? 1.00 70.91  1 
+ATOM   3398 C CE  . LYS B 1 184 11.906 -17.753 4.883  B 184 ? 1.00 77.63  1 
+ATOM   3399 N NZ  . LYS B 1 184 12.859 -18.748 4.423  B 184 ? 1.00 84.36  1 
+ATOM   3400 N N   . GLU B 1 185 13.683 -11.791 3.336  B 185 ? 1.00 51.88  1 
+ATOM   3401 C CA  . GLU B 1 185 13.140 -10.855 2.362  B 185 ? 1.00 46.95  1 
+ATOM   3402 C C   . GLU B 1 185 14.194 -10.465 1.351  B 185 ? 1.00 43.00  1 
+ATOM   3403 O O   . GLU B 1 185 13.906 -10.499 0.162  B 185 ? 1.00 52.61  1 
+ATOM   3404 C CB  . GLU B 1 185 12.653 -9.562  2.985  B 185 ? 1.00 53.16  1 
+ATOM   3405 C CG  . GLU B 1 185 11.594 -9.691  4.074  B 185 ? 1.00 61.26  1 
+ATOM   3406 C CD  . GLU B 1 185 10.250 -10.229 3.612  B 185 ? 1.00 67.26  1 
+ATOM   3407 O OE1 . GLU B 1 185 9.681  -9.691  2.651  B 185 ? 1.00 66.62  1 
+ATOM   3408 O OE2 . GLU B 1 185 9.783  -11.186 4.233  B 185 ? 1.00 71.90  1 
+ATOM   3409 N N   . ALA B 1 186 15.420 -10.109 1.709  B 186 ? 1.00 40.59  1 
+ATOM   3410 C CA  . ALA B 1 186 16.434 -9.751  0.746  B 186 ? 1.00 42.91  1 
+ATOM   3411 C C   . ALA B 1 186 16.758 -10.958 -0.128 B 186 ? 1.00 56.53  1 
+ATOM   3412 O O   . ALA B 1 186 17.130 -10.784 -1.296 B 186 ? 1.00 58.06  1 
+ATOM   3413 C CB  . ALA B 1 186 17.704 -9.293  1.450  B 186 ? 1.00 44.61  1 
+ATOM   3414 N N   . GLU B 1 187 16.612 -12.187 0.413  B 187 ? 1.00 60.15  1 
+ATOM   3415 C CA  . GLU B 1 187 16.847 -13.418 -0.321 B 187 ? 1.00 60.33  1 
+ATOM   3416 C C   . GLU B 1 187 15.784 -13.607 -1.362 B 187 ? 1.00 66.23  1 
+ATOM   3417 O O   . GLU B 1 187 16.080 -14.055 -2.473 B 187 ? 1.00 68.06  1 
+ATOM   3418 C CB  . GLU B 1 187 16.812 -14.616 0.575  B 187 ? 1.00 61.81  1 
+ATOM   3419 C CG  . GLU B 1 187 18.216 -14.898 1.052  B 187 ? 1.00 67.86  1 
+ATOM   3420 C CD  . GLU B 1 187 18.290 -15.875 2.214  B 187 ? 1.00 73.10  1 
+ATOM   3421 O OE1 . GLU B 1 187 17.588 -16.903 2.226  B 187 ? 1.00 72.53  1 
+ATOM   3422 O OE2 . GLU B 1 187 19.075 -15.565 3.111  B 187 ? 1.00 77.23  1 
+ATOM   3423 N N   . ALA B 1 188 14.542 -13.302 -0.992 B 188 ? 1.00 67.26  1 
+ATOM   3424 C CA  . ALA B 1 188 13.470 -13.341 -1.966 B 188 ? 1.00 74.45  1 
+ATOM   3425 C C   . ALA B 1 188 13.616 -12.206 -2.999 B 188 ? 1.00 76.90  1 
+ATOM   3426 O O   . ALA B 1 188 13.232 -12.374 -4.156 B 188 ? 1.00 82.38  1 
+ATOM   3427 C CB  . ALA B 1 188 12.129 -13.217 -1.243 B 188 ? 1.00 72.36  1 
+ATOM   3428 N N   . GLY B 1 189 14.202 -11.058 -2.628 B 189 ? 1.00 77.17  1 
+ATOM   3429 C CA  . GLY B 1 189 14.364 -9.915  -3.522 B 189 ? 1.00 72.41  1 
+ATOM   3430 C C   . GLY B 1 189 13.493 -8.711  -3.145 B 189 ? 1.00 69.07  1 
+ATOM   3431 O O   . GLY B 1 189 13.538 -7.675  -3.813 B 189 ? 1.00 73.50  1 
+ATOM   3432 N N   . ASN B 1 190 12.734 -8.731  -2.054 B 190 ? 1.00 61.51  1 
+ATOM   3433 C CA  . ASN B 1 190 11.857 -7.621  -1.673 B 190 ? 1.00 70.48  1 
+ATOM   3434 C C   . ASN B 1 190 12.427 -6.494  -0.779 B 190 ? 1.00 74.21  1 
+ATOM   3435 O O   . ASN B 1 190 11.682 -5.679  -0.192 B 190 ? 1.00 70.23  1 
+ATOM   3436 C CB  . ASN B 1 190 10.626 -8.230  -1.010 B 190 ? 1.00 75.90  1 
+ATOM   3437 C CG  . ASN B 1 190 9.830  -9.076  -1.984 B 190 ? 1.00 77.13  1 
+ATOM   3438 O OD1 . ASN B 1 190 10.391 -9.813  -2.800 B 190 ? 1.00 74.64  1 
+ATOM   3439 N ND2 . ASN B 1 190 8.509  -8.997  -1.943 B 190 ? 1.00 80.02  1 
+ATOM   3440 N N   . THR B 1 191 13.768 -6.447  -0.673 B 191 ? 1.00 70.29  1 
+ATOM   3441 C CA  . THR B 1 191 14.517 -5.469  0.095  B 191 ? 1.00 64.41  1 
+ATOM   3442 C C   . THR B 1 191 16.001 -5.700  -0.165 B 191 ? 1.00 66.65  1 
+ATOM   3443 O O   . THR B 1 191 16.378 -6.717  -0.770 B 191 ? 1.00 60.96  1 
+ATOM   3444 C CB  . THR B 1 191 14.198 -5.634  1.584  B 191 ? 1.00 66.21  1 
+ATOM   3445 O OG1 . THR B 1 191 14.298 -4.283  1.981  B 191 ? 1.00 64.16  1 
+ATOM   3446 C CG2 . THR B 1 191 15.057 -6.599  2.433  B 191 ? 1.00 62.97  1 
+ATOM   3447 N N   . LYS B 1 192 16.855 -4.768  0.252  B 192 ? 1.00 70.21  1 
+ATOM   3448 C CA  . LYS B 1 192 18.291 -4.952  0.111  B 192 ? 1.00 72.86  1 
+ATOM   3449 C C   . LYS B 1 192 18.764 -4.923  1.548  B 192 ? 1.00 67.41  1 
+ATOM   3450 O O   . LYS B 1 192 18.313 -4.056  2.304  B 192 ? 1.00 71.61  1 
+ATOM   3451 C CB  . LYS B 1 192 18.900 -3.812  -0.684 B 192 ? 1.00 80.64  1 
+ATOM   3452 C CG  . LYS B 1 192 20.250 -4.146  -1.329 B 192 ? 1.00 88.95  1 
+ATOM   3453 C CD  . LYS B 1 192 20.300 -3.481  -2.721 B 192 ? 1.00 97.79  1 
+ATOM   3454 C CE  . LYS B 1 192 21.563 -3.796  -3.543 B 192 ? 1.00 99.49  1 
+ATOM   3455 N NZ  . LYS B 1 192 21.475 -3.263  -4.900 B 192 ? 1.00 99.52  1 
+ATOM   3456 N N   . TYR B 1 193 19.605 -5.870  1.956  B 193 ? 1.00 59.13  1 
+ATOM   3457 C CA  . TYR B 1 193 20.007 -5.995  3.348  B 193 ? 1.00 51.42  1 
+ATOM   3458 C C   . TYR B 1 193 21.475 -5.674  3.399  B 193 ? 1.00 50.30  1 
+ATOM   3459 O O   . TYR B 1 193 22.225 -6.113  2.528  B 193 ? 1.00 58.56  1 
+ATOM   3460 C CB  . TYR B 1 193 19.789 -7.448  3.901  B 193 ? 1.00 51.95  1 
+ATOM   3461 C CG  . TYR B 1 193 19.830 -7.589  5.443  B 193 ? 1.00 50.77  1 
+ATOM   3462 C CD1 . TYR B 1 193 21.034 -7.723  6.129  B 193 ? 1.00 42.82  1 
+ATOM   3463 C CD2 . TYR B 1 193 18.638 -7.507  6.159  B 193 ? 1.00 43.90  1 
+ATOM   3464 C CE1 . TYR B 1 193 21.019 -7.750  7.509  B 193 ? 1.00 43.54  1 
+ATOM   3465 C CE2 . TYR B 1 193 18.622 -7.541  7.537  B 193 ? 1.00 40.11  1 
+ATOM   3466 C CZ  . TYR B 1 193 19.816 -7.657  8.200  B 193 ? 1.00 42.88  1 
+ATOM   3467 O OH  . TYR B 1 193 19.808 -7.665  9.580  B 193 ? 1.00 40.73  1 
+ATOM   3468 N N   . ALA B 1 194 21.911 -4.909  4.387  B 194 ? 1.00 46.20  1 
+ATOM   3469 C CA  . ALA B 1 194 23.319 -4.659  4.592  B 194 ? 1.00 45.47  1 
+ATOM   3470 C C   . ALA B 1 194 23.613 -4.445  6.074  B 194 ? 1.00 50.71  1 
+ATOM   3471 O O   . ALA B 1 194 22.818 -3.873  6.829  B 194 ? 1.00 54.61  1 
+ATOM   3472 C CB  . ALA B 1 194 23.763 -3.418  3.867  B 194 ? 1.00 48.73  1 
+ATOM   3473 N N   . LYS B 1 195 24.736 -4.965  6.522  B 195 ? 1.00 51.89  1 
+ATOM   3474 C CA  . LYS B 1 195 25.150 -4.813  7.904  B 195 ? 1.00 61.05  1 
+ATOM   3475 C C   . LYS B 1 195 26.296 -3.810  7.979  B 195 ? 1.00 55.55  1 
+ATOM   3476 O O   . LYS B 1 195 27.131 -3.770  7.067  B 195 ? 1.00 67.88  1 
+ATOM   3477 C CB  . LYS B 1 195 25.571 -6.185  8.392  B 195 ? 1.00 64.89  1 
+ATOM   3478 C CG  . LYS B 1 195 26.011 -6.336  9.829  B 195 ? 1.00 67.96  1 
+ATOM   3479 C CD  . LYS B 1 195 26.525 -7.749  9.787  B 195 ? 1.00 75.81  1 
+ATOM   3480 C CE  . LYS B 1 195 27.016 -8.210  11.116 B 195 ? 1.00 77.92  1 
+ATOM   3481 N NZ  . LYS B 1 195 27.672 -9.479  10.905 B 195 ? 1.00 84.89  1 
+ATOM   3482 N N   . VAL B 1 196 26.387 -2.977  9.004  B 196 ? 1.00 48.29  1 
+ATOM   3483 C CA  . VAL B 1 196 27.505 -2.054  9.101  B 196 ? 1.00 46.39  1 
+ATOM   3484 C C   . VAL B 1 196 28.178 -2.349  10.421 B 196 ? 1.00 41.83  1 
+ATOM   3485 O O   . VAL B 1 196 27.534 -2.805  11.368 B 196 ? 1.00 40.02  1 
+ATOM   3486 C CB  . VAL B 1 196 27.062 -0.525  9.050  B 196 ? 1.00 47.76  1 
+ATOM   3487 C CG1 . VAL B 1 196 26.316 -0.307  7.727  B 196 ? 1.00 38.52  1 
+ATOM   3488 C CG2 . VAL B 1 196 26.160 -0.104  10.220 B 196 ? 1.00 45.69  1 
+ATOM   3489 N N   . ASP B 1 197 29.478 -2.141  10.509 B 197 ? 1.00 42.45  1 
+ATOM   3490 C CA  . ASP B 1 197 30.176 -2.289  11.771 B 197 ? 1.00 47.11  1 
+ATOM   3491 C C   . ASP B 1 197 29.876 -1.025  12.567 B 197 ? 1.00 44.78  1 
+ATOM   3492 O O   . ASP B 1 197 30.469 0.031   12.315 B 197 ? 1.00 45.82  1 
+ATOM   3493 C CB  . ASP B 1 197 31.681 -2.416  11.515 B 197 ? 1.00 47.13  1 
+ATOM   3494 C CG  . ASP B 1 197 32.619 -2.512  12.723 B 197 ? 1.00 47.42  1 
+ATOM   3495 O OD1 . ASP B 1 197 32.148 -2.531  13.857 B 197 ? 1.00 42.49  1 
+ATOM   3496 O OD2 . ASP B 1 197 33.829 -2.595  12.509 B 197 ? 1.00 50.76  1 
+ATOM   3497 N N   . GLY B 1 198 28.996 -1.106  13.556 B 198 ? 1.00 38.00  1 
+ATOM   3498 C CA  . GLY B 1 198 28.672 0.058   14.330 B 198 ? 1.00 36.33  1 
+ATOM   3499 C C   . GLY B 1 198 29.810 0.469   15.275 B 198 ? 1.00 44.24  1 
+ATOM   3500 O O   . GLY B 1 198 29.575 1.415   16.029 B 198 ? 1.00 48.83  1 
+ATOM   3501 N N   . THR B 1 199 31.017 -0.141  15.336 B 199 ? 1.00 44.16  1 
+ATOM   3502 C CA  . THR B 1 199 32.052 0.254   16.304 B 199 ? 1.00 48.27  1 
+ATOM   3503 C C   . THR B 1 199 33.026 1.340   15.822 B 199 ? 1.00 48.50  1 
+ATOM   3504 O O   . THR B 1 199 33.764 1.943   16.638 B 199 ? 1.00 46.73  1 
+ATOM   3505 C CB  . THR B 1 199 32.878 -1.002  16.777 B 199 ? 1.00 47.18  1 
+ATOM   3506 O OG1 . THR B 1 199 33.614 -1.522  15.674 B 199 ? 1.00 45.37  1 
+ATOM   3507 C CG2 . THR B 1 199 31.962 -2.090  17.337 B 199 ? 1.00 49.24  1 
+ATOM   3508 N N   . LYS B 1 200 32.955 1.525   14.479 B 200 ? 1.00 45.04  1 
+ATOM   3509 C CA  . LYS B 1 200 33.734 2.494   13.729 B 200 ? 1.00 37.02  1 
+ATOM   3510 C C   . LYS B 1 200 33.315 3.880   14.144 B 200 ? 1.00 41.61  1 
+ATOM   3511 O O   . LYS B 1 200 32.166 4.094   14.548 B 200 ? 1.00 44.98  1 
+ATOM   3512 C CB  . LYS B 1 200 33.494 2.447   12.262 B 200 ? 1.00 38.35  1 
+ATOM   3513 C CG  . LYS B 1 200 34.150 1.348   11.551 B 200 ? 1.00 41.43  1 
+ATOM   3514 C CD  . LYS B 1 200 33.829 1.627   10.119 B 200 ? 1.00 46.23  1 
+ATOM   3515 C CE  . LYS B 1 200 34.381 0.466   9.329  B 200 ? 1.00 48.49  1 
+ATOM   3516 N NZ  . LYS B 1 200 34.303 0.796   7.931  B 200 ? 1.00 52.79  1 
+ATOM   3517 N N   . PRO B 1 201 34.211 4.859   14.019 B 201 ? 1.00 43.75  1 
+ATOM   3518 C CA  . PRO B 1 201 33.901 6.270   14.226 B 201 ? 1.00 43.54  1 
+ATOM   3519 C C   . PRO B 1 201 32.650 6.691   13.485 B 201 ? 1.00 37.46  1 
+ATOM   3520 O O   . PRO B 1 201 32.403 6.261   12.351 B 201 ? 1.00 35.82  1 
+ATOM   3521 C CB  . PRO B 1 201 35.150 6.983   13.766 B 201 ? 1.00 46.15  1 
+ATOM   3522 C CG  . PRO B 1 201 36.205 6.004   14.203 B 201 ? 1.00 44.17  1 
+ATOM   3523 C CD  . PRO B 1 201 35.631 4.672   13.750 B 201 ? 1.00 38.45  1 
+ATOM   3524 N N   . VAL B 1 202 31.894 7.575   14.131 B 202 ? 1.00 39.22  1 
+ATOM   3525 C CA  . VAL B 1 202 30.613 8.034   13.612 B 202 ? 1.00 40.34  1 
+ATOM   3526 C C   . VAL B 1 202 30.708 8.446   12.143 B 202 ? 1.00 42.18  1 
+ATOM   3527 O O   . VAL B 1 202 29.909 8.016   11.304 B 202 ? 1.00 48.53  1 
+ATOM   3528 C CB  . VAL B 1 202 30.136 9.183   14.530 B 202 ? 1.00 37.09  1 
+ATOM   3529 C CG1 . VAL B 1 202 28.956 9.914   13.900 B 202 ? 1.00 38.08  1 
+ATOM   3530 C CG2 . VAL B 1 202 29.672 8.607   15.867 B 202 ? 1.00 32.16  1 
+ATOM   3531 N N   . ALA B 1 203 31.778 9.168   11.776 B 203 ? 1.00 46.01  1 
+ATOM   3532 C CA  . ALA B 1 203 31.964 9.635   10.406 B 203 ? 1.00 33.87  1 
+ATOM   3533 C C   . ALA B 1 203 32.311 8.511   9.476  B 203 ? 1.00 36.96  1 
+ATOM   3534 O O   . ALA B 1 203 31.962 8.594   8.306  B 203 ? 1.00 47.24  1 
+ATOM   3535 C CB  . ALA B 1 203 33.077 10.643  10.321 B 203 ? 1.00 40.62  1 
+ATOM   3536 N N   . GLU B 1 204 32.954 7.454   9.967  B 204 ? 1.00 33.26  1 
+ATOM   3537 C CA  . GLU B 1 204 33.291 6.328   9.158  B 204 ? 1.00 39.10  1 
+ATOM   3538 C C   . GLU B 1 204 32.050 5.508   8.898  B 204 ? 1.00 45.64  1 
+ATOM   3539 O O   . GLU B 1 204 31.827 5.081   7.758  B 204 ? 1.00 51.75  1 
+ATOM   3540 C CB  . GLU B 1 204 34.346 5.500   9.856  B 204 ? 1.00 53.18  1 
+ATOM   3541 C CG  . GLU B 1 204 35.763 5.912   9.440  B 204 ? 1.00 66.23  1 
+ATOM   3542 C CD  . GLU B 1 204 36.888 5.111   10.100 B 204 ? 1.00 76.78  1 
+ATOM   3543 O OE1 . GLU B 1 204 36.927 3.869   10.030 B 204 ? 1.00 77.38  1 
+ATOM   3544 O OE2 . GLU B 1 204 37.745 5.765   10.698 B 204 ? 1.00 86.08  1 
+ATOM   3545 N N   . VAL B 1 205 31.197 5.318   9.908  B 205 ? 1.00 44.14  1 
+ATOM   3546 C CA  . VAL B 1 205 29.926 4.622   9.719  B 205 ? 1.00 40.70  1 
+ATOM   3547 C C   . VAL B 1 205 29.133 5.491   8.736  B 205 ? 1.00 36.73  1 
+ATOM   3548 O O   . VAL B 1 205 28.571 4.951   7.790  B 205 ? 1.00 37.11  1 
+ATOM   3549 C CB  . VAL B 1 205 29.144 4.474   11.066 B 205 ? 1.00 37.34  1 
+ATOM   3550 C CG1 . VAL B 1 205 27.871 3.668   10.822 B 205 ? 1.00 37.31  1 
+ATOM   3551 C CG2 . VAL B 1 205 29.968 3.717   12.112 B 205 ? 1.00 33.15  1 
+ATOM   3552 N N   . ARG B 1 206 29.131 6.822   8.839  B 206 ? 1.00 33.63  1 
+ATOM   3553 C CA  . ARG B 1 206 28.437 7.674   7.897  B 206 ? 1.00 43.93  1 
+ATOM   3554 C C   . ARG B 1 206 28.896 7.366   6.452  B 206 ? 1.00 45.24  1 
+ATOM   3555 O O   . ARG B 1 206 28.087 7.178   5.536  B 206 ? 1.00 42.62  1 
+ATOM   3556 C CB  . ARG B 1 206 28.711 9.146   8.304  B 206 ? 1.00 50.94  1 
+ATOM   3557 C CG  . ARG B 1 206 28.074 10.180  7.350  B 206 ? 1.00 69.00  1 
+ATOM   3558 C CD  . ARG B 1 206 28.509 11.672  7.368  B 206 ? 1.00 82.22  1 
+ATOM   3559 N NE  . ARG B 1 206 27.921 12.365  6.204  B 206 ? 1.00 99.36  1 
+ATOM   3560 C CZ  . ARG B 1 206 27.967 13.692  5.942  B 206 ? 1.00 104.25 1 
+ATOM   3561 N NH1 . ARG B 1 206 28.593 14.554  6.748  B 206 ? 1.00 107.32 1 
+ATOM   3562 N NH2 . ARG B 1 206 27.366 14.169  4.839  B 206 ? 1.00 104.42 1 
+ATOM   3563 N N   . ALA B 1 207 30.205 7.188   6.278  B 207 ? 1.00 43.83  1 
+ATOM   3564 C CA  . ALA B 1 207 30.781 6.879   4.985  B 207 ? 1.00 46.95  1 
+ATOM   3565 C C   . ALA B 1 207 30.343 5.539   4.444  B 207 ? 1.00 45.84  1 
+ATOM   3566 O O   . ALA B 1 207 30.001 5.461   3.274  B 207 ? 1.00 46.56  1 
+ATOM   3567 C CB  . ALA B 1 207 32.279 6.830   5.047  B 207 ? 1.00 47.27  1 
+ATOM   3568 N N   . ASP B 1 208 30.344 4.480   5.252  B 208 ? 1.00 46.78  1 
+ATOM   3569 C CA  . ASP B 1 208 29.902 3.156   4.816  B 208 ? 1.00 50.67  1 
+ATOM   3570 C C   . ASP B 1 208 28.443 3.200   4.412  B 208 ? 1.00 51.20  1 
+ATOM   3571 O O   . ASP B 1 208 27.995 2.522   3.488  B 208 ? 1.00 53.49  1 
+ATOM   3572 C CB  . ASP B 1 208 29.959 2.082   5.899  B 208 ? 1.00 53.42  1 
+ATOM   3573 C CG  . ASP B 1 208 31.260 1.885   6.654  B 208 ? 1.00 60.20  1 
+ATOM   3574 O OD1 . ASP B 1 208 32.312 1.857   6.020  B 208 ? 1.00 63.21  1 
+ATOM   3575 O OD2 . ASP B 1 208 31.217 1.748   7.880  B 208 ? 1.00 69.30  1 
+ATOM   3576 N N   . LEU B 1 209 27.694 3.992   5.161  B 209 ? 1.00 47.37  1 
+ATOM   3577 C CA  . LEU B 1 209 26.288 4.114   4.933  B 209 ? 1.00 47.53  1 
+ATOM   3578 C C   . LEU B 1 209 26.049 4.822   3.657  B 209 ? 1.00 47.99  1 
+ATOM   3579 O O   . LEU B 1 209 25.261 4.318   2.867  B 209 ? 1.00 52.26  1 
+ATOM   3580 C CB  . LEU B 1 209 25.613 4.894   6.012  B 209 ? 1.00 49.50  1 
+ATOM   3581 C CG  . LEU B 1 209 25.268 4.068   7.202  B 209 ? 1.00 46.22  1 
+ATOM   3582 C CD1 . LEU B 1 209 24.648 4.994   8.221  B 209 ? 1.00 48.83  1 
+ATOM   3583 C CD2 . LEU B 1 209 24.327 2.937   6.815  B 209 ? 1.00 43.54  1 
+ATOM   3584 N N   . GLU B 1 210 26.761 5.929   3.463  B 210 ? 1.00 51.95  1 
+ATOM   3585 C CA  . GLU B 1 210 26.684 6.680   2.232  B 210 ? 1.00 58.59  1 
+ATOM   3586 C C   . GLU B 1 210 27.003 5.725   1.076  B 210 ? 1.00 66.91  1 
+ATOM   3587 O O   . GLU B 1 210 26.240 5.674   0.106  B 210 ? 1.00 69.90  1 
+ATOM   3588 C CB  . GLU B 1 210 27.670 7.820   2.326  B 210 ? 1.00 62.46  1 
+ATOM   3589 C CG  . GLU B 1 210 26.938 9.124   2.095  B 210 ? 1.00 68.16  1 
+ATOM   3590 C CD  . GLU B 1 210 27.760 10.383  2.306  B 210 ? 1.00 72.92  1 
+ATOM   3591 O OE1 . GLU B 1 210 28.160 10.690  3.426  B 210 ? 1.00 75.42  1 
+ATOM   3592 O OE2 . GLU B 1 210 27.993 11.077  1.327  B 210 ? 1.00 82.20  1 
+ATOM   3593 N N   . LYS B 1 211 28.035 4.863   1.200  B 211 ? 1.00 70.99  1 
+ATOM   3594 C CA  . LYS B 1 211 28.363 3.832   0.200  B 211 ? 1.00 72.23  1 
+ATOM   3595 C C   . LYS B 1 211 27.245 2.866   -0.160 B 211 ? 1.00 65.61  1 
+ATOM   3596 O O   . LYS B 1 211 27.123 2.452   -1.311 B 211 ? 1.00 63.49  1 
+ATOM   3597 C CB  . LYS B 1 211 29.542 2.949   0.631  B 211 ? 1.00 78.16  1 
+ATOM   3598 C CG  . LYS B 1 211 30.865 3.601   0.328  B 211 ? 1.00 89.99  1 
+ATOM   3599 C CD  . LYS B 1 211 31.986 2.898   1.057  B 211 ? 1.00 100.42 1 
+ATOM   3600 C CE  . LYS B 1 211 33.189 3.836   1.020  B 211 ? 1.00 110.36 1 
+ATOM   3601 N NZ  . LYS B 1 211 34.131 3.549   2.092  B 211 ? 1.00 119.63 1 
+ATOM   3602 N N   . ILE B 1 212 26.432 2.465   0.807  B 212 ? 1.00 61.38  1 
+ATOM   3603 C CA  . ILE B 1 212 25.357 1.553   0.525  B 212 ? 1.00 55.20  1 
+ATOM   3604 C C   . ILE B 1 212 24.174 2.273   -0.092 B 212 ? 1.00 54.42  1 
+ATOM   3605 O O   . ILE B 1 212 23.385 1.622   -0.779 B 212 ? 1.00 61.03  1 
+ATOM   3606 C CB  . ILE B 1 212 25.037 0.858   1.846  B 212 ? 1.00 51.74  1 
+ATOM   3607 C CG1 . ILE B 1 212 26.216 -0.034  2.178  B 212 ? 1.00 54.21  1 
+ATOM   3608 C CG2 . ILE B 1 212 23.793 0.014   1.764  B 212 ? 1.00 48.78  1 
+ATOM   3609 C CD1 . ILE B 1 212 26.365 -0.365  3.677  B 212 ? 1.00 61.40  1 
+ATOM   3610 N N   . LEU B 1 213 23.973 3.574   0.049  B 213 ? 1.00 51.82  1 
+ATOM   3611 C CA  . LEU B 1 213 22.748 4.118   -0.514 B 213 ? 1.00 63.92  1 
+ATOM   3612 C C   . LEU B 1 213 22.827 4.814   -1.894 B 213 ? 1.00 73.67  1 
+ATOM   3613 O O   . LEU B 1 213 22.087 4.433   -2.815 B 213 ? 1.00 74.46  1 
+ATOM   3614 C CB  . LEU B 1 213 22.166 5.010   0.596  B 213 ? 1.00 59.88  1 
+ATOM   3615 C CG  . LEU B 1 213 21.938 4.358   1.991  B 213 ? 1.00 52.75  1 
+ATOM   3616 C CD1 . LEU B 1 213 21.434 5.431   2.933  B 213 ? 1.00 54.79  1 
+ATOM   3617 C CD2 . LEU B 1 213 20.923 3.223   1.949  B 213 ? 1.00 44.34  1 
+ATOM   3618 N N   . GLY B 1 214 23.691 5.789   -2.152 B 214 ? 1.00 80.17  1 
+ATOM   3619 C CA  . GLY B 1 214 23.754 6.450   -3.450 B 214 ? 1.00 88.01  1 
+ATOM   3620 C C   . GLY B 1 214 24.173 7.911   -3.276 B 214 ? 1.00 94.23  1 
+ATOM   3621 O O   . GLY B 1 214 24.730 8.496   -4.208 B 214 ? 1.00 94.94  1 
+ATOM   3622 O OXT . GLY B 1 214 23.962 8.474   -2.196 B 214 ? 1.00 95.71  1 
+HETATM 3623 P PA  . AP5 D 2 .   22.201 6.089   19.452 B 215 ? 1.00 37.30  1 
+HETATM 3624 O O1A . AP5 D 2 .   22.416 6.745   18.144 B 215 ? 1.00 32.10  1 
+HETATM 3625 O O2A . AP5 D 2 .   21.476 6.864   20.478 B 215 ? 1.00 33.29  1 
+HETATM 3626 O O3A . AP5 D 2 .   21.770 4.549   19.290 B 215 ? 1.00 30.65  1 
+HETATM 3627 P PB  . AP5 D 2 .   20.344 3.896   18.917 B 215 ? 1.00 31.29  1 
+HETATM 3628 O O1B . AP5 D 2 .   20.857 2.643   18.377 B 215 ? 1.00 33.55  1 
+HETATM 3629 O O2B . AP5 D 2 .   19.561 4.700   17.951 B 215 ? 1.00 44.91  1 
+HETATM 3630 O O3B . AP5 D 2 .   19.580 3.556   20.304 B 215 ? 1.00 43.60  1 
+HETATM 3631 P PG  . AP5 D 2 .   17.985 3.557   20.606 B 215 ? 1.00 45.69  1 
+HETATM 3632 O O1G . AP5 D 2 .   17.476 4.926   20.866 B 215 ? 1.00 43.69  1 
+HETATM 3633 O O2G . AP5 D 2 .   17.289 2.760   19.558 B 215 ? 1.00 55.55  1 
+HETATM 3634 O O3G . AP5 D 2 .   18.082 2.680   21.967 B 215 ? 1.00 58.11  1 
+HETATM 3635 P PD  . AP5 D 2 .   16.945 2.326   23.101 B 215 ? 1.00 63.48  1 
+HETATM 3636 O O1D . AP5 D 2 .   16.975 0.838   23.248 B 215 ? 1.00 48.98  1 
+HETATM 3637 O O2D . AP5 D 2 .   17.317 3.050   24.336 B 215 ? 1.00 60.31  1 
+HETATM 3638 O O3D . AP5 D 2 .   15.397 2.495   22.602 B 215 ? 1.00 62.90  1 
+HETATM 3639 P PE  . AP5 D 2 .   14.541 3.700   21.938 B 215 ? 1.00 54.65  1 
+HETATM 3640 O O1E . AP5 D 2 .   14.837 5.089   22.338 B 215 ? 1.00 72.00  1 
+HETATM 3641 O O2E . AP5 D 2 .   14.021 3.514   20.557 B 215 ? 1.00 43.23  1 
+HETATM 3642 O O5F . AP5 D 2 .   23.694 5.984   20.010 B 215 ? 1.00 31.76  1 
+HETATM 3643 C C5F . AP5 D 2 .   23.863 5.533   21.343 B 215 ? 1.00 30.61  1 
+HETATM 3644 C C4F . AP5 D 2 .   24.868 6.417   22.062 B 215 ? 1.00 35.15  1 
+HETATM 3645 O O4F . AP5 D 2 .   26.197 6.203   21.583 B 215 ? 1.00 39.02  1 
+HETATM 3646 C C3F . AP5 D 2 .   24.677 7.945   21.924 B 215 ? 1.00 31.89  1 
+HETATM 3647 O O3F . AP5 D 2 .   25.346 8.532   23.016 B 215 ? 1.00 31.03  1 
+HETATM 3648 C C2F . AP5 D 2 .   25.443 8.295   20.628 B 215 ? 1.00 36.27  1 
+HETATM 3649 O O2F . AP5 D 2 .   26.145 9.548   20.716 B 215 ? 1.00 33.15  1 
+HETATM 3650 C C1F . AP5 D 2 .   26.421 7.150   20.562 B 215 ? 1.00 38.30  1 
+HETATM 3651 N N9A . AP5 D 2 .   27.112 6.824   19.345 B 215 ? 1.00 34.90  1 
+HETATM 3652 C C8A . AP5 D 2 .   26.489 6.695   18.135 B 215 ? 1.00 29.88  1 
+HETATM 3653 N N7A . AP5 D 2 .   27.295 6.275   17.223 B 215 ? 1.00 29.22  1 
+HETATM 3654 C C5A . AP5 D 2 .   28.529 6.124   17.797 B 215 ? 1.00 35.00  1 
+HETATM 3655 C C6A . AP5 D 2 .   29.735 5.649   17.285 B 215 ? 1.00 40.51  1 
+HETATM 3656 N N6A . AP5 D 2 .   29.771 5.190   16.024 B 215 ? 1.00 36.93  1 
+HETATM 3657 N N1A . AP5 D 2 .   30.793 5.669   18.130 B 215 ? 1.00 42.32  1 
+HETATM 3658 C C2A . AP5 D 2 .   30.595 6.010   19.414 B 215 ? 1.00 34.63  1 
+HETATM 3659 N N3A . AP5 D 2 .   29.508 6.464   20.023 B 215 ? 1.00 36.24  1 
+HETATM 3660 C C4A . AP5 D 2 .   28.440 6.487   19.168 B 215 ? 1.00 33.97  1 
+HETATM 3661 O O5J . AP5 D 2 .   13.178 3.399   22.744 B 215 ? 1.00 56.44  1 
+HETATM 3662 C C5J . AP5 D 2 .   13.096 3.370   24.177 B 215 ? 1.00 45.38  1 
+HETATM 3663 C C4J . AP5 D 2 .   11.797 2.648   24.646 B 215 ? 1.00 39.49  1 
+HETATM 3664 O O4J . AP5 D 2 .   10.642 3.052   23.872 B 215 ? 1.00 38.58  1 
+HETATM 3665 C C3J . AP5 D 2 .   11.850 1.118   24.442 B 215 ? 1.00 38.37  1 
+HETATM 3666 O O3J . AP5 D 2 .   12.535 0.450   25.490 B 215 ? 1.00 35.76  1 
+HETATM 3667 C C2J . AP5 D 2 .   10.402 0.698   24.318 B 215 ? 1.00 34.32  1 
+HETATM 3668 O O2J . AP5 D 2 .   9.706  0.889   25.519 B 215 ? 1.00 36.76  1 
+HETATM 3669 C C1J . AP5 D 2 .   10.066 1.830   23.414 B 215 ? 1.00 35.78  1 
+HETATM 3670 N N9B . AP5 D 2 .   9.747  1.616   22.023 B 215 ? 1.00 36.11  1 
+HETATM 3671 C C8B . AP5 D 2 .   10.182 2.374   20.967 B 215 ? 1.00 34.84  1 
+HETATM 3672 N N7B . AP5 D 2 .   9.821  1.888   19.815 B 215 ? 1.00 38.30  1 
+HETATM 3673 C C5B . AP5 D 2 .   9.099  0.730   20.087 B 215 ? 1.00 37.03  1 
+HETATM 3674 C C6B . AP5 D 2 .   8.487  -0.225  19.272 B 215 ? 1.00 36.27  1 
+HETATM 3675 N N6B . AP5 D 2 .   8.669  -0.222  17.956 B 215 ? 1.00 35.20  1 
+HETATM 3676 N N1B . AP5 D 2 .   7.799  -1.199  19.879 B 215 ? 1.00 41.59  1 
+HETATM 3677 C C2B . AP5 D 2 .   7.763  -1.199  21.208 B 215 ? 1.00 40.84  1 
+HETATM 3678 N N3B . AP5 D 2 .   8.373  -0.426  22.108 B 215 ? 1.00 36.71  1 
+HETATM 3679 C C4B . AP5 D 2 .   9.034  0.571   21.499 B 215 ? 1.00 30.89  1 
+HETATM 3680 O O   . HOH F 3 .   27.600 25.972  30.626 B 532 ? 1.00 79.23  1 
+HETATM 3681 O O   . HOH F 3 .   17.974 30.572  30.201 B 533 ? 1.00 91.93  1 
+HETATM 3682 O O   . HOH F 3 .   14.262 -4.102  21.572 B 601 ? 1.00 29.20  1 
+HETATM 3683 O O   . HOH F 3 .   14.508 -3.401  24.138 B 602 ? 1.00 44.68  1 
+HETATM 3684 O O   . HOH F 3 .   12.809 2.042   27.522 B 603 ? 1.00 48.81  1 
+HETATM 3685 O O   . HOH F 3 .   25.424 10.836  18.328 B 604 ? 1.00 26.42  1 
+HETATM 3686 O O   . HOH F 3 .   27.080 5.928   14.673 B 605 ? 1.00 29.83  1 
+HETATM 3687 O O   . HOH F 3 .   27.155 3.168   14.978 B 606 ? 1.00 33.75  1 
+HETATM 3688 O O   . HOH F 3 .   13.146 4.311   18.331 B 607 ? 1.00 61.95  1 
+HETATM 3689 O O   . HOH F 3 .   9.283  -10.922 17.996 B 608 ? 1.00 40.47  1 
+HETATM 3690 O O   . HOH F 3 .   23.684 -6.770  15.000 B 609 ? 1.00 52.05  1 
+HETATM 3691 O O   . HOH F 3 .   27.294 22.690  20.713 B 610 ? 1.00 22.54  1 
+HETATM 3692 O O   . HOH F 3 .   14.038 -1.934  14.863 B 611 ? 1.00 36.23  1 
+HETATM 3693 O O   . HOH F 3 .   30.865 -1.257  8.032  B 612 ? 1.00 42.48  1 
+HETATM 3694 O O   . HOH F 3 .   23.300 -4.486  16.874 B 613 ? 1.00 50.62  1 
+HETATM 3695 O O   . HOH F 3 .   36.194 -0.357  15.183 B 614 ? 1.00 40.67  1 
+HETATM 3696 O O   . HOH F 3 .   8.078  -6.158  6.927  B 615 ? 1.00 41.50  1 
+HETATM 3697 O O   . HOH F 3 .   14.938 7.129   18.969 B 616 ? 1.00 43.71  1 
+HETATM 3698 O O   . HOH F 3 .   12.624 7.473   28.626 B 617 ? 1.00 53.66  1 
+HETATM 3699 O O   . HOH F 3 .   5.822  -5.075  21.277 B 618 ? 1.00 40.77  1 
+HETATM 3700 O O   . HOH F 3 .   5.656  -8.926  20.631 B 619 ? 1.00 40.57  1 
+HETATM 3701 O O   . HOH F 3 .   18.812 7.475   20.270 B 620 ? 1.00 43.71  1 
+HETATM 3702 O O   . HOH F 3 .   27.161 -3.197  28.023 B 621 ? 1.00 43.36  1 
+HETATM 3703 O O   . HOH F 3 .   16.306 -2.364  18.273 B 622 ? 1.00 56.48  1 
+HETATM 3704 O O   . HOH F 3 .   26.262 -6.933  4.576  B 623 ? 1.00 62.51  1 
+HETATM 3705 O O   . HOH F 3 .   27.732 17.512  27.265 B 624 ? 1.00 39.28  1 
+HETATM 3706 O O   . HOH F 3 .   16.075 -3.508  15.805 B 625 ? 1.00 53.75  1 
+HETATM 3707 O O   . HOH F 3 .   24.777 14.775  17.003 B 626 ? 1.00 65.65  1 
+HETATM 3708 O O   . HOH F 3 .   11.433 13.919  26.646 B 627 ? 1.00 52.58  1 
+HETATM 3709 O O   . HOH F 3 .   21.935 -8.276  16.655 B 628 ? 1.00 64.77  1 
+HETATM 3710 O O   . HOH F 3 .   12.653 -2.910  25.978 B 629 ? 1.00 41.70  1 
+HETATM 3711 O O   . HOH F 3 .   10.547 13.281  22.576 B 630 ? 1.00 47.66  1 
+HETATM 3712 O O   . HOH F 3 .   29.546 -0.764  28.431 B 631 ? 1.00 49.67  1 
+HETATM 3713 O O   . HOH F 3 .   10.057 10.512  14.629 B 632 ? 1.00 68.20  1 
+HETATM 3714 O O   . HOH F 3 .   31.004 -6.079  12.407 B 633 ? 1.00 63.45  1 
+HETATM 3715 O O   . HOH F 3 .   32.468 23.483  25.572 B 634 ? 1.00 61.99  1 
+HETATM 3716 O O   . HOH F 3 .   16.481 11.283  21.359 B 635 ? 1.00 44.47  1 
+HETATM 3717 O O   . HOH F 3 .   9.027  11.838  28.200 B 636 ? 1.00 48.83  1 
+HETATM 3718 O O   . HOH F 3 .   30.543 16.996  26.794 B 637 ? 1.00 50.07  1 
+HETATM 3719 O O   . HOH F 3 .   -2.574 -3.060  14.718 B 638 ? 1.00 62.64  1 
+HETATM 3720 O O   . HOH F 3 .   14.859 14.032  27.367 B 639 ? 1.00 54.32  1 
+HETATM 3721 O O   . HOH F 3 .   13.655 0.649   12.731 B 640 ? 1.00 68.16  1 
+HETATM 3722 O O   . HOH F 3 .   18.067 9.039   22.417 B 641 ? 1.00 44.96  1 
+HETATM 3723 O O   . HOH F 3 .   26.493 15.961  31.982 B 642 ? 1.00 57.56  1 
+HETATM 3724 O O   . HOH F 3 .   3.860  11.813  19.839 B 643 ? 1.00 53.65  1 
+HETATM 3725 O O   . HOH F 3 .   1.192  0.670   31.965 B 644 ? 1.00 61.41  1 
+HETATM 3726 O O   . HOH F 3 .   13.301 12.513  22.066 B 645 ? 1.00 38.82  1 
+HETATM 3727 O O   . HOH F 3 .   7.241  0.734   35.037 B 646 ? 1.00 68.91  1 
+HETATM 3728 O O   . HOH F 3 .   -3.144 -0.652  16.183 B 647 ? 1.00 35.82  1 
+HETATM 3729 O O   . HOH F 3 .   14.823 21.679  17.608 B 648 ? 1.00 59.60  1 
+HETATM 3730 O O   . HOH F 3 .   26.485 -8.797  21.103 B 649 ? 1.00 79.23  1 
+HETATM 3731 O O   . HOH F 3 .   5.979  16.827  22.814 B 650 ? 1.00 56.88  1 
+HETATM 3732 O O   . HOH F 3 .   26.273 12.843  15.518 B 651 ? 1.00 50.62  1 
+HETATM 3733 O O   . HOH F 3 .   28.605 17.145  9.953  B 652 ? 1.00 70.21  1 
+HETATM 3734 O O   . HOH F 3 .   16.783 -6.342  14.912 B 653 ? 1.00 70.08  1 
+HETATM 3735 O O   . HOH F 3 .   -0.379 13.042  1.442  B 654 ? 1.00 60.69  1 
+HETATM 3736 O O   . HOH F 3 .   16.741 0.350   19.669 B 655 ? 1.00 42.77  1 
+HETATM 3737 O O   . HOH F 3 .   24.251 -9.881  9.498  B 656 ? 1.00 41.98  1 
+HETATM 3738 O O   . HOH F 3 .   11.420 13.205  17.112 B 657 ? 1.00 54.84  1 
+HETATM 3739 O O   . HOH F 3 .   0.156  1.470   29.588 B 658 ? 1.00 34.07  1 
+HETATM 3740 O O   . HOH F 3 .   0.068  -8.426  19.940 B 659 ? 1.00 52.11  1 
+HETATM 3741 O O   . HOH F 3 .   -5.777 4.897   27.627 B 660 ? 1.00 36.48  1 
+HETATM 3742 O O   . HOH F 3 .   18.421 26.044  26.361 B 661 ? 1.00 45.14  1 
+HETATM 3743 O O   . HOH F 3 .   1.451  14.197  19.730 B 662 ? 1.00 62.26  1 
+HETATM 3744 O O   . HOH F 3 .   33.486 19.697  22.158 B 663 ? 1.00 54.81  1 
+HETATM 3745 O O   . HOH F 3 .   16.604 18.860  25.124 B 664 ? 1.00 41.75  1 
+HETATM 3746 O O   . HOH F 3 .   23.409 27.189  31.356 B 665 ? 1.00 49.04  1 
+HETATM 3747 O O   . HOH F 3 .   33.433 5.012   19.162 B 666 ? 1.00 64.69  1 
+HETATM 3748 O O   . HOH F 3 .   24.702 -10.861 22.043 B 667 ? 1.00 52.32  1 
+HETATM 3749 O O   . HOH F 3 .   18.202 29.291  18.618 B 668 ? 1.00 42.27  1 
+HETATM 3750 O O   . HOH F 3 .   24.806 26.086  14.054 B 669 ? 1.00 53.35  1 
+HETATM 3751 O O   . HOH F 3 .   3.413  2.498   37.269 B 670 ? 1.00 81.37  1 
+HETATM 3752 O O   . HOH F 3 .   -3.637 0.822   13.866 B 671 ? 1.00 40.98  1 
+HETATM 3753 O O   . HOH F 3 .   34.054 9.850   13.628 B 672 ? 1.00 62.62  1 
+HETATM 3754 O O   . HOH F 3 .   0.636  19.313  27.366 B 673 ? 1.00 95.62  1 
+HETATM 3755 O O   . HOH F 3 .   2.008  10.222  2.938  B 674 ? 1.00 48.67  1 
+HETATM 3756 O O   . HOH F 3 .   24.219 -7.060  20.238 B 675 ? 1.00 45.06  1 
+HETATM 3757 O O   . HOH F 3 .   22.044 28.201  29.205 B 676 ? 1.00 47.66  1 
+HETATM 3758 O O   . HOH F 3 .   20.948 -7.852  -0.325 B 677 ? 1.00 48.16  1 
+HETATM 3759 O O   . HOH F 3 .   5.720  16.059  0.775  B 678 ? 1.00 79.93  1 
+HETATM 3760 O O   . HOH F 3 .   -7.668 9.530   28.979 B 679 ? 1.00 57.70  1 
+HETATM 3761 O O   . HOH F 3 .   15.305 -1.481  -5.343 B 680 ? 1.00 63.31  1 
+HETATM 3762 O O   . HOH F 3 .   6.179  -12.703 0.598  B 681 ? 1.00 62.32  1 
+HETATM 3763 O O   . HOH F 3 .   14.527 13.865  29.996 B 682 ? 1.00 63.43  1 
+HETATM 3764 O O   . HOH F 3 .   30.980 1.856   25.286 B 683 ? 1.00 42.16  1 
+HETATM 3765 O O   . HOH F 3 .   20.040 10.695  27.163 B 684 ? 1.00 42.75  1 
+HETATM 3766 O O   . HOH F 3 .   16.245 -2.027  21.032 B 685 ? 1.00 53.14  1 
+HETATM 3767 O O   . HOH F 3 .   6.857  12.812  34.962 B 686 ? 1.00 66.68  1 
+HETATM 3768 O O   . HOH F 3 .   0.721  -8.017  12.167 B 687 ? 1.00 64.25  1 
+HETATM 3769 O O   . HOH F 3 .   23.427 -6.208  38.643 B 688 ? 1.00 83.39  1 
+HETATM 3770 O O   . HOH F 3 .   33.202 9.472   16.354 B 689 ? 1.00 49.00  1 
+HETATM 3771 O O   . HOH F 3 .   14.673 -17.530 0.817  B 690 ? 1.00 58.58  1 
+HETATM 3772 O O   . HOH F 3 .   -3.896 -1.428  8.614  B 691 ? 1.00 98.40  1 
+HETATM 3773 O O   . HOH F 3 .   29.993 13.720  9.810  B 692 ? 1.00 73.33  1 
+HETATM 3774 O O   . HOH F 3 .   19.071 15.842  32.800 B 693 ? 1.00 78.67  1 
+HETATM 3775 O O   . HOH F 3 .   32.008 19.405  24.569 B 694 ? 1.00 63.58  1 
+HETATM 3776 O O   . HOH F 3 .   5.560  -13.800 16.544 B 695 ? 1.00 93.11  1 
+HETATM 3777 O O   . HOH F 3 .   -1.792 -5.424  11.954 B 696 ? 1.00 59.42  1 
+HETATM 3778 O O   . HOH F 3 .   10.148 7.509   29.811 B 697 ? 1.00 66.17  1 
+HETATM 3779 O O   . HOH F 3 .   14.310 12.573  24.883 B 698 ? 1.00 56.18  1 
+HETATM 3780 O O   . HOH F 3 .   6.123  -0.872  33.139 B 699 ? 1.00 55.86  1 
+HETATM 3781 O O   . HOH F 3 .   28.749 24.817  28.172 B 700 ? 1.00 53.60  1 
+HETATM 3782 O O   . HOH F 3 .   18.400 9.388   33.137 B 701 ? 1.00 47.18  1 
+HETATM 3783 O O   . HOH F 3 .   35.070 7.944   19.914 B 702 ? 1.00 56.91  1 
+HETATM 3784 O O   . HOH F 3 .   24.752 11.075  -3.179 B 703 ? 1.00 67.32  1 
+HETATM 3785 O O   . HOH F 3 .   9.949  -9.523  -5.593 B 704 ? 1.00 89.09  1 
+HETATM 3786 O O   . HOH F 3 .   9.942  19.330  23.088 B 705 ? 1.00 64.17  1 
+HETATM 3787 O O   . HOH F 3 .   13.726 19.246  26.405 B 706 ? 1.00 49.09  1 
+HETATM 3788 O O   . HOH F 3 .   31.961 13.776  7.446  B 707 ? 1.00 73.55  1 
+HETATM 3789 O O   . HOH F 3 .   -0.822 10.816  18.021 B 708 ? 1.00 95.39  1 
+HETATM 3790 O O   . HOH F 3 .   13.000 -3.184  -4.148 B 709 ? 1.00 76.83  1 
+HETATM 3791 O O   . HOH F 3 .   14.202 16.495  4.958  B 710 ? 1.00 76.08  1 
+HETATM 3792 O O   . HOH F 3 .   -1.174 -5.432  20.724 B 711 ? 1.00 67.54  1 
+HETATM 3793 O O   . HOH F 3 .   3.128  11.513  32.191 B 712 ? 1.00 70.79  1 
+HETATM 3794 O O   . HOH F 3 .   16.282 22.447  26.712 B 713 ? 1.00 76.08  1 
+HETATM 3795 O O   . HOH F 3 .   18.971 28.066  29.665 B 714 ? 1.00 89.64  1 
+HETATM 3796 O O   . HOH F 3 .   26.365 2.181   34.042 B 715 ? 1.00 51.61  1 
+HETATM 3797 O O   . HOH F 3 .   23.727 3.680   35.684 B 716 ? 1.00 70.58  1 
+HETATM 3798 O O   . HOH F 3 .   23.151 -12.467 24.419 B 717 ? 1.00 79.25  1 
+HETATM 3799 O O   . HOH F 3 .   20.135 -10.789 -1.732 B 718 ? 1.00 56.50  1 
+HETATM 3800 O O   . HOH F 3 .   6.636  6.283   -0.077 B 719 ? 1.00 48.04  1 
+HETATM 3801 O O   . HOH F 3 .   32.218 10.973  5.537  B 720 ? 1.00 62.14  1 
+HETATM 3802 O O   . HOH F 3 .   22.443 27.117  12.621 B 721 ? 1.00 80.07  1 
+HETATM 3803 O O   . HOH F 3 .   26.616 18.010  15.049 B 722 ? 1.00 85.62  1 
+HETATM 3804 O O   . HOH F 3 .   23.710 17.075  16.032 B 723 ? 1.00 77.45  1 
+HETATM 3805 O O   . HOH F 3 .   11.615 23.280  22.798 B 724 ? 1.00 67.20  1 
+HETATM 3806 O O   . HOH F 3 .   34.939 14.336  27.553 B 725 ? 1.00 51.15  1 
+HETATM 3807 O O   . HOH F 3 .   11.124 -3.299  -2.129 B 726 ? 1.00 72.53  1 
+HETATM 3808 O O   . HOH F 3 .   20.985 -10.100 27.399 B 727 ? 1.00 57.72  1 
+HETATM 3809 O O   . HOH F 3 .   8.250  10.481  35.969 B 728 ? 1.00 76.62  1 
+HETATM 3810 O O   . HOH F 3 .   14.948 -4.898  -3.489 B 729 ? 1.00 58.26  1 
+HETATM 3811 O O   . HOH F 3 .   34.776 4.217   5.146  B 730 ? 1.00 62.26  1 
+HETATM 3812 O O   . HOH F 3 .   16.727 -16.699 -3.703 B 731 ? 1.00 61.27  1 
+HETATM 3813 O O   . HOH F 3 .   1.429  8.800   0.402  B 732 ? 1.00 77.69  1 
+HETATM 3814 O O   . HOH F 3 .   24.241 12.734  13.411 B 733 ? 1.00 67.64  1 
+HETATM 3815 O O   . HOH F 3 .   24.591 -9.996  12.367 B 734 ? 1.00 68.65  1 
+HETATM 3816 O O   . HOH F 3 .   34.364 -6.362  12.342 B 735 ? 1.00 70.58  1 
+#
+loop_
+_struct_conf.id
+_struct_conf.conf_type_id
+_struct_conf.beg_label_comp_id
+_struct_conf.beg_label_asym_id
+_struct_conf.beg_label_seq_id
+_struct_conf.end_label_comp_id
+_struct_conf.end_label_asym_id
+_struct_conf.end_label_seq_id
+_struct_conf.beg_auth_asym_id
+_struct_conf.beg_auth_seq_id
+_struct_conf.pdbx_beg_PDB_ins_code
+_struct_conf.end_auth_asym_id
+_struct_conf.end_auth_seq_id
+_struct_conf.pdbx_end_PDB_ins_code
+HELX1  HELX_P GLY A 12  GLY A 25  A 12  ? A 25  ? 
+HELX2  HELX_P SER A 30  GLY A 42  A 30  ? A 42  ? 
+HELX3  HELX_P ALA A 49  GLY A 56  A 49  ? A 56  ? 
+HELX4  HELX_P THR A 60  ALA A 73  A 60  ? A 73  ? 
+HELX5  HELX_P THR A 89  ALA A 99  A 89  ? A 99  ? 
+HELX6  HELX_P LEU A 115 VAL A 121 A 115 ? A 121 ? 
+HELX7  HELX_P GLN A 160 THR A 175 A 160 ? A 175 ? 
+HELX8  HELX_P PRO A 177 ALA A 188 A 177 ? A 188 ? 
+HELX9  HELX_P PRO A 201 GLY A 214 A 201 ? A 214 ? 
+HELX10 HELX_P GLY B 12  GLY B 25  B 12  ? B 25  ? 
+HELX11 HELX_P SER B 30  GLY B 42  B 30  ? B 42  ? 
+HELX12 HELX_P ALA B 49  GLY B 56  B 49  ? B 56  ? 
+HELX13 HELX_P THR B 60  ALA B 73  B 60  ? B 73  ? 
+HELX14 HELX_P THR B 89  ALA B 99  B 89  ? B 99  ? 
+HELX15 HELX_P ILE B 116 VAL B 121 B 116 ? B 121 ? 
+HELX16 HELX_P GLN B 160 THR B 175 B 160 ? B 175 ? 
+HELX17 HELX_P PRO B 177 GLY B 189 B 177 ? B 189 ? 
+HELX18 HELX_P PRO B 201 GLY B 214 B 201 ? B 214 ? 
+#
+_struct_conf_type.id HELX_P
+#
+loop_
+_struct_sheet_range.sheet_id
+_struct_sheet_range.id
+_struct_sheet_range.beg_label_comp_id
+_struct_sheet_range.beg_label_asym_id
+_struct_sheet_range.beg_label_seq_id
+_struct_sheet_range.end_label_comp_id
+_struct_sheet_range.end_label_asym_id
+_struct_sheet_range.end_label_seq_id
+_struct_sheet_range.symmetry
+_struct_sheet_range.beg_auth_asym_id
+_struct_sheet_range.beg_auth_seq_id
+_struct_sheet_range.pdbx_beg_PDB_ins_code
+_struct_sheet_range.end_auth_asym_id
+_struct_sheet_range.end_auth_seq_id
+_struct_sheet_range.pdbx_end_PDB_ins_code
+? 1  MET A 1   LEU A 6   1_555 A 1   ? A 6   ? 
+? 2  PRO A 27  ILE A 29  1_555 A 27  ? A 29  ? 
+? 3  PHE A 81  ASP A 84  1_555 A 81  ? A 84  ? 
+? 4  ASP A 104 ASP A 110 1_555 A 104 ? A 110 ? 
+? 5  GLY A 122 HIS A 126 1_555 A 122 ? A 126 ? 
+? 6  ARG A 131 VAL A 135 1_555 A 131 ? A 135 ? 
+? 7  GLY A 144 ASP A 146 1_555 A 144 ? A 146 ? 
+? 8  GLU A 151 THR A 154 1_555 A 151 ? A 154 ? 
+? 9  LYS A 192 GLY A 198 1_555 A 192 ? A 198 ? 
+? 10 MET B 1   LEU B 6   1_555 B 1   ? B 6   ? 
+? 11 PRO B 27  ILE B 29  1_555 B 27  ? B 29  ? 
+? 12 PHE B 81  ASP B 84  1_555 B 81  ? B 84  ? 
+? 13 ASP B 104 ASP B 110 1_555 B 104 ? B 110 ? 
+? 14 GLY B 122 HIS B 126 1_555 B 122 ? B 126 ? 
+? 15 ARG B 131 VAL B 135 1_555 B 131 ? B 135 ? 
+? 16 GLY B 144 ASP B 146 1_555 B 144 ? B 146 ? 
+? 17 GLU B 151 THR B 154 1_555 B 151 ? B 154 ? 
+? 18 LYS B 192 GLY B 198 1_555 B 192 ? B 198 ? 
+#
+_entity_src_gen.entity_id 1
+_entity_src_gen.pdbx_src_id 1
+_entity_src_gen.pdbx_alt_source_flag sample
+_entity_src_gen.pdbx_seq_type ?
+_entity_src_gen.pdbx_beg_seq_num ?
+_entity_src_gen.pdbx_end_seq_num ?
+_entity_src_gen.gene_src_common_name ?
+_entity_src_gen.gene_src_genus Escherichia
+_entity_src_gen.pdbx_gene_src_gene ?
+_entity_src_gen.gene_src_species ?
+_entity_src_gen.gene_src_strain ?
+_entity_src_gen.gene_src_tissue ?
+_entity_src_gen.gene_src_tissue_fraction ?
+_entity_src_gen.gene_src_details ?
+_entity_src_gen.pdbx_gene_src_fragment ?
+_entity_src_gen.pdbx_gene_src_scientific_name "Escherichia coli"
+_entity_src_gen.pdbx_gene_src_ncbi_taxonomy_id 562
+_entity_src_gen.pdbx_gene_src_variant ?
+_entity_src_gen.pdbx_gene_src_cell_line ?
+_entity_src_gen.pdbx_gene_src_atcc ?
+_entity_src_gen.pdbx_gene_src_organ ?
+_entity_src_gen.pdbx_gene_src_organelle ?
+_entity_src_gen.pdbx_gene_src_cell ?
+_entity_src_gen.pdbx_gene_src_cellular_location ?
+_entity_src_gen.host_org_common_name ?
+_entity_src_gen.pdbx_host_org_scientific_name "Escherichia coli"
+_entity_src_gen.pdbx_host_org_ncbi_taxonomy_id 562
+_entity_src_gen.host_org_genus Escherichia
+_entity_src_gen.pdbx_host_org_gene ?
+_entity_src_gen.pdbx_host_org_organ ?
+_entity_src_gen.host_org_species ?
+_entity_src_gen.pdbx_host_org_tissue ?
+_entity_src_gen.pdbx_host_org_tissue_fraction ?
+_entity_src_gen.pdbx_host_org_strain ?
+_entity_src_gen.pdbx_host_org_variant ?
+_entity_src_gen.pdbx_host_org_cell_line ?
+_entity_src_gen.pdbx_host_org_atcc ?
+_entity_src_gen.pdbx_host_org_culture_collection ?
+_entity_src_gen.pdbx_host_org_cell ?
+_entity_src_gen.pdbx_host_org_organelle ?
+_entity_src_gen.pdbx_host_org_cellular_location ?
+_entity_src_gen.pdbx_host_org_vector_type ?
+_entity_src_gen.pdbx_host_org_vector ?
+_entity_src_gen.host_org_details ?
+_entity_src_gen.expression_system_id ?
+_entity_src_gen.plasmid_name ?
+_entity_src_gen.plasmid_details ?
+_entity_src_gen.pdbx_description ?
+#
+_cell.entry_id 1AKE
+_cell.length_a 73.200
+_cell.length_b 79.800
+_cell.length_c 85.000
+_cell.angle_alpha 90.00
+_cell.angle_beta 90.00
+_cell.angle_gamma 90.00
+_cell.Z_PDB 8
+_cell.pdbx_unique_axis ?
+#
+_symmetry.entry_id 1AKE
+_symmetry.space_group_name_H-M "P 21 2 21"
+_symmetry.pdbx_full_space_group_name_H-M ?
+_symmetry.cell_setting ?
+_symmetry.Int_Tables_number 18
+#
+loop_
+_pdbx_struct_assembly.id
+_pdbx_struct_assembly.details
+_pdbx_struct_assembly.method_details
+_pdbx_struct_assembly.oligomeric_details
+_pdbx_struct_assembly.oligomeric_count
+1 author_defined_assembly ? monomeric 1 
+2 author_defined_assembly ? monomeric 1 
+#
+loop_
+_pdbx_struct_assembly_gen.assembly_id
+_pdbx_struct_assembly_gen.oper_expression
+_pdbx_struct_assembly_gen.asym_id_list
+1 1 A,C,E 
+2 1 B,D,F 
+#
+_pdbx_struct_oper_list.id 1
+_pdbx_struct_oper_list.type "identity operation"
+_pdbx_struct_oper_list.name 1_555
+_pdbx_struct_oper_list.symmetry_operation x,y,z
+_pdbx_struct_oper_list.matrix[1][1] 1.0000000000
+_pdbx_struct_oper_list.matrix[1][2] 0.0000000000
+_pdbx_struct_oper_list.matrix[1][3] 0.0000000000
+_pdbx_struct_oper_list.vector[1] 0.0000000000
+_pdbx_struct_oper_list.matrix[2][1] 0.0000000000
+_pdbx_struct_oper_list.matrix[2][2] 1.0000000000
+_pdbx_struct_oper_list.matrix[2][3] 0.0000000000
+_pdbx_struct_oper_list.vector[2] 0.0000000000
+_pdbx_struct_oper_list.matrix[3][1] 0.0000000000
+_pdbx_struct_oper_list.matrix[3][2] 0.0000000000
+_pdbx_struct_oper_list.matrix[3][3] 1.0000000000
+_pdbx_struct_oper_list.vector[3] 0.0000000000
+#

--- a/prody/tests/proteins/test_ciffile.py
+++ b/prody/tests/proteins/test_ciffile.py
@@ -24,6 +24,7 @@ class TestParseMMCIF(unittest.TestCase):
         self.multi = DATA_FILES['multi_model_cif']
         self.no_pdb = DATA_FILES['long_chid_cif']
         self.biomols = DATA_FILES['biomols_cif']
+        self.chimerax = DATA_FILES['chimerax_cif']
 
         self.altlocs = DATA_FILES['cif_6flr']
         self.his_selstr = 'resname HIS and chain B and resnum 234 and name CA'
@@ -175,6 +176,17 @@ class TestParseMMCIF(unittest.TestCase):
                         self.biomols['bm_chains_united'],
                         'parseMMCIF failed to parse correct numbers of chains '
                         'with biomol True and unite_chain True')
+
+    def testChimeraxCIFBiomolArguments(self):
+        """Test outcome of valid and invalid *segment* arguments."""
+
+        path = pathDatafile(self.chimerax['file'])
+
+        bm_non_united = parseMMCIF(path, biomol=True)
+        self.assertEqual(bm_non_united[0].numAtoms(),
+                        self.chimerax['bm0_atoms'],
+                        'parseMMCIF failed to parse correct number of atoms '
+                        'with biomol True for the chimerax mmcif of 1ake')
 
     def testSubsetArgument(self):
         """Test outcome of valid and invalid *subset* arguments."""


### PR DESCRIPTION
There was a string of errors from trying to parse header information, such as biomols, from a chimerax cif file generated by scipion, which is now included in the tests datafiles. These commits should fix it.