### PR TITLE
fix clustenm 0 1 parallel handling

### DIFF
--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -1112,10 +1112,10 @@ class ClustENM(Ensemble):
         if not isinstance(self._parallel, (int, bool)):
             raise TypeError('parallel should be an int or bool')
 
-        if self._parallel == 1:
+        if not isinstance(self._parallel, bool) and self._parallel == 1:
             # this is equivalent to not actually being parallel
             self._parallel = False
-        elif self._parallel == 0:
+        elif not isinstance(self._parallel, bool) and self._parallel == 0:
             # this is a deliberate choice and is documented
             self._parallel = True
 


### PR DESCRIPTION
True is equivalent to 1 and False is equivalent to 0 and count as integers, so this functionality didn't work as expected. With these type checks, then True and False behave as expected again.