### PR TITLE
ClustENM fixes

### DIFF
--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -1185,7 +1185,9 @@ class ClustENM(Ensemble):
                 self._maxclust = (0,) + (maxclust,) * n_gens
 
             if len(self._maxclust) != self._n_gens + 1:
-                raise ValueError('size mismatch: %d generations were set; %d maxclusts were given' % (self._n_gens + 1, self._maxclust))
+                raise ValueError(
+                    'size mismatch: %d generations were set; %d maxclusts were given' % (
+                        self._n_gens + 1, len(self._maxclust)))
 
         if threshold is None:
             self._threshold = None

--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -749,15 +749,15 @@ class ClustENM(Ensemble):
             LOGGER.report('Centroids were generated in %.2fs.',
                         label='_clustenm_gen')
             confs_centers = confs_ex[centers]
-            ccList = list(np.array(ccList)[centers])
         else:
             confs_centers, wei = confs_ex, [len(confs_ex)]
 
         if self._fitmap is not None:
             self._cc_prev = max(self._cc)
             LOGGER.info('Best CC is %f from %d conformers after clustering' % (self._cc_prev, len(confs_centers)))
-
-        self._cc.extend(ccList)
+            if len(confs_cg) > 1:
+                ccList = list(np.array(ccList)[centers])
+            self._cc.extend(ccList)
         return confs_centers, wei
 
     def _outliers(self, arg):

--- a/prody/dynamics/clustenm.py
+++ b/prody/dynamics/clustenm.py
@@ -739,7 +739,7 @@ class ClustENM(Ensemble):
         confs_cg = confs_ex[:, self._idx_cg]
         
         if self._fitmap is not None:
-            self._cc_prev = max(self._cc)
+            self._cc_prev = max(max(ccList), max(self._cc))
             LOGGER.info('Best CC is %f from %d conformers' % (self._cc_prev, len(confs_ex)))
 
         if len(confs_cg) > 1:
@@ -753,11 +753,11 @@ class ClustENM(Ensemble):
             confs_centers, wei = confs_ex, [len(confs_ex)]
 
         if self._fitmap is not None:
-            self._cc_prev = max(self._cc)
-            LOGGER.info('Best CC is %f from %d conformers after clustering' % (self._cc_prev, len(confs_centers)))
             if len(confs_cg) > 1:
                 ccList = list(np.array(ccList)[centers])
             self._cc.extend(ccList)
+            self._cc_prev = max(self._cc)
+            LOGGER.info('Best CC is %f from %d conformers after clustering' % (self._cc_prev, len(confs_centers)))
         return confs_centers, wei
 
     def _outliers(self, arg):


### PR DESCRIPTION
fixes #2154 
```
Python 3.10.18 | packaged by conda-forge | (main, Jun  4 2025, 14:45:41) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.30.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: In [1]: import numpy as np
   ...: 
   ...: In [2]: import matplotlib.pyplot as plt
   ...: 
   ...: In [3]: from prody import *
   ...: 
   ...: In [4]: plt.ion()
Out[1]: <contextlib.ExitStack at 0x7f35cd16fbb0>

In [2]: QStandardPaths: wrong permissions on runtime directory /mnt/wslg/runtime-dir, 0777 instead of 0700
In [2]: pdb = parsePDB('1tw7', compressed=False)
@> PDB file is found in working directory (1tw7.pdb).
@> 1890 atoms and 1 coordinate set(s) were parsed in 0.02s.

In [3]: clustenm = ClustENM()

In [4]: clustenm.setAtoms(pdb)
@> Fixing the structure ...
/home/jkrieger/software/miniconda/envs/prody-github/lib/python3.10/site-packages/pdbfixer/pdbfixer.py:58: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import resource_filename
@> 3108 atoms and 1 coordinate set(s) were parsed in 0.02s.
@> The structure was fixed in 2.25s.

In [5]: In [9]: clustenm.run(n_modes=3, n_gens=1,
   ...:    ...:              maxclust=tuple(range(20, 40, 20)),
   ...:    ...:              sim=False, solvent='imp',
   ...:    ...:              t_steps_i=0, t_steps_g=0,
   ...:    ...:              platform='CPU')
@> Kirchhoff was built in 0.01s.
@> Generation 0 ...
@> Minimization in generation 0 ...
@> Completed in 6.91s.
@> #-------------------/*\-------------------#
@> Generation 1 ...
@> Sampling conformers in generation 1 ...
@> Hessian was built in 0.06s.
@> 3 modes were calculated in 0.21s.
@> Parameter: rmsd = 1.00 A
@> Parameter: n_confs = 50
@> Modes are scaled by 26.273792105754428.
@> Clustering in generation 1 ...
@> Centroids were generated in 0.89s.
@> Minimization in generation 1 ...
@> Structures were sampled in 146.50s.
@> #-------------------/*\-------------------#
@> Creating an ensemble of conformers ...
@> Ensemble was created in 0.00s.
@> All completed in 154.31s.
```

Also fixes an bug with the error for wrong length maxclust.

And I confirm that this works for the cryo-EM fitting case too:
```
Python 3.10.18 | packaged by conda-forge | (main, Jun  4 2025, 14:45:41) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.30.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: In [1]: import numpy as np
   ...: 
   ...: In [2]: import matplotlib.pyplot as plt
   ...: 
   ...: In [3]: from prody import *
   ...: 
   ...: In [4]: plt.ion()
Out[1]: <contextlib.ExitStack at 0x7f0a718b3bb0>

In [2]: QStandardPaths: wrong permissions on runtime directory /mnt/wslg/runtime-dir, 0777 instead of 0700
In [2]: import os

In [3]: TESTDIR = os.path.join("../../../../plugins/scipion-em-prody/prody2/",
   ...:                        "tests", "datafiles")
   ...: 
   ...: PRODY_TEST_PDB_FILE = os.path.join(TESTDIR, "4akeA_alg_map_fixed.pdb")
   ...: PRODY_TEST_MRC_FILE = os.path.join(TESTDIR, "1ake.mrc")

In [4]: pdb = parsePDB(PRODY_TEST_PDB_FILE)
@> 3341 atoms and 1 coordinate set(s) were parsed in 0.03s.

In [5]: mrc = parseEMD(PRODY_TEST_MRC_FILE)
@> Output is an EMDMAP with 2.00 A/pix.

In [6]: clustenm = ClustENM()

In [7]: clustenm.setAtoms(pdb)
@> Fixing the structure ...
/home/jkrieger/software/miniconda/envs/prody-github/lib/python3.10/site-packages/pdbfixer/pdbfixer.py:58: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  from pkg_resources import resource_filename
@> 3341 atoms and 1 coordinate set(s) were parsed in 0.06s.
@> The structure was fixed in 1.70s.

In [8]: In [9]: clustenm.run(n_modes=3, n_gens=1,
   ...:    ...:              maxclust=tuple(range(20, 40, 20)),
   ...:    ...:              sim=False, solvent='imp',
   ...:    ...:              t_steps_i=0, t_steps_g=0,
   ...:    ...:              platform='CPU', fitmap=mrc)
@> Kirchhoff was built in 0.02s.
@> Starting CC is 0.640894
@> Generation 0 ...
@> Minimization in generation 0 ...
@> Completed in 12.45s.
@> #-------------------/*\-------------------#
@> Generation 1 ...
@> Sampling conformers in generation 1 ...
@> Hessian was built in 0.14s.
@> 3 modes were calculated in 0.34s.
@> Parameter: rmsd = 1.00 A
@> Parameter: n_confs = 50
@> Modes are scaled by 9.534282879472999.
@> Filtering for fitting in generation 1 ...
@> Best CC is 0.691311 from 29 conformers
@> Clustering in generation 1 ...
@> Centroids were generated in 33.72s.
@> Best CC is 0.691311 from 20 conformers after clustering
@> Minimization in generation 1 ...
@> Structures were sampled in 149.45s.
@> #-------------------/*\-------------------#
@> Creating an ensemble of conformers ...
@> Ensemble was created in 0.00s.
@> All completed in 195.63s.
```