### PR TITLE
Handling new mmcif biomolecular transformation operator conventions

### DIFF
--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -206,6 +206,7 @@ def _getBiomoltrans(lines):
         if oper_expression[0].isnumeric():
             operators = oper_expression.split(',')
         elif (oper_expression.startswith('(')
+              and np.count_nonzero(np.array(list(oper_expression))=='(') == 1
               and oper_expression.find('-') != -1
               and oper_expression.endswith(')')):
             firstOperator = int(oper_expression.split('(')[1].split('-')[0])-1

--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -207,16 +207,26 @@ def _getBiomoltrans(lines):
             operators = oper_expression.split(',')
         elif (oper_expression.startswith('(')
               and np.count_nonzero(np.array(list(oper_expression))=='(') == 1
-              and oper_expression.find('-') != -1
+              and oper_expression.find('-') != -1 and oper_expression.find(',') == -1
               and oper_expression.endswith(')')):
             firstOperator = int(oper_expression.split('(')[1].split('-')[0])-1
             lastOperator = int(oper_expression.split('-')[1].split(')')[0])
-            operators = range(firstOperator, lastOperator)
+            operators = list(range(firstOperator, lastOperator))
         elif (oper_expression.startswith('(')
               and np.count_nonzero(np.array(list(oper_expression))=='(') == 1
-              and oper_expression.find(',') != -1
+              and oper_expression.find(',') != -1 and oper_expression.find('-') == -1
               and oper_expression.endswith(')')):
             operators = oper_expression[1:-1].split(',')
+        elif (oper_expression.startswith('(')
+              and np.count_nonzero(np.array(list(oper_expression))=='(') == 1
+              and oper_expression.find(',') != -1 and oper_expression.find('-') != -1
+              and oper_expression.endswith(')')):
+            operator_groups = oper_expression[1:-1].split(',')
+            operators = []
+            for group in operator_groups:
+                firstOperator = int(group.split('(')[1].split('-')[0])-1
+                lastOperator = int(group.split('-')[1].split(')')[0])
+                operators.extend(list(range(firstOperator, lastOperator)))
         else:
             operators = []
         for oper in operators:

--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -212,6 +212,11 @@ def _getBiomoltrans(lines):
             firstOperator = int(oper_expression.split('(')[1].split('-')[0])-1
             lastOperator = int(oper_expression.split('-')[1].split(')')[0])
             operators = range(firstOperator, lastOperator)
+        elif (oper_expression.startswith('(')
+              and np.count_nonzero(np.array(list(oper_expression))=='(') == 1
+              and oper_expression.find(',') != -1
+              and oper_expression.endswith(')')):
+            operators = oper_expression[1:-1].split(',')
         else:
             operators = []
         for oper in operators:

--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -191,6 +191,7 @@ def _getBiomoltrans(lines):
     # _pdbx_struct_oper_list: everything else
     data1 = parseSTARSection(lines, '_pdbx_struct_assembly_gen', report=False)
     data2 = parseSTARSection(lines, '_pdbx_struct_oper_list', report=False)
+    data2 = {item['_pdbx_struct_oper_list.id']: item for item in data2}
 
     # extracting the data
     for _, item1 in enumerate(data1):
@@ -203,36 +204,37 @@ def _getBiomoltrans(lines):
         biomt = biomolecule[currentBiomolecule]
 
         oper_expression = item1["_pdbx_struct_assembly_gen.oper_expression"]
-        if oper_expression[0].isnumeric():
+        oper_expr_array = np.array(list(oper_expression))
+        if np.count_nonzero(oper_expr_array=='(') == 0:
             operators = oper_expression.split(',')
         elif (oper_expression.startswith('(')
-              and np.count_nonzero(np.array(list(oper_expression))=='(') == 1
+              and np.count_nonzero(oper_expr_array=='(') == 1
               and oper_expression.find('-') != -1 and oper_expression.find(',') == -1
               and oper_expression.endswith(')')):
-            firstOperator = int(oper_expression.split('(')[1].split('-')[0])-1
-            lastOperator = int(oper_expression.split('-')[1].split(')')[0])
-            operators = list(range(firstOperator, lastOperator))
+            firstOperator = int(oper_expression.split('(')[1].split('-')[0])
+            lastOperator = int(oper_expression.split('-')[1].split(')')[0])+1
+            operators = list([str(oper) for oper in range(firstOperator, lastOperator)])
         elif (oper_expression.startswith('(')
-              and np.count_nonzero(np.array(list(oper_expression))=='(') == 1
+              and np.count_nonzero(oper_expr_array=='(') == 1
               and oper_expression.find(',') != -1 and oper_expression.find('-') == -1
               and oper_expression.endswith(')')):
             operators = oper_expression[1:-1].split(',')
         elif (oper_expression.startswith('(')
-              and np.count_nonzero(np.array(list(oper_expression))=='(') == 1
+              and np.count_nonzero(oper_expr_array=='(') == 1
               and oper_expression.find(',') != -1 and oper_expression.find('-') != -1
               and oper_expression.endswith(')')):
             operator_groups = oper_expression[1:-1].split(',')
             operators = []
             for group in operator_groups:
-                firstOperator = int(group.split('(')[1].split('-')[0])-1
-                lastOperator = int(group.split('-')[1].split(')')[0])
-                operators.extend(list(range(firstOperator, lastOperator)))
+                firstOperator = int(group.split('(')[1].split('-')[0])
+                lastOperator = int(group.split('-')[1].split(')')[0])+1
+                operators.extend([str(oper) for oper in range(firstOperator, lastOperator)])
         else:
             operators = []
         for oper in operators:
             biomt.append(applyToChains)
 
-            item2 = data2[int(oper)-1]
+            item2 = data2[oper]
 
             for i in range(1,4):
                 biomt.append(" ".join([

--- a/prody/proteins/cifheader.py
+++ b/prody/proteins/cifheader.py
@@ -8,7 +8,7 @@ import os.path
 from prody import LOGGER
 from prody.atomic import flags, AAMAP
 from prody.atomic.atomic import invAAMAP
-from prody.utilities import openFile, alignBioPairwise, GAP_EXT_PENALTY
+from prody.utilities import openFile
 
 from .localpdb import fetchPDB
 from .header import (Chemical, Polymer, DBRef, _PDB_DBREF,
@@ -193,7 +193,7 @@ def _getBiomoltrans(lines):
     data2 = parseSTARSection(lines, '_pdbx_struct_oper_list', report=False)
 
     # extracting the data
-    for n, item1 in enumerate(data1):
+    for _, item1 in enumerate(data1):
         currentBiomolecule = item1["_pdbx_struct_assembly_gen.assembly_id"]
         applyToChains = []
 


### PR DESCRIPTION
fixes #2162 

1al2 uses some conventions in its biomolecular transformation operator conventions blocks that we haven't come across before
```
loop_
_pdbx_struct_assembly_gen.assembly_id 
_pdbx_struct_assembly_gen.oper_expression 
_pdbx_struct_assembly_gen.asym_id_list 
1 '(1-60)'                      A,B,C,D,E,F,G,H,I,J,K,L 
2 1                             A,B,C,D,E,F,G,H,I,J,K,L 
3 '(1-5)'                       A,B,C,D,E,F,G,H,I,J,K,L 
4 '(1,2,6,10,23,24)'            A,B,C,D,E,F,G,H,I,J,K,L 
5 P                             A,B,C,D,E,F,G,H,I,J,K,L 
6 '(X0)(1-5,11-15,21-30,41-50)' A,B,C,D,E,F,G,H,I,J,K,L 
# 
loop_
_pdbx_struct_oper_list.id 
_pdbx_struct_oper_list.type 
_pdbx_struct_oper_list.name 
_pdbx_struct_oper_list.symmetry_operation 
_pdbx_struct_oper_list.matrix[1][1] 
_pdbx_struct_oper_list.matrix[1][2] 
_pdbx_struct_oper_list.matrix[1][3] 
_pdbx_struct_oper_list.vector[1] 
_pdbx_struct_oper_list.matrix[2][1] 
_pdbx_struct_oper_list.matrix[2][2] 
_pdbx_struct_oper_list.matrix[2][3] 
_pdbx_struct_oper_list.vector[2] 
_pdbx_struct_oper_list.matrix[3][1] 
_pdbx_struct_oper_list.matrix[3][2] 
_pdbx_struct_oper_list.matrix[3][3] 
_pdbx_struct_oper_list.vector[3] 
X0 'identity operation'       1_555 x,y,z 1.00000000  0.00000000  0.00000000  0.00000   0.00000000  1.00000000  0.00000000  
0.00000   0.00000000  0.00000000  1.00000000  0.00000    
P  'transform to point frame' ?     ?     0.99804017  0.06725702  0.00000000  0.00000   -0.06717578 0.99796599  0.00000000  
0.00000   0.00000000  0.00000000  1.00000000  94.07771   
```

1. operator ids can have letters in them e.g. P and X0 for assemblies 5 and 6
2. operator ids can be ordered with multiple sets of brackets to apply groups of operations in series, e.g. assembly 6
3. operators separated by commas can be included in brackets too (we previously only had hyphened ranges), as in assembly 4
4. there can be comma-separated groups of hyphened ranges, as in assembly 6

Assembly 6 was previously raising an error because it was trying to be captured as a single set of brackets containing a hyphened range. 

This PR adds some first fixes to handle this:
1. exclude cases with multiple open brackets from the current case that is being analysed with brackets containing ranges
2. add in a case for brackets containing comma-separated operator ids (case 3)
3. add in a case for brackets containing comma-separated ranges (case 4)

This captures the first 4 assemblies without raising errors but still does not capture assemblies 5 and 6.
```
(py3126) jkrieger@CNB-WHIPPLE ~/software/scipion3/software/em/prody-github/ProDy (cif_bmt_new_conventions) $ ipython
Python 3.12.6 | packaged by conda-forge | (main, Sep 22 2024, 14:16:49) [GCC 13.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.27.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import prody

In [2]: x = prody.parseMMCIF("1al2", biomol=True)
@> CIF file is found in working directory (1al2.cif).
@> WARNING SEQADV for chain 3: database sequence reference not found (1AL2:2)
@> WARNING SEQADV for chain 3: database sequence reference not found (1AL2:2)
@> 7203 atoms and 1 coordinate set(s) were parsed in 0.30s.
@> Secondary structures were assigned to 0 residues.
@> Biomolecular transformations were applied, 4 biomolecule(s) are returned.

In [3]: [bm.numChains()/12 for bm in x]
Out[3]: [60.0, 1.0, 5.0, 6.0]
```