### PR TITLE
Fix typo in 'tanh' function name

### DIFF
--- a/prody/atomic/select.py
+++ b/prody/atomic/select.py
@@ -673,7 +673,7 @@ FUNCTIONS = {
     'atan'  : np.arctan,
     'sinh'  : np.sinh,
     'cosh'  : np.cosh,
-    'tahn'  : np.tanh,
+    'tanh'  : np.tanh,
     'exp'   : np.exp,
     'log'   : np.log,
     'log10' : np.log10,


### PR DESCRIPTION
The hyperbolic tangent function wasn't working on the selection. It seems it was misspelled as `tahn` instead of `tanh` in the parser.