### PR TITLE
start supporting extended pdb id

### DIFF
--- a/prody/proteins/__init__.py
+++ b/prody/proteins/__init__.py
@@ -246,6 +246,9 @@ from . import ciffile
 from .ciffile import *
 __all__.extend(ciffile.__all__)
 
+_getPDBid  = ciffile._getPDBid = pdbfile._getPDBid
+long_id_check_str = ciffile.long_id_check_str = pdbfile.long_id_check_str
+
 from . import starfile
 from .starfile import *
 __all__.extend(starfile.__all__)

--- a/prody/proteins/__init__.py
+++ b/prody/proteins/__init__.py
@@ -247,7 +247,7 @@ from .ciffile import *
 __all__.extend(ciffile.__all__)
 
 _getPDBid  = ciffile._getPDBid = pdbfile._getPDBid
-long_id_check_str = ciffile.long_id_check_str = pdbfile.long_id_check_str
+long_id_check_str = wwpdb.long_id_check_str = ciffile.long_id_check_str = pdbfile.long_id_check_str
 
 from . import starfile
 from .starfile import *

--- a/prody/proteins/__init__.py
+++ b/prody/proteins/__init__.py
@@ -247,7 +247,8 @@ from .ciffile import *
 __all__.extend(ciffile.__all__)
 
 _getPDBid  = ciffile._getPDBid = pdbfile._getPDBid
-long_id_check_str = wwpdb.long_id_check_str = ciffile.long_id_check_str = pdbfile.long_id_check_str
+long_id_check_str = ciffile.long_id_check_str = pdbfile.long_id_check_str
+wwpdb.long_id_check_str = long_id_check_str
 
 from . import starfile
 from .starfile import *

--- a/prody/proteins/ciffile.py
+++ b/prody/proteins/ciffile.py
@@ -88,17 +88,16 @@ def parseMMCIF(pdb, **kwargs):
     if get_bonds:
         LOGGER.warn('Parsing struct_conn information from mmCIF is currently unsupported and no bond information is added to the results')
     if not os.path.isfile(pdb):
-        if len(pdb) == 5 and pdb.isalnum():
+        if (len(pdb) == 5 and pdb.isalnum()) or eval(long_id_check_str % 13):
             if chain is None:
-                chain = pdb[-1]
-                pdb = pdb[:4]
+                pdb, chain = _getPDBid(pdb)
             else:
                 raise ValueError('Please provide chain as a keyword argument '
                                  'or part of the PDB ID, not both')
         else:
             chain = chain
 
-        if len(pdb) == 4 and pdb.isalnum():
+        if (len(pdb) == 4 and pdb.isalnum()) or eval(long_id_check_str % 12):
             if title is None:
                 title = pdb
                 kwargs['title'] = title

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -215,7 +215,8 @@ def _parsePDB(pdb, **kwargs):
         filename = fetchPDB(pdb, **kwargs)
         if filename is None:
             try:
-                LOGGER.warn("Trying to parse mmCIF file instead")
+                if not (eval(long_id_check_str % 12) or eval(long_id_check_str % 13)):
+                    LOGGER.warn("Trying to parse mmCIF file instead")
                 chain = kwargs.pop('chain', chain)
                 return parseMMCIF(pdb+chain, **kwargs)
             except OSError:

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -197,7 +197,7 @@ def _getPDBid(pdb):
     else:
         raise IOError('{0} is not a valid filename or a valid PDB '
                       'identifier.'.format(pdb))
-    if not (pdbid.isalnum() or eval(long_id_check_str % 12)):
+    if not (pdbid.isalnum() or len(pdbid) == 12 and pdbid.startswith('pdb_') and pdbid[3] == '_'):
         raise IOError('{0} is not a valid filename or a valid PDB '
                       'identifier.'.format(pdb))
     if chain != '' and not chain.isalnum():

--- a/prody/proteins/pdbfile.py
+++ b/prody/proteins/pdbfile.py
@@ -29,6 +29,8 @@ __all__ = ['parsePDBStream', 'parsePDB', 'parseChainsList', 'parsePQR',
 MAX_N_ATOM = 99999 
 MAX_N_RES = 9999
 
+long_id_check_str = "len(pdb) == %d and pdb.startswith('pdb_') and pdb[3] == '_'"
+
 class PDBParseError(Exception):
     pass
 
@@ -185,17 +187,17 @@ def parsePDB(*pdb, **kwargs):
 
 def _getPDBid(pdb):
     l = len(pdb)
-    if l == 4:
+    if l == 4 or eval(long_id_check_str % 12):
         pdbid, chain = pdb, ''
-    elif l == 5:
-        pdbid = pdb[:4]; chain = pdb[-1]
+    elif l == 5 or eval(long_id_check_str % 13):
+        pdbid = pdb[:-1]; chain = pdb[-1]
     elif ':' in pdb:
         i = pdb.find(':')
         pdbid = pdb[:i]; chain = pdb[i+1:]
     else:
         raise IOError('{0} is not a valid filename or a valid PDB '
                       'identifier.'.format(pdb))
-    if not pdbid.isalnum():
+    if not (pdbid.isalnum() or eval(long_id_check_str % 12)):
         raise IOError('{0} is not a valid filename or a valid PDB '
                       'identifier.'.format(pdb))
     if chain != '' and not chain.isalnum():

--- a/prody/proteins/wwpdb.py
+++ b/prody/proteins/wwpdb.py
@@ -314,7 +314,8 @@ def fetchPDBviaHTTP(*pdb, **kwargs):
                 url = url.replace('.pdb', extension)
             handle = openURL(url)
         except Exception as err:
-            LOGGER.warn('{0} download failed ({1}).'.format(pdb, str(err)))
+            if not (eval(long_id_check_str % 12) or eval(long_id_check_str % 13)):
+                LOGGER.warn('{0} download failed ({1}).'.format(pdb, str(err)))
             failure += 1
             filenames.append(None)
         else:

--- a/prody/proteins/wwpdb.py
+++ b/prody/proteins/wwpdb.py
@@ -255,6 +255,9 @@ def fetchPDBviaHTTP(*pdb, **kwargs):
     compressed = bool(kwargs.pop('compressed', True))
 
     format = kwargs.get('format', 'pdb')
+    if (eval(long_id_check_str % 12) or eval(long_id_check_str % 13)):
+        format = 'cif'
+
     noatom = bool(kwargs.pop('noatom', False))
     if format == 'pdb':
         extension = '.pdb'

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -659,7 +659,9 @@ def checkIdentifiers(*pdb, **kwargs):
             LOGGER.warn('{0} is not a valid identifier.'.format(repr(pid)))
             append(None)
         else:
-            if format != 'emd' and not (len(pid) == 4 and pid.isalnum()):
+            if format != 'emd' and not ((len(pid) == 4 and pid.isalnum()) 
+                                        or (len(pid) == 12 and pid.startswith('pdb_') 
+                                            and pid[3] == '_')):
                 LOGGER.warn('{0} is not a valid identifier.'
                             .format(repr(pid)))
                 append(None)


### PR DESCRIPTION
The first mmCIF files with extended pdb ids are here: https://www.rcsb.org/news/feature/67edb35096cbbd16fc52edaf

Now, we have some start at being able to support them.
```
In [1]: from prody import *

In [2]: ag = parsePDB('pdb_00006uv8')
@> Connecting wwPDB FTP server RCSB PDB (USA).
@> Downloading PDB files via FTP failed, trying HTTP.
@> WARNING pdb_00006uv8 download failed ('https://files.rcsb.org/download/PDB_00006UV8.pdb.gz' could not be opened for reading, invalid URL or no internet connection).
@> PDB download via HTTP completed (0 downloaded, 1 failed).
@> WARNING Trying to parse mmCIF file instead
@> CIF file is found in working directory (pdb_00006uv8.cif).
@> 1554 atoms and 1 coordinate set(s) were parsed in 0.02s.
```