### PR TITLE
switch biopython alignment to global

### DIFF
--- a/prody/utilities/seqtools.py
+++ b/prody/utilities/seqtools.py
@@ -10,7 +10,7 @@ MATCH_SCORE = 1.0
 MISMATCH_SCORE = 0.0
 GAP_PENALTY = -1.
 GAP_EXT_PENALTY = -0.1
-ALIGNMENT_METHOD = 'local'
+ALIGNMENT_METHOD = 'global'
 
 SPLITLABEL = re.compile(r'[/-]+').split
 


### PR DESCRIPTION
This seems to fix #2205 
```
In [1]: import prody
/Users/kriegej/scipion3/software/em/prody-github/ProDy/prody/drugui/gui.py:1867: SyntaxWarning: invalid escape sequence '\$'
  """
/Users/kriegej/scipion3/software/em/prody-github/ProDy/prody/drugui/no_gui.py:1160: SyntaxWarning: invalid escape sequence '\$'
  """

In [2]: prody_model = prody.parsePDB("centered_model.pdb")
@> 2280 atoms and 1 coordinate set(s) were parsed in 0.01s.

In [3]: prody_ref_model = prody.parsePDB("ref_model.pdb")
@> 2243 atoms and 1 coordinate set(s) were parsed in 0.01s.

In [4]: target = list(prody_model.getHierView())[3]

In [5]: chain = list(prody_ref_model.getHierView())[3]

In [6]: from prody.utilities import MATCH_SCORE, MISMATCH_SCORE, GAP_PENALTY, GAP_EXT_PENALTY, ALIGNMENT_METHOD, alignBioPairwise

In [7]:             alignments = alignBioPairwise(target.getSequence(),
   ...:                                           chain.getSequence()[3:],
   ...:                                           "local",
   ...:                                           MATCH_SCORE, MISMATCH_SCORE,
   ...:                                           GAP_PENALTY,  GAP_EXT_PENALTY,
   ...:                                           max_alignments=1)

In [8]: alignments
Out[8]: [('FEVKKWNAVALWAWDIV', 'FEVKKWNAVALWAWDIV', 17.0, '3', '20')]

In [9]:             alignments = alignBioPairwise(target.getSequence(),
   ...:                                           chain.getSequence()[3:],
   ...:                                           "global",
   ...:                                           MATCH_SCORE, MISMATCH_SCORE,
   ...:                                           GAP_PENALTY,  GAP_EXT_PENALTY,
   ...:                                           max_alignments=1)

In [10]: alignments
Out[10]: 
[('KKRFEVKKWNAVALWAWDIVNCAICRNHIMDLCIECQANQASATSEECTVAWGVCNHAFHFHCISRWLKTRQVCPLDNREWE',
  'F---EVKKWNAVALWAWDIV-------------------------------------------------------------V',
  7.800000000000022,
  '0',
  '82')]
```

@AnthonyBogetti and @anupam-banerjee please check if this breaks anything else you're working with 