### PR TITLE
speed up getMasses by looking up each distinct element once

### DIFF
--- a/prody/atomic/atomgroup.py
+++ b/prody/atomic/atomgroup.py
@@ -1968,10 +1968,7 @@ for fname, field in ATOMIC_FIELDS.items():
 
                 if not np.isscalar(array):
                     if var == 'chain':
-                        max_len = 0
-                        for val in array:
-                            if len(val) > max_len:
-                                max_len = len(val)
+                        max_len = max(map(len, array), default=0)
 
                         if max_len > int(dtype[1:]):
                             dtype = dtype[0] + str(max_len)

--- a/prody/tests/utilities/test_misctools.py
+++ b/prody/tests/utilities/test_misctools.py
@@ -1,6 +1,10 @@
+from numpy import array
+from numpy.testing import assert_allclose
+
 from prody.tests import TestCase
 
 from prody.utilities import rangeString
+from prody.utilities.misctools import getMasses
 
 
 class TestRangeString(TestCase):
@@ -26,3 +30,48 @@ class TestRangeString(TestCase):
         self.assertEqual(rangeString(list(range(10, 20)) +
                                      list(range(15, 20)) +
                                      list(range(30))), '0 to 29')
+
+
+class TestGetMasses(TestCase):
+
+    def testKnownElements(self):
+
+        assert_allclose(getMasses(['C', 'N', 'O', 'S']),
+                        [12.0107, 14.0067, 15.9994, 32.065])
+
+    def testCaseInsensitive(self):
+        """Element symbols are matched regardless of case."""
+
+        assert_allclose(getMasses(['c', 'n', 'FE']),
+                        getMasses(['C', 'N', 'Fe']))
+
+    def testUnknownElementIsZero(self):
+        """An unrecognised symbol contributes zero mass, it does not raise."""
+
+        assert_allclose(getMasses(['C', 'Xx', 'O']), [12.0107, 0., 15.9994])
+
+    def testRepeatedElements(self):
+        """Repeated symbols must all map back to their own mass.
+
+        The lookup is done once per distinct symbol and mapped back onto the
+        atoms, so a wrong mapping would show up here as masses landing on the
+        wrong atoms.
+        """
+
+        elements = ['O', 'C', 'C', 'N', 'O', 'S', 'C', 'N']
+        expected = [15.9994, 12.0107, 12.0107, 14.0067,
+                    15.9994, 32.065, 12.0107, 14.0067]
+        assert_allclose(getMasses(elements), expected)
+
+    def testEmpty(self):
+
+        self.assertEqual(len(getMasses([])), 0)
+
+    def testString(self):
+        """A single symbol still returns a scalar."""
+
+        self.assertAlmostEqual(getMasses('c'), 12.0107)
+
+    def testArrayInput(self):
+
+        assert_allclose(getMasses(array(['C', 'O'])), [12.0107, 15.9994])

--- a/prody/utilities/misctools.py
+++ b/prody/utilities/misctools.py
@@ -370,13 +370,15 @@ def getMasses(elements):
     if isinstance(elements, str):
         return mass_dict[elements.capitalize()]
     else:
-        masses = zeros(len(elements))
-        for i,element in enumerate(elements):
-            if element.capitalize() in mass_dict:
-                masses[i] = mass_dict[element.capitalize()]
-            else:
-                masses[i] = 0.
-        return masses
+        elements = asarray(elements)
+        if elements.size == 0:
+            return zeros(0)
+        # a structure has only a handful of distinct element symbols, so the
+        # lookup is done once per distinct symbol rather than once per atom
+        unique_elements, inverse = unique(elements, return_inverse=True)
+        unique_masses = array([mass_dict.get(str(element).capitalize(), 0.)
+                               for element in unique_elements])
+        return unique_masses[inverse.reshape(-1)]
 
 def count(L, a=None):
     return len([b for b in L if b is a])


### PR DESCRIPTION
disclosing up front, same as #2262: put together with help from claude, then reproduced, measured and verified by me before opening.

two performance fixes, both in code that runs on every structure load. no behaviour change in either.

## 1. getMasses looks up every atom individually

`getMasses` in `prody/utilities/misctools.py` loops over every atom, calls `str.capitalize()` twice per atom and does a dict lookup each time. but a structure only contains a handful of distinct element symbols, so nearly all of that work is repeated. switched it to resolve each distinct symbol once and map the result back onto the atoms with `unique(..., return_inverse=True)`.

this is on the path for every pdb, mmcif and mmtf load (`pdbfile.py`, `ciffile.py`, `mmtffile.py` all call it right after parsing elements), so it shows up on essentially any structure a user opens.

measured on my machine, output identical in every case:

| structure | before | after | |
|---|---|---|---|
| 1,079 atoms | 0.36 ms | 0.03 ms | 11.1x |
| 12,750 atoms (antibody) | 3.59 ms | 0.27 ms | 13.3x |
| 100,000 atoms | 43.4 ms | 5.1 ms | 8.5x |
| 1,000,000 atoms | 292 ms | 45 ms | 6.4x |

the unknown-symbol case still returns 0.0 rather than raising, the single-string case still returns a scalar, and case-insensitive matching is unchanged.

## 2. max_len loop in setData

`prody/atomic/atomgroup.py` finds the longest chain identifier with an explicit python loop. `max(map(len, array), default=0)` does the same in C, and the `default` covers the empty case the loop handled by leaving `max_len` at 0. small, but it runs on every chain assignment.

## verification

added `TestGetMasses` to `prody/tests/utilities/test_misctools.py`: 7 tests covering known elements, case insensitivity, unknown symbols, repeated symbols (which is what would break if the unique/inverse mapping were wrong), empty input, single-string input and array input. i checked these have teeth by deliberately breaking the mapping and confirming they fail.

ran `prody/tests/atomic` and `prody/tests/utilities`: 618 passed. `prody/tests/proteins` has 16 failures and 1 error on my machine, but they are identical on unpatched main, so they are pre-existing and unrelated to this change (mostly `test_insty` and a network-dependent mmtf test).

happy to split these into two prs if you'd rather take them separately.

mike
