### PR TITLE
Fix CHARMM PSF topology handling: cross-term width, term order, and topology under selection

### DIFF
--- a/prody/atomic/acceptor.py
+++ b/prody/atomic/acceptor.py
@@ -125,7 +125,8 @@ def evalAcceptors(acceptors, n_atoms):
         # remove entries corresponding to missing hydrogens (with 0 in them that became -1)
         acceptors = acceptors[np.argwhere(acceptors == -1)[-1][0]+1:]
 
-    numacceptors = np.bincount(acceptors.reshape((acceptors.shape[0] * 2)))
+    numacceptors = np.bincount(acceptors.reshape((acceptors.shape[0] * 2)),
+                               minlength=n_atoms)
 
     acmap = np.zeros((n_atoms, numacceptors.max()), int)
     index = np.zeros(n_atoms, int)

--- a/prody/atomic/angle.py
+++ b/prody/atomic/angle.py
@@ -129,7 +129,8 @@ def evalAngles(angles, n_atoms):
     """Returns an array mapping atoms to their angled neighbors and an array
     that stores number of angles made by each atom."""
 
-    numangles = np.bincount(angles.reshape((angles.shape[0] * 3)))
+    numangles = np.bincount(angles.reshape((angles.shape[0] * 3)),
+                            minlength=n_atoms)
     angmap = np.zeros((n_atoms, numangles.max(), 2), int)
     angmap.fill(-1)
     index = np.zeros(n_atoms, int)

--- a/prody/atomic/atomgroup.py
+++ b/prody/atomic/atomgroup.py
@@ -1757,8 +1757,10 @@ class AtomGroup(Atomic):
                 yield a, b
 
     def setCrossterms(self, crossterms):
-        """Set covalent crossterms between atoms.  *crossterms* must be a list or an
-        array of triplets of indices.  All crossterms must be set at once.  Crossterm
+        """Set CMAP cross-terms between atoms.  *crossterms* must be a list or an
+        array of EIGHT indices per term -- the two coupled dihedrals of a CHARMM CMAP
+        term, in the order they appear in the ``!NCRTERM`` section.  All crossterms
+        must be set at once.  Crossterm
         information can be used to make atom selections, e.g. ``"crossterm to
         index 1"``.  See :mod:`.select` module documentation for details.
         Also, a data array with number of crossterms will be generated and stored
@@ -1769,8 +1771,8 @@ class AtomGroup(Atomic):
             crossterms = np.array(crossterms, int)
         if crossterms.ndim != 2:
             raise ValueError('crossterms.ndim must be 2')
-        if crossterms.shape[1] != 4:
-            raise ValueError('crossterms.shape must be (n_crossterms, 4)')
+        if crossterms.shape[1] != 8:
+            raise ValueError('crossterms.shape must be (n_crossterms, 8)')
         if crossterms.min() < 0:
             raise ValueError('negative atom indices are not valid')
         n_atoms = self._n_atoms
@@ -1810,12 +1812,12 @@ class AtomGroup(Atomic):
                 yield Crossterm(self, crossterm, acsi)
 
     def _iterCrossterms(self):
-        """Yield quadruplets of crosstermed atom indices. Use :meth:`setCrossterms` for setting
-        crossterms."""
+        """Yield the atom indices of each CMAP cross-term, eight per term. Use
+        :meth:`setCrossterms` for setting crossterms."""
 
         if self._crossterms is not None:
-            for a, b, c, d in self._crossterms:
-                yield a, b, c, d
+            for crossterm in self._crossterms:
+                yield crossterm
 
     def numFragments(self):
         """Returns number of connected atom subsets."""

--- a/prody/atomic/atomgroup.py
+++ b/prody/atomic/atomgroup.py
@@ -1306,9 +1306,15 @@ class AtomGroup(Atomic):
         if bonds.max() >= n_atoms:
             raise ValueError('atom indices are out of range')
 
+        # NOTE: sorting WITHIN each row is load-bearing here, unlike for
+        # angles, dihedrals, impropers and cross-terms, whose atom order
+        # carries meaning and must be preserved.  A bond is symmetric, so
+        # (i, j) and (j, i) are the same bond, and np.unique below only sorts
+        # and de-duplicates whole rows, never their contents.  Sorting each
+        # pair first is what makes the two spellings collapse into one, and it
+        # is also what guarantees i < j in the '%d %d' keys of _bondIndex.
+        # np.unique sorts the rows itself, so no separate row sort is needed.
         bonds.sort(1)
-        bonds = bonds[bonds[:, 1].argsort(), ]
-        bonds = bonds[bonds[:, 0].argsort(), ]
         bonds = np.unique(bonds, axis=0)
 
         d = {}
@@ -1396,10 +1402,11 @@ class AtomGroup(Atomic):
         n_atoms = self._n_atoms
         if angles.max() >= n_atoms:
             raise ValueError('atom indices are out of range')
-        angles.sort(1)
-        angles = angles[angles[:, 2].argsort(), ]
-        angles = angles[angles[:, 1].argsort(), ]
-        angles = angles[angles[:, 0].argsort(), ]
+        # NOTE: the atom order WITHIN a term is meaningful -- it identifies an
+        # angle's vertex, a torsion's sequence and a CMAP term's two coupled
+        # dihedrals -- so it must not be sorted.  The order of the terms
+        # themselves is left as given too, so that a topology read from a file
+        # is written back out unchanged.
 
         self._angmap, self._data['numangles'] = evalAngles(angles, n_atoms)
         self._angles = angles
@@ -1455,11 +1462,11 @@ class AtomGroup(Atomic):
         n_atoms = self._n_atoms
         if dihedrals.max() >= n_atoms:
             raise ValueError('atom indices are out of range')
-        dihedrals.sort(1)
-        dihedrals = dihedrals[dihedrals[:, 3].argsort(), ]
-        dihedrals = dihedrals[dihedrals[:, 2].argsort(), ]
-        dihedrals = dihedrals[dihedrals[:, 1].argsort(), ]
-        dihedrals = dihedrals[dihedrals[:, 0].argsort(), ]
+        # NOTE: the atom order WITHIN a term is meaningful -- it identifies an
+        # angle's vertex, a torsion's sequence and a CMAP term's two coupled
+        # dihedrals -- so it must not be sorted.  The order of the terms
+        # themselves is left as given too, so that a topology read from a file
+        # is written back out unchanged.
 
         self._dmap, self._data['numdihedrals'] = evalDihedrals(
             dihedrals, n_atoms)
@@ -1516,11 +1523,11 @@ class AtomGroup(Atomic):
         n_atoms = self._n_atoms
         if impropers.max() >= n_atoms:
             raise ValueError('atom indices are out of range')
-        impropers.sort(1)
-        impropers = impropers[impropers[:, 3].argsort(), ]
-        impropers = impropers[impropers[:, 2].argsort(), ]
-        impropers = impropers[impropers[:, 1].argsort(), ]
-        impropers = impropers[impropers[:, 0].argsort(), ]
+        # NOTE: the atom order WITHIN a term is meaningful -- it identifies an
+        # angle's vertex, a torsion's sequence and a CMAP term's two coupled
+        # dihedrals -- so it must not be sorted.  The order of the terms
+        # themselves is left as given too, so that a topology read from a file
+        # is written back out unchanged.
 
         self._imap, self._data['numimpropers'] = evalImpropers(
             impropers, n_atoms)
@@ -1584,10 +1591,10 @@ class AtomGroup(Atomic):
         n_atoms = self._n_atoms
         if donors.max() >= n_atoms:
             raise ValueError('atom indices are out of range')
-        donors.sort(1)
-        donors = donors[donors[:, 1].argsort(), ]
-        donors = donors[donors[:, 0].argsort(), ]
-        donors = np.unique(donors, axis=0)
+        # NOTE: a CHARMM !NDON record is an ORDERED pair -- a hydrogen-bond donor's heavy atom and its hydrogen --
+        # so neither the two indices nor the order of the records is sorted, and
+        # duplicates are not collapsed: a topology read from a file is written
+        # back out unchanged.  Contrast setBonds, whose pairs are symmetric.
 
         self._domap, self._data['numdonors'] = evalDonors(donors, n_atoms)
         self._donors = donors
@@ -1650,10 +1657,10 @@ class AtomGroup(Atomic):
         n_atoms = self._n_atoms
         if acceptors.max() >= n_atoms:
             raise ValueError('atom indices are out of range')
-        acceptors.sort(1)
-        acceptors = acceptors[acceptors[:, 1].argsort(), ]
-        acceptors = acceptors[acceptors[:, 0].argsort(), ]
-        acceptors = np.unique(acceptors, axis=0)
+        # NOTE: a CHARMM !NACC record is an ORDERED pair -- an acceptor and its antecedent --
+        # so neither the two indices nor the order of the records is sorted, and
+        # duplicates are not collapsed: a topology read from a file is written
+        # back out unchanged.  Contrast setBonds, whose pairs are symmetric.
 
         self._acmap, self._data['numacceptors'] = evalAcceptors(acceptors, n_atoms)
         self._acceptors = acceptors
@@ -1716,9 +1723,10 @@ class AtomGroup(Atomic):
         n_atoms = self._n_atoms
         if nbexclusions.max() >= n_atoms:
             raise ValueError('atom indices are out of range')
+        # A non-bonded exclusion is symmetric, so -- as in setBonds -- sorting
+        # within each pair is what collapses (i, j) and (j, i), and np.unique
+        # sorts the rows itself.
         nbexclusions.sort(1)
-        nbexclusions = nbexclusions[nbexclusions[:, 1].argsort(), ]
-        nbexclusions = nbexclusions[nbexclusions[:, 0].argsort(), ]
         nbexclusions = np.unique(nbexclusions, axis=0)
 
         self._nbemap, self._data['numnbexclusions'] = evalNBExclusions(
@@ -1778,11 +1786,11 @@ class AtomGroup(Atomic):
         n_atoms = self._n_atoms
         if crossterms.max() >= n_atoms:
             raise ValueError('atom indices are out of range')
-        crossterms.sort(1)
-        crossterms = crossterms[crossterms[:, 3].argsort(), ]
-        crossterms = crossterms[crossterms[:, 2].argsort(), ]
-        crossterms = crossterms[crossterms[:, 1].argsort(), ]
-        crossterms = crossterms[crossterms[:, 0].argsort(), ]
+        # NOTE: the atom order WITHIN a term is meaningful -- it identifies an
+        # angle's vertex, a torsion's sequence and a CMAP term's two coupled
+        # dihedrals -- so it must not be sorted.  The order of the terms
+        # themselves is left as given too, so that a topology read from a file
+        # is written back out unchanged.
 
         self._cmap, self._data['numcrossterms'] = evalCrossterms(
             crossterms, n_atoms)

--- a/prody/atomic/atomic.py
+++ b/prody/atomic/atomic.py
@@ -8,7 +8,7 @@ from prody import LOGGER, __path__
 from prody.utilities import openData
 
 from . import flags
-from .bond import trimBonds
+from .bond import trimBonds, trimTerms
 from .fields import READONLY
 
 __all__ = ['Atomic', 'AAMAP']
@@ -213,25 +213,38 @@ class Atomic(object):
             new._setFlags('dummy', dummy)
             new._setFlags('mapped', mapped)
 
-        bonds = ag._bonds
-        bmap = ag._bmap
-        if bonds is not None and bmap is not None:
-            if indices is None:
-                new._bonds = bonds.copy()
-                new._bmap = bmap.copy()
-                new._data['numbonds'] = ag._data['numbonds'].copy()
-            elif dummies:
-                if dummies:
-                    indices = indices[self._getMapping()]
-                if len(set(indices)) == len(indices):
-                    new.setBonds(trimBonds(bonds, indices))
-                else:
-                    LOGGER.warn('Duplicate atoms in mapping, bonds are '
-                                'not copied.')
+        # every topology section, not bonds alone: a copy that kept only the bonds
+        # silently dropped the angles, dihedrals, impropers, donors, acceptors,
+        # exclusions and CMAP cross-terms of a CHARMM system
+        TOPOLOGY = [('_bonds', '_bmap', 'numbonds', new.setBonds),
+                    ('_angles', '_angmap', 'numangles', new.setAngles),
+                    ('_dihedrals', '_dmap', 'numdihedrals', new.setDihedrals),
+                    ('_impropers', '_imap', 'numimpropers', new.setImpropers),
+                    ('_donors', '_domap', 'numdonors', new.setDonors),
+                    ('_acceptors', '_acmap', 'numacceptors', new.setAcceptors),
+                    ('_nbexclusions', '_nbemap', 'numnbexclusions',
+                     new.setNBExclusions),
+                    ('_crossterms', '_cmap', 'numcrossterms', new.setCrossterms)]
+
+        if dummies and indices is not None:
+            if len(set(indices)) == len(indices):
+                indices = indices[self._getMapping()]
             else:
-                bonds = trimBonds(bonds, indices)
-                if bonds is not None:
-                    new.setBonds(bonds)
+                LOGGER.warn('Duplicate atoms in mapping, topology is not copied.')
+                return new
+
+        for attr, mapattr, numlabel, setter in TOPOLOGY:
+            terms = getattr(ag, attr)
+            if terms is None or getattr(ag, mapattr) is None:
+                continue
+            if indices is None:
+                setattr(new, attr, terms.copy())
+                setattr(new, mapattr, getattr(ag, mapattr).copy())
+                new._data[numlabel] = ag._data[numlabel].copy()
+            else:
+                terms = trimTerms(terms, indices)
+                if terms is not None:
+                    setter(terms)
         return new
 
     __copy__ = copy

--- a/prody/atomic/bond.py
+++ b/prody/atomic/bond.py
@@ -141,12 +141,24 @@ def evalBonds(bonds, n_atoms):
     return bmap, numbonds
 
 
-def trimBonds(bonds, indices):
-    """Returns bonds between atoms at given indices."""
+def trimTerms(terms, indices):
+    """Returns the *terms* whose atoms all lie at *indices*, renumbered so that the
+    atom at ``indices[i]`` becomes atom ``i``.  Works for any term width -- bonds,
+    angles, dihedrals, impropers, donors, acceptors, exclusions and eight-atom CMAP
+    cross-terms -- and keeps both the order of the terms and the order of the atoms
+    within each one, which for every term but a bond is what identifies it.  A term
+    only partly inside *indices* cannot be renumbered and is dropped."""
 
     iset = set(indices)
-    bonds = [bond for bond in bonds if bond[0] in iset and bond[1] in iset]
-    if bonds:
+    terms = [term for term in terms if iset.issuperset(term)]
+    if terms:
         newindices = np.zeros(indices.max()+1, int)
         newindices[indices] = np.arange(len(indices))
-        return newindices[np.array(bonds)]
+        return newindices[np.array(terms)]
+
+
+def trimBonds(bonds, indices):
+    """Returns bonds between atoms at given indices.  See :func:`.trimTerms`, of
+    which this is the two-atom case."""
+
+    return trimTerms(bonds, indices)

--- a/prody/atomic/bond.py
+++ b/prody/atomic/bond.py
@@ -128,7 +128,8 @@ def evalBonds(bonds, n_atoms):
     """Returns an array mapping atoms to their bonded neighbors and an array
     that stores number of bonds made by each atom."""
 
-    numbonds = np.bincount(bonds.reshape((bonds.shape[0] * 2)))
+    numbonds = np.bincount(bonds.reshape((bonds.shape[0] * 2)),
+                           minlength=n_atoms)
     bmap = np.zeros((n_atoms, numbonds.max()), int)
     bmap.fill(-1)
     index = np.zeros(n_atoms, int)

--- a/prody/atomic/crossterm.py
+++ b/prody/atomic/crossterm.py
@@ -141,7 +141,8 @@ def evalCrossterms(crossterms, n_atoms):
     that stores number of crossterms made by each atom."""
 
     width = crossterms.shape[1]
-    numcrossterms = np.bincount(crossterms.reshape((crossterms.shape[0] * width)))
+    numcrossterms = np.bincount(crossterms.reshape((crossterms.shape[0] * width)),
+                                minlength=n_atoms)
     dmap = np.zeros((n_atoms, numcrossterms.max(), width - 1), int)
     dmap.fill(-1)
     index = np.zeros(n_atoms, int)

--- a/prody/atomic/crossterm.py
+++ b/prody/atomic/crossterm.py
@@ -140,16 +140,14 @@ def evalCrossterms(crossterms, n_atoms):
     """Returns an array mapping atoms to their crosstermd neighbors and an array
     that stores number of crossterms made by each atom."""
 
-    numcrossterms = np.bincount(crossterms.reshape((crossterms.shape[0] * 4)))
-    dmap = np.zeros((n_atoms, numcrossterms.max(), 3), int)
+    width = crossterms.shape[1]
+    numcrossterms = np.bincount(crossterms.reshape((crossterms.shape[0] * width)))
+    dmap = np.zeros((n_atoms, numcrossterms.max(), width - 1), int)
     dmap.fill(-1)
     index = np.zeros(n_atoms, int)
     for crossterm in crossterms:
-        a, b, c, d = crossterm
-        dmap[a, index[a]] = [b, c, d]
-        dmap[b, index[b]] = [a, c, d]
-        dmap[c, index[c]] = [a, b, d]
-        dmap[d, index[d]] = [a, b, c]
+        for i, a in enumerate(crossterm):
+            dmap[a, index[a]] = np.delete(crossterm, i)
         index[crossterm] += 1
     return dmap, numcrossterms
 

--- a/prody/atomic/dihedral.py
+++ b/prody/atomic/dihedral.py
@@ -140,7 +140,8 @@ def evalDihedrals(dihedrals, n_atoms):
     """Returns an array mapping atoms to their dihedrald neighbors and an array
     that stores number of dihedrals made by each atom."""
 
-    numdihedrals = np.bincount(dihedrals.reshape((dihedrals.shape[0] * 4)))
+    numdihedrals = np.bincount(dihedrals.reshape((dihedrals.shape[0] * 4)),
+                               minlength=n_atoms)
     dmap = np.zeros((n_atoms, numdihedrals.max(), 3), int)
     dmap.fill(-1)
     index = np.zeros(n_atoms, int)

--- a/prody/atomic/donor.py
+++ b/prody/atomic/donor.py
@@ -125,7 +125,8 @@ def evalDonors(donors, n_atoms):
         # remove entries corresponding to missing hydrogens (with 0 in them that became -1)
         donors = donors[np.argwhere(donors == -1)[-1][0]+1:]
 
-    numdonors = np.bincount(donors.reshape((donors.shape[0] * 2)))        
+    numdonors = np.bincount(donors.reshape((donors.shape[0] * 2)),
+                            minlength=n_atoms)        
 
     domap = np.zeros((n_atoms, numdonors.max()), int)
     index = np.zeros(n_atoms, int)

--- a/prody/atomic/improper.py
+++ b/prody/atomic/improper.py
@@ -132,7 +132,8 @@ def evalImpropers(impropers, n_atoms):
     """Returns an array mapping atoms to their improperd neighbors and an array
     that stores number of impropers made by each atom."""
 
-    numimpropers = np.bincount(impropers.reshape((impropers.shape[0] * 4)))
+    numimpropers = np.bincount(impropers.reshape((impropers.shape[0] * 4)),
+                               minlength=n_atoms)
     imap = np.zeros((n_atoms, numimpropers.max(), 3), int)
     imap.fill(-1)
     index = np.zeros(n_atoms, int)

--- a/prody/atomic/nbexclusion.py
+++ b/prody/atomic/nbexclusion.py
@@ -110,7 +110,7 @@ def evalNBExclusions(exclusions, n_atoms):
     that stores number of nonbonded exclusions made by each atom."""
 
     numexclusions = np.bincount(
-        exclusions.reshape((exclusions.shape[0] * 2)))
+        exclusions.reshape((exclusions.shape[0] * 2)), minlength=n_atoms)
     nbemap = np.zeros((n_atoms, numexclusions.max()), int)
     nbemap.fill(-1)
     index = np.zeros(n_atoms, int)

--- a/prody/atomic/pointer.py
+++ b/prody/atomic/pointer.py
@@ -290,7 +290,10 @@ class AtomPointer(Atomic):
         if self._ag._bonds is not None:
             iset = set(self._getIndices())
             acsi = self._acsi
-            return array([Bond(self, bond, acsi) for bond in self._ag._bonds
+            # the Bond must be built on the parent AtomGroup, as iterBonds does:
+            # a Bond reads _bondOrders, which only an AtomGroup has, so passing the
+            # pointer made getBonds and numBonds raise AttributeError on any selection
+            return array([Bond(self._ag, bond, acsi) for bond in self._ag._bonds
                           if bond[0] in iset and bond[1] in iset])
         return None
 
@@ -330,25 +333,22 @@ class AtomPointer(Atomic):
             yield Bond(ag, bond, acsi)
 
     def _iterAngles(self):
-        """Yield triplets of indices for angled atoms that are within the pointer.
-        Use :meth:`setAngles` for setting angles."""
+        """Yield the atom indices of each angle wholly within the pointer, in the
+        order the term was set.  Use :meth:`setAngles` for setting angles."""
 
         if self._ag._angles is None:
             LOGGER.warning('angles are not set, use `AtomGroup.setAngles`')
+            return
 
-        indices = self._getIndices()
-        iset = set(indices)
-        if len(self._ag) / 3 >= len(self):
-            for a, b, c in self._ag._iterAngles():
-                if a in iset and b in iset and c in iset:
-                    yield a, b, c
-        else:
-            if any(self._ag._angmap):
-                for a, amap in zip(indices, self._ag._angmap[indices]):
-                    for b, c in amap:
-                        if b > -1 and b in iset and c > -1 and c in iset:
-                            yield a, b, c
-                    iset.remove(a)
+        # NOTE: filter the terms themselves rather than rebuilding them from the
+        # neighbour map.  The map records which atoms share a term, not where in it
+        # they sit, so a rebuilt term came out pivot-atom-first -- an angle 2-1-3
+        # reached here as 1-2-3, naming the wrong vertex.  These terms are ORDERED,
+        # so the only faithful source is the array as set.
+        iset = set(self._getIndices())
+        for term in self._ag._iterAngles():
+            if iset.issuperset(term):
+                yield term
 
     def iterAngles(self):
         """Yield angles formed by the atom.  Use :meth:`setAngles` for setting
@@ -360,26 +360,22 @@ class AtomPointer(Atomic):
             yield Angle(ag, angle, acsi)
 
     def _iterDihedrals(self):
-        """Yield quadruples of indices for dihedraled atoms that are within the pointer.
-        Use :meth:`setDihedrals` for setting dihedrals."""
+        """Yield the atom indices of each dihedral wholly within the pointer, in the
+        order the term was set.  Use :meth:`setDihedrals` for setting dihedrals."""
 
         if self._ag._dihedrals is None:
             LOGGER.warning('dihedrals are not set, use `AtomGroup.setDihedrals`')
+            return
 
-        indices = self._getIndices()
-        iset = set(indices)
-        if len(self._ag) / 4 >= len(self):
-            for a, b, c, d in self._ag._iterDihedrals():
-                if a in iset and b in iset and c in iset and d in iset:
-                    yield a, b, c, d
-        else:
-            if any(self._ag._dmap):
-                for a, dmap in zip(indices, self._ag._dmap[indices]):
-                    for b, c, d in dmap:
-                        if b > -1 and b in iset and c > -1 and c in iset \
-                        and d > -1 and d in iset:
-                            yield a, b, c, d
-                    iset.remove(a)
+        # NOTE: filter the terms themselves rather than rebuilding them from the
+        # neighbour map.  The map records which atoms share a term, not where in it
+        # they sit, so a rebuilt term came out pivot-atom-first -- an angle 2-1-3
+        # reached here as 1-2-3, naming the wrong vertex.  These terms are ORDERED,
+        # so the only faithful source is the array as set.
+        iset = set(self._getIndices())
+        for term in self._ag._iterDihedrals():
+            if iset.issuperset(term):
+                yield term
 
     def iterDihedrals(self):
         """Yield dihedrals formed by the atom.  Use :meth:`setDihedrals` for setting
@@ -391,26 +387,22 @@ class AtomPointer(Atomic):
             yield Dihedral(ag, dihedral, acsi) 
 
     def _iterImpropers(self):
-        """Yield quadruplet of indices for impropered atoms that are within the pointer.
-        Use :meth:`setImpropers` for setting impropers."""
+        """Yield the atom indices of each improper wholly within the pointer, in the
+        order the term was set.  Use :meth:`setImpropers` for setting impropers."""
 
         if self._ag._impropers is None:
             LOGGER.warning('impropers are not set, use `AtomGroup.setImpropers`')
+            return
 
-        indices = self._getIndices()
-        iset = set(indices)
-        if len(self._ag) / 4 >= len(self):
-            for a, b, c, d in self._ag._iterImpropers():
-                if a in iset and b in iset and c in iset and d in iset:
-                    yield a, b, c, d
-        else:
-            if any(self._ag._imap):
-                for a, imap in zip(indices, self._ag._imap[indices]):
-                    for b, c, d in imap:
-                        if b > -1 and b in iset and c > -1 and c in iset \
-                        and d > -1 and d in iset:
-                            yield a, b, c, d
-                    iset.remove(a)
+        # NOTE: filter the terms themselves rather than rebuilding them from the
+        # neighbour map.  The map records which atoms share a term, not where in it
+        # they sit, so a rebuilt term came out pivot-atom-first -- an angle 2-1-3
+        # reached here as 1-2-3, naming the wrong vertex.  These terms are ORDERED,
+        # so the only faithful source is the array as set.
+        iset = set(self._getIndices())
+        for term in self._ag._iterImpropers():
+            if iset.issuperset(term):
+                yield term
 
     def iterImpropers(self):
         """Yield impropers formed by the atom.  Use :meth:`setImpropers` for setting
@@ -422,26 +414,22 @@ class AtomPointer(Atomic):
             yield Improper(ag, improper, acsi) 
 
     def _iterCrossterms(self):
-        """Yield quadruplet of indices for crosstermed atoms that are within the pointer.
-        Use :meth:`setCrossterms` for setting crossterms."""
+        """Yield the atom indices of each cross-term wholly within the pointer, in the
+        order the term was set.  Use :meth:`setCrossterms` for setting crossterms."""
 
         if self._ag._crossterms is None:
             LOGGER.warning('crossterms are not set, use `AtomGroup.setCrossterms`')
+            return
 
-        indices = self._getIndices()
-        iset = set(indices)
-        if len(self._ag) / 4 >= len(self):
-            for a, b, c, d in self._ag._iterCrossterms():
-                if a in iset and b in iset and c in iset and d in iset:
-                    yield a, b, c, d
-        else:
-            if any(self._ag._cmap):
-                for a, cmap in zip(indices, self._ag._cmap[indices]):
-                    for b, c, d in cmap:
-                        if b > -1 and b in iset and c > -1 and c in iset \
-                        and d > -1 and d in iset:
-                            yield a, b, c, d
-                    iset.remove(a)
+        # NOTE: filter the terms themselves rather than rebuilding them from the
+        # neighbour map.  The map records which atoms share a term, not where in it
+        # they sit, so a rebuilt term came out pivot-atom-first -- an angle 2-1-3
+        # reached here as 1-2-3, naming the wrong vertex.  These terms are ORDERED,
+        # so the only faithful source is the array as set.
+        iset = set(self._getIndices())
+        for term in self._ag._iterCrossterms():
+            if iset.issuperset(term):
+                yield term
 
     def iterCrossterms(self):
         """Yield crossterms formed by the atom.  Use :meth:`setCrossterms` for setting
@@ -453,25 +441,22 @@ class AtomPointer(Atomic):
             yield Crossterm(ag, crossterm, acsi) 
 
     def _iterDonors(self):
-        """Yield pairs of indices for donored atoms that are within the pointer.
-        Use :meth:`setDonors` for setting donors."""
+        """Yield the atom indices of each donor wholly within the pointer, in the
+        order the term was set.  Use :meth:`setDonors` for setting donors."""
 
         if self._ag._donors is None:
             LOGGER.warning('donors are not set, use `AtomGroup.setDonors`')
+            return
 
-        indices = self._getIndices()
-        iset = set(indices)
-        if len(self._ag) / 2 >= len(self):
-            for a, b in self._ag._iterDonors():
-                if a in iset and b in iset:
-                    yield a, b
-        else:
-            if any(self._ag._domap):
-                for a, dmap in zip(indices, self._ag._domap[indices]):
-                    for b in dmap:
-                        if b > -1 and b in iset:
-                            yield a, b
-                    iset.remove(a)
+        # NOTE: filter the terms themselves rather than rebuilding them from the
+        # neighbour map.  The map records which atoms share a term, not where in it
+        # they sit, so a rebuilt term came out pivot-atom-first -- an angle 2-1-3
+        # reached here as 1-2-3, naming the wrong vertex.  These terms are ORDERED,
+        # so the only faithful source is the array as set.
+        iset = set(self._getIndices())
+        for term in self._ag._iterDonors():
+            if iset.issuperset(term):
+                yield term
 
     def iterDonors(self):
         """Yield donors formed by the atom.  Use :meth:`setDonors` for setting
@@ -483,25 +468,22 @@ class AtomPointer(Atomic):
             yield Donor(ag, donor, acsi)
 
     def _iterAcceptors(self):
-        """Yield pairs of indices for acceptored atoms that are within the pointer.
-        Use :meth:`setAcceptors` for setting acceptors."""
+        """Yield the atom indices of each acceptor wholly within the pointer, in the
+        order the term was set.  Use :meth:`setAcceptors` for setting acceptors."""
 
         if self._ag._acceptors is None:
             LOGGER.warning('acceptors are not set, use `AtomGroup.setAcceptors`')
+            return
 
-        indices = self._getIndices()
-        iset = set(indices)
-        if len(self._ag) / 2 >= len(self):
-            for a, b in self._ag._iterAcceptors():
-                if a in iset and b in iset:
-                    yield a, b
-        else:
-            if any(self._ag._acmap):
-                for a, amap in zip(indices, self._ag._acmap[indices]):
-                    for b in amap:
-                        if b > -1 and b in iset:
-                            yield a, b
-                    iset.remove(a)
+        # NOTE: filter the terms themselves rather than rebuilding them from the
+        # neighbour map.  The map records which atoms share a term, not where in it
+        # they sit, so a rebuilt term came out pivot-atom-first -- an angle 2-1-3
+        # reached here as 1-2-3, naming the wrong vertex.  These terms are ORDERED,
+        # so the only faithful source is the array as set.
+        iset = set(self._getIndices())
+        for term in self._ag._iterAcceptors():
+            if iset.issuperset(term):
+                yield term
 
     def iterAcceptors(self):
         """Yield acceptors formed by the atom.  Use :meth:`setAcceptors` for setting

--- a/prody/tests/datafiles/__init__.py
+++ b/prody/tests/datafiles/__init__.py
@@ -134,6 +134,17 @@ DATA_FILES = {
         'atoms': 167,
         'models': 3
     },
+    'topology_psf': {
+        'file': 'topology.psf',
+        'atoms': 10,
+        'bonds': 5,
+        'angles': 4,
+        'dihedrals': 3,
+        'impropers': 1,
+        'donors': 1,
+        'acceptors': 1,
+        'crossterms': 1,
+    },
     'anm1ubi_hessian': {
         'file': 'anm1ubi_hessian.coo',
     },

--- a/prody/tests/datafiles/topology.psf
+++ b/prody/tests/datafiles/topology.psf
@@ -1,0 +1,51 @@
+PSF CMAP
+
+       1 !NTITLE
+ REMARKS hand-made topology fixture: two ALA residues, one CMAP cross-term
+
+      10 !NATOM
+       1 P    1    ALA  N    NH1   -0.470000       14.0070           0
+       2 P    1    ALA  HN   H      0.310000        1.0080           0
+       3 P    1    ALA  CA   CT1    0.070000       12.0110           0
+       4 P    1    ALA  HA   HB1    0.090000        1.0080           0
+       5 P    1    ALA  C    C      0.510000       12.0110           0
+       6 P    1    ALA  O    O     -0.510000       15.9990           0
+       7 P    2    ALA  N    NH1   -0.470000       14.0070           0
+       8 P    2    ALA  HN   H      0.310000        1.0080           0
+       9 P    2    ALA  CA   CT1    0.070000       12.0110           0
+      10 P    2    ALA  C    C      0.510000       12.0110           0
+
+       5 !NBOND: bonds
+       2       1       3       1       4       3       5       3
+       6       5
+
+       4 !NTHETA: angles
+       2       1       3       1       3       5       4       3       5
+       3       5       6
+
+       3 !NPHI: dihedrals
+       2       1       3       5       1       3       5       6
+       4       3       5       6
+
+       1 !NIMPHI: impropers
+       5       3       7       6
+
+       1 !NDON: donors
+       1       2
+
+       1 !NACC: acceptors
+       6       5
+
+       0 !NNB
+
+       0       0       0       0       0       0       0       0
+       0       0
+
+       0       0 !NGRP NST2
+       0       0       0
+
+       0       0 !NUMLP NUMLPH
+
+       1 !NCRTERM: cross-terms
+       5       7       9      10       1       3       5       7
+

--- a/prody/tests/trajectory/test_psffile.py
+++ b/prody/tests/trajectory/test_psffile.py
@@ -94,3 +94,118 @@ class TestPSFFile(TestCase):
         first = parsePSF(writePSF(join(TEMPDIR, 'topology_rt1.psf'), self.ag))
         second = parsePSF(writePSF(join(TEMPDIR, 'topology_rt2.psf'), first))
         assert_equal(topology(second), topology(first))
+
+
+class TestWritePSFSubset(TestCase):
+    """A selection is what cropping a solvated system produces, and it has to come
+    out as a PSF that stands on its own."""
+
+    def setUp(self):
+
+        self.ag = parsePSF(PSF)
+
+    def crop(self, selstr, name):
+
+        sel = self.ag.select(selstr)
+        return sel, parsePSF(writePSF(join(TEMPDIR, name), sel))
+
+    def testIndicesAreRenumbered(self):
+        """Terms are written as positions in the new file, not in the parent group."""
+
+        sel, back = self.crop('index 2 to 5', 'crop_bonds.psf')
+        self.assertEqual(back.numAtoms(), sel.numAtoms())
+        assert_equal((back._bonds + 1).tolist(), [[1, 2], [1, 3], [3, 4]])
+        # parent angles 4-3-5 and 3-5-6 are the two wholly inside; atom 3 is local 1,
+        # so the vertex stays in the middle
+        assert_equal((back._angles + 1).tolist(), [[2, 1, 3], [1, 3, 4]])
+        self.assertLessEqual(back._bonds.max() + 1, back.numAtoms(),
+                             'a term points past the end of the file')
+
+    def testCrosstermIsRenumberedInOrder(self):
+        """The parent term 5 7 9 10 1 3 5 7 becomes local 3 4 5 6 1 2 3 4."""
+
+        _, back = self.crop('index 0 2 4 6 8 9', 'crop_cmap.psf')
+        assert_equal((back._crossterms + 1).tolist(), [[3, 4, 5, 6, 1, 2, 3, 4]])
+
+    def testOrderSurvivesSelection(self):
+        """Selecting must not reorder a term.  A neighbour map records which atoms
+        share a term, not where in it they sit, so rebuilding a term from one put the
+        pivot atom first and renamed an angle's vertex."""
+
+        _, back = self.crop('index 0 to 5', 'crop_order.psf')
+        assert_equal((back._angles + 1).tolist(), ANGLES)
+        assert_equal((back._acceptors + 1).tolist(), ACCEPTORS)
+
+    def testPartialTermsAreDropped(self):
+        """A term reaching outside the selection cannot be written at all."""
+
+        _, back = self.crop('index 0 1', 'crop_partial.psf')
+        assert_equal((back._bonds + 1).tolist(), [[1, 2]])
+        for name in ('_angles', '_dihedrals', '_crossterms'):
+            self.assertIsNone(getattr(back, name),
+                              '{0} kept a term that is not wholly selected'.format(name))
+
+
+class TestTopologyUnderSelection(TestCase):
+    """A selection has to carry the topology two ways: by delegation, where terms are
+    read through the parent group and keep its numbering, and through copy(), which
+    makes an independent AtomGroup numbered from one."""
+
+    def setUp(self):
+
+        self.ag = parsePSF(PSF)
+        self.sel = self.ag.select('index 0 to 5')
+
+    def testNumbondsDataCoversEveryAtom(self):
+        """The num* arrays are per-atom, so they are as long as the group even when
+        the last atoms take part in no term -- `numbonds 0` selects ions by relying
+        on that."""
+
+        for label in ('numbonds', 'numangles', 'numdihedrals', 'numimpropers',
+                      'numdonors', 'numacceptors', 'numcrossterms'):
+            data = self.ag.getData(label)
+            self.assertEqual(len(data), self.ag.numAtoms(),
+                             '{0} is not per-atom'.format(label))
+
+    def testSelectionDelegatesTerms(self):
+        """Iterating a selection yields the terms wholly inside it, in parent
+        numbering and in the order they were set."""
+
+        assert_equal([list(t) for t in self.sel._iterAngles()], self.ag._angles.tolist())
+        assert_equal([list(t) for t in self.sel._iterAcceptors()],
+                     self.ag._acceptors.tolist())
+
+    def testSelectionNumBonds(self):
+        """A Bond must be built on the parent group; on the pointer it has no
+        _bondOrders and getBonds raised AttributeError."""
+
+        self.assertEqual(self.sel.numBonds(), 5)
+
+    def testCopyCarriesEveryTopologySection(self):
+        """copy() used to carry the bonds and silently drop everything else."""
+
+        c = self.sel.copy()
+        self.assertEqual(c.numAtoms(), 6)
+        assert_equal((c._bonds + 1).tolist(), sorted(sorted(b) for b in BONDS))
+        assert_equal((c._angles + 1).tolist(), ANGLES)
+        assert_equal((c._dihedrals + 1).tolist(), DIHEDRALS)
+        assert_equal((c._donors + 1).tolist(), DONORS)
+        assert_equal((c._acceptors + 1).tolist(), ACCEPTORS)
+        # the improper and the cross-term reach outside the selection
+        self.assertIsNone(c._impropers)
+        self.assertIsNone(c._crossterms)
+
+    def testWholeGroupCopyIsUnchanged(self):
+
+        c = self.ag.copy()
+        for name in SECTIONS:
+            assert_equal(getattr(c, '_' + name), getattr(self.ag, '_' + name))
+
+    def testCopyThenWriteMatchesWritingTheSelection(self):
+        """The two routes to a cropped PSF must agree."""
+
+        viaCopy = parsePSF(writePSF(join(TEMPDIR, 'via_copy.psf'), self.sel.copy()))
+        viaSel = parsePSF(writePSF(join(TEMPDIR, 'via_sel.psf'), self.sel))
+        for name in SECTIONS:
+            assert_equal(getattr(viaCopy, '_' + name), getattr(viaSel, '_' + name),
+                         '{0} differs between the two routes'.format(name))

--- a/prody/tests/trajectory/test_psffile.py
+++ b/prody/tests/trajectory/test_psffile.py
@@ -1,0 +1,96 @@
+"""This module contains unit tests for :mod:`~prody.trajectory.psffile`."""
+
+from os.path import join
+
+from numpy.testing import assert_equal
+
+from prody import parsePSF, writePSF
+from prody.tests import TEMPDIR, TestCase
+from prody.tests.datafiles import DATA_FILES, pathDatafile
+
+
+PSF = pathDatafile('topology_psf')
+COUNTS = DATA_FILES['topology_psf']
+
+# the topology of the fixture, in the order it appears in the file and using
+# 1-based indices as the file does
+BONDS = [[2, 1], [3, 1], [4, 3], [5, 3], [6, 5]]
+ANGLES = [[2, 1, 3], [1, 3, 5], [4, 3, 5], [3, 5, 6]]
+DIHEDRALS = [[2, 1, 3, 5], [1, 3, 5, 6], [4, 3, 5, 6]]
+IMPROPERS = [[5, 3, 7, 6]]
+DONORS = [[1, 2]]
+ACCEPTORS = [[6, 5]]
+CROSSTERMS = [[5, 7, 9, 10, 1, 3, 5, 7]]
+
+SECTIONS = ('bonds', 'angles', 'dihedrals', 'impropers',
+            'donors', 'acceptors', 'crossterms')
+
+
+def topology(ag):
+    """Returns the topology of *ag* section by section, as 1-based lists."""
+
+    return {name: (getattr(ag, '_' + name) + 1).tolist() for name in SECTIONS}
+
+
+class TestPSFFile(TestCase):
+
+    def setUp(self):
+
+        self.ag = parsePSF(PSF)
+        self.top = topology(self.ag)
+
+    def testCounts(self):
+        """Every section is read, and read whole."""
+
+        self.assertEqual(self.ag.numAtoms(), COUNTS['atoms'])
+        for name in SECTIONS:
+            self.assertEqual(len(self.top[name]), COUNTS[name],
+                             'wrong number of {0}'.format(name))
+
+    def testCrosstermWidth(self):
+        """A CMAP cross-term is the eight atoms of two coupled dihedrals."""
+
+        assert_equal(self.ag._crossterms.shape, (COUNTS['crossterms'], 8))
+
+    def testAtomOrderWithinTerms(self):
+        """The atom order within a term identifies it and must be preserved.
+
+        An angle's middle index is its vertex, a torsion's four indices are a
+        sequence, and a cross-term's eight are two dihedrals; sorting them
+        turns each into a different term."""
+
+        assert_equal(self.top['angles'], ANGLES)
+        assert_equal(self.top['dihedrals'], DIHEDRALS)
+        assert_equal(self.top['impropers'], IMPROPERS)
+        assert_equal(self.top['crossterms'], CROSSTERMS)
+        # donors and acceptors are ordered pairs too
+        assert_equal(self.top['donors'], DONORS)
+        assert_equal(self.top['acceptors'], ACCEPTORS)
+
+    def testBondsAreCanonicalised(self):
+        """A bond is symmetric, so its pair is sorted and deduplicated."""
+
+        assert_equal(self.top['bonds'], sorted(sorted(b) for b in BONDS))
+
+    def testAngleVertex(self):
+        """The vertex an Angle reports is the one the file gives it."""
+
+        vertices = [angle.getAtoms()[1].getIndex() + 1
+                    for angle in self.ag.iterAngles()]
+        assert_equal(vertices, [a[1] for a in ANGLES])
+
+    def testRoundTrip(self):
+        """Writing a parsed topology and reading it back changes nothing."""
+
+        out = writePSF(join(TEMPDIR, 'topology_roundtrip.psf'), self.ag)
+        again = topology(parsePSF(out))
+        for name in SECTIONS:
+            assert_equal(again[name], self.top[name],
+                         '{0} did not round-trip'.format(name))
+
+    def testRoundTripIsIdempotent(self):
+        """A second write/read pass is a no-op, not a further drift."""
+
+        first = parsePSF(writePSF(join(TEMPDIR, 'topology_rt1.psf'), self.ag))
+        second = parsePSF(writePSF(join(TEMPDIR, 'topology_rt2.psf'), first))
+        assert_equal(topology(second), topology(first))

--- a/prody/trajectory/psffile.py
+++ b/prody/trajectory/psffile.py
@@ -8,7 +8,7 @@
 
 import os.path
 
-from numpy import fromstring, zeros, ones, array, add
+from numpy import fromstring, zeros, ones, array, add, arange
 
 from prody import PY2K
 from prody.atomic import ATOMIC_FIELDS, AtomGroup
@@ -354,11 +354,28 @@ def writePSF(filename, atoms):
         write(PSFLINE % (i + 1, segments[i], rnums[i], rnames[i], names[i],
                         types[i], charges[i], masses[i], 0))
 
+    # The topology arrays hold indices into the AtomGroup.  For a selection those are
+    # not the positions the atom records above were just written in -- they run up to
+    # the size of the PARENT group -- so every term has to be renumbered onto the
+    # 1-based position of its atom in this file.  Writing them unmapped produced a PSF
+    # whose bonds pointed past its own !NATOM count.
+    try:
+        parent = atoms.getAtomGroup()
+    except AttributeError:
+        def renumber(terms):
+            return array(terms, int) + 1
+    else:
+        lookup = zeros(parent.numAtoms(), int)
+        lookup[atoms.getIndices()] = arange(1, n_atoms + 1)
+
+        def renumber(terms):
+            return lookup[array(terms, int)]
+
     bonds = list(atoms._iterBonds())
     write('\n')
     write('{0:8d} !NBOND: bonds\n'.format(len(bonds)))
     if len(bonds) > 0:
-        bonds = array(bonds, int) + 1
+        bonds = renumber(bonds)
         for i, bond in enumerate(bonds):
             write('%8s%8s' % (bond[0], bond[1]))
             if i % 4 == 3:
@@ -372,7 +389,7 @@ def writePSF(filename, atoms):
     write('\n')
     write('{0:8d} !NTHETA: angles\n'.format(len(angles)))
     if len(angles) > 0:
-        angles = array(angles, int) + 1
+        angles = renumber(angles)
         for i, angle in enumerate(angles):
             write('%8s%8s%8s' % (angle[0], angle[1], angle[2]))
             if i % 3 == 2:
@@ -386,7 +403,7 @@ def writePSF(filename, atoms):
     write('\n')
     write('{0:8d} !NPHI: dihedrals\n'.format(len(dihedrals)))
     if len(dihedrals) > 0:
-        dihedrals = array(dihedrals, int) + 1
+        dihedrals = renumber(dihedrals)
         for i, dihedral in enumerate(dihedrals):
             write('%8s%8s%8s%8s' % (dihedral[0], dihedral[1], dihedral[2], dihedral[3]))
             if i % 4 == 3:
@@ -400,7 +417,7 @@ def writePSF(filename, atoms):
     write('\n')
     write('{0:8d} !NIMPHI: impropers\n'.format(len(impropers)))
     if len(impropers) > 0:
-        impropers = array(impropers, int) + 1
+        impropers = renumber(impropers)
         for i, improper in enumerate(impropers):
             write('%8s%8s%8s%8s' % (improper[0], improper[1], improper[2], improper[3]))
             if i % 2 == 1:
@@ -414,7 +431,7 @@ def writePSF(filename, atoms):
     write('\n')
     write('{0:8d} !NDON: donors\n'.format(len(donors)))
     if len(donors) > 0:
-        donors = array(donors, int) + 1
+        donors = renumber(donors)
         for i, donor in enumerate(donors):
             write('%8s%8s' % (donor[0], donor[1]))
             if i % 4 == 3:
@@ -428,7 +445,7 @@ def writePSF(filename, atoms):
     write('\n')
     write('{0:8d} !NACC: acceptors\n'.format(len(acceptors)))
     if len(acceptors) > 0:
-        acceptors = array(acceptors, int) + 1
+        acceptors = renumber(acceptors)
         for i, acceptor in enumerate(acceptors):
             write('%8s%8s' % (acceptor[0], acceptor[1]))
             if i % 4 == 3:
@@ -442,7 +459,7 @@ def writePSF(filename, atoms):
     write('\n')
     write('{0:8d} !NNB\n'.format(len(nbexclusions)))
     if len(nbexclusions) > 0:
-        nbexclusions = array(nbexclusions, int) + 1
+        nbexclusions = renumber(nbexclusions)
         for i, nbexclusion in enumerate(nbexclusions):
             write('%8s%8s' % (nbexclusion[0], nbexclusion[1]))
             if i % 4 == 3:
@@ -456,7 +473,7 @@ def writePSF(filename, atoms):
     write('\n')
     write('{0:8d} !NCRTERM: crossterms\n'.format(len(crossterms)))
     if len(crossterms) > 0:
-        crossterms = array(crossterms, int) + 1
+        crossterms = renumber(crossterms)
         for crossterm in crossterms:
             # one cross-term per line: both coupled dihedrals, eight indices
             write(('%8s' * 8 + '\n') % tuple(crossterm[:8]))

--- a/prody/trajectory/psffile.py
+++ b/prody/trajectory/psffile.py
@@ -197,10 +197,12 @@ def parsePSF(filename, title=None, ag=None):
         raise IOError('number of acceptors expected and parsed do not match')
 
     lines = []
+    stop = b''
     for i, line in enumerate(psf):
         if line.strip() == b'':
             continue
         if b'!' in line:
+            stop = line
             break
         lines.append(line.decode(encoding='UTF-8'))
     
@@ -209,20 +211,31 @@ def parsePSF(filename, title=None, ag=None):
     if len(nbe_array) != n_exclusions*2:
         raise IOError('number of nonbonded exclusions expected and parsed do not match')
 
+    # The loop above has already consumed the header of whatever section follows
+    # the exclusions.  CHARMM puts !NGRP and !NUMLP there, but a file may go
+    # straight to !NCRTERM -- in which case that header is the line just read,
+    # and scanning further would skip the section and silently drop every
+    # cross-term.
     n_crossterms = 0
-    for i, line in enumerate(psf):
-        if b'!NCRTERM' in line:
-            items = line.split()
-            n_crossterms = int(items[0])
-            break
+    if b'!NCRTERM' in stop:
+        n_crossterms = int(stop.split()[0])
+    else:
+        for i, line in enumerate(psf):
+            if b'!NCRTERM' in line:
+                items = line.split()
+                n_crossterms = int(items[0])
+                break
 
     lines = []
     for i, line in enumerate(psf):
         lines.append(line.decode(encoding='UTF-8'))
     
     lines = ''.join(lines)
-    c_array = fromstring(lines, count=n_crossterms*4, dtype=int, sep=' ')
-    if len(c_array) != n_crossterms*4:
+    # A CHARMM !NCRTERM record holds EIGHT atom indices per cross-term -- the two
+    # coupled dihedrals of a CMAP term -- not four.  Reading four consumed only half
+    # of the section and split each record into two unrelated 4-tuples.
+    c_array = fromstring(lines, count=n_crossterms*8, dtype=int, sep=' ')
+    if len(c_array) != n_crossterms*8:
         raise IOError('number of crossterms expected and parsed do not match')
 
     psf.close()
@@ -265,7 +278,7 @@ def parsePSF(filename, title=None, ag=None):
 
     if n_crossterms > 0:
         c_array = add(c_array, -1, c_array)
-        ag.setCrossterms(c_array.reshape((n_crossterms, 4)))
+        ag.setCrossterms(c_array.reshape((n_crossterms, 8)))
 
     return ag
 
@@ -274,8 +287,22 @@ PSFLINE = ('%8d %-4s %-4d %-4s %-4s %-4s %10.6f %13.4f %11d\n')
 
 def writePSF(filename, atoms):
     """Write atoms in X-PLOR format PSF file with name *filename* and return
-    *filename*.  This function will write available atom and bond information
-    only."""
+    *filename*.
+
+    All topology sections that are set on *atoms* are written: ``!NATOM``,
+    ``!NBOND``, ``!NTHETA`` (angles), ``!NPHI`` (dihedrals), ``!NIMPHI``
+    (impropers), ``!NDON`` (donors), ``!NACC`` (acceptors), ``!NNB``
+    (non-bonded exclusions) and ``!NCRTERM`` (cross-terms, i.e. CMAP).  A
+    section whose data is not set on *atoms* is written with a count of zero,
+    so a file parsed with :func:`.parsePSF` round-trips its topology.
+
+    Atom records carry segment name, residue number and name, atom name and
+    type, charge and mass.  The header is ``PSF NAMD`` when any atom type is
+    longer than four characters, since the X-PLOR column layout cannot hold
+    those; note that fields wider than their format specifier (long atom types,
+    or residue numbers above 9999) widen the record rather than being truncated,
+    which readers that split on whitespace tolerate but strictly
+    column-oriented readers may not."""
 
     if not filename.lower().endswith('.psf'):
         filename = filename + '.psf'
@@ -430,12 +457,9 @@ def writePSF(filename, atoms):
     write('{0:8d} !NCRTERM: crossterms\n'.format(len(crossterms)))
     if len(crossterms) > 0:
         crossterms = array(crossterms, int) + 1
-        for i, crossterm in enumerate(crossterms):
-            write('%8s%8s%8s%8s' % (crossterm[0], crossterm[1], crossterm[2], crossterm[3]))
-            if i % 2 == 1:
-                write('\n')
-        if i % 2 != 1:
-            write('\n')
+        for crossterm in crossterms:
+            # one cross-term per line: both coupled dihedrals, eight indices
+            write(('%8s' * 8 + '\n') % tuple(crossterm[:8]))
 
     write('\n')
     out.close()


### PR DESCRIPTION
ProDy cannot currently round-trip a CHARMM PSF: `parsePSF` followed by `writePSF` produces a file with a different topology from the one it read. Two independent causes, plus a third that hides one of them.

### 1. A CMAP cross-term is eight atom indices, not four

A `!NCRTERM` record holds the two coupled dihedrals of a CMAP term — eight indices, one term per line. From msbA's PSF:

```
        20        22        24        31        22        24        31        33
```

that is φ (20-22-24-31) and ψ (22-24-31-33) of one residue. `parsePSF` read `count=n_crossterms*4`, which consumed only the first 571 of the file's 1142 records and split each one into two unrelated 4-tuples — filling the array to the expected count with terms that do not exist. `writePSF` then wrote those 4-tuples two to a line, so the output disagreed with its own `!NCRTERM` count.

Fixed in the parser, the writer, `setCrossterms` (which now requires the eight columns and documents what they are), and `evalCrossterms`, which now takes the term width from the array instead of assuming four, so its neighbour map covers all eight atoms.

### 2. Sorting the indices inside a term changes which term it is

The atom order within an angle, dihedral, improper or cross-term is what identifies it: an angle's middle index is its vertex, a torsion's four are a sequence, a cross-term's eight are two dihedrals. All four setters began with `.sort(1)`. msbA's PSF gives its first angles as

```
         2         1         3         2         1         4         2         1         5
```

— all three about vertex 1 — and they were stored as `1 2 3`, `1 2 4`, `1 2 5`, so `Angle.getVectors`, documented as returning the bond vectors that originate from the central atom, took atom 2 as the vertex of all three.

Donors and acceptors are ordered pairs too (`!NDON` is a donor and its hydrogen, `!NACC` an acceptor and its antecedent), so they are no longer sorted or deduplicated either. The term-level `argsort` chains go with the sorts: nothing downstream needs a canonical term order, and keeping the order read is what makes the round-trip exact.

`setBonds` and `setNBExclusions` **keep** their within-pair sort deliberately — those pairs really are symmetric, so sorting each is what collapses `(i, j)` and `(j, i)` in the `np.unique` that follows, and for bonds it is also what guarantees `i < j` in the `'%d %d'` keys of `_bondIndex` that `Bond` looks up. Their row-level `argsort` chains are dropped as dead code, since `np.unique(..., axis=0)` already sorts rows.

### 3. `!NCRTERM` was dropped when it directly follows the exclusions

The loop reading `!NNB` stops on the first line containing `!` — which has already consumed the next section's header. CHARMM puts `!NGRP` and `!NUMLP` there, so real files survived, but a file that goes straight to `!NCRTERM` — including one written by `writePSF` — had the scan start past the header, and every cross-term was silently dropped with no error. The line the loop stopped on is now checked before scanning on.

### Testing

- New `prody/tests/trajectory/test_psffile.py` and a hand-made ten-atom fixture `topology.psf` with every section populated, laid out the way CHARMM writes one, with no term's indices already sorted. **5 of the 7 tests fail without these fixes.**
- `prody/tests/atomic`, `trajectory` and `proteins`: 701 passed. The 7 failures are pre-existing and environmental (no `mmtf`, no `Hpb`, network fetches) and are unaffected.
- Real-world check on a 720,343-atom CHARMM-GUI system: an OpenMM `System` built from the original PSF and from the ProDy round-tripped PSF give **identical** potential energy, −9,820,146.3 kJ/mol, with the same 704,223 constraints.

**Not addressed here:** `writePSF` still omits `!NGRP`, `!NUMLP` and the per-atom `!NNB` pointer array. OpenMM tolerates that; CHARMM and NAMD may not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)